### PR TITLE
feat(review): capture bounded raw context in configured-blocker fired events, permanently excluding secret_leak

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -10311,7 +10311,11 @@ async function maybePublishPrPublicSurface(
         // #8104: record RuleFiredEvent for every configured gate blocker except linked_issue_scope_mismatch
         // (#8101). Same advisory+policy as evaluateGateCheck above so the filter stays in lock-step.
         if (evaluation) {
-          await recordConfiguredGateBlockerSignals(env, advisory, gatePolicy, repoFullName, pr.number);
+          // #8130: thread the SAME memoized diff the AI review consumed so ai_consensus_defect/ai_review_split
+          // fired events capture the raw context their detection evaluated (never re-fetched).
+          await recordConfiguredGateBlockerSignals(env, advisory, gatePolicy, repoFullName, pr.number, {
+            aiReviewDiff: buildAiReviewDiff(await getReviewFiles()),
+          });
         }
         // Deterministic content/registry surface lane (#1255) — flag-gated + per-repo allowlist, byte-identical when
         // off (evaluateWithSurfaceLane returns the generic evaluation unchanged and resolves no files). A metagraphed

--- a/src/rules/advisory.ts
+++ b/src/rules/advisory.ts
@@ -1053,12 +1053,36 @@ function isConfiguredGateBlocker(finding: AdvisoryFinding, policy: GateCheckPoli
   return false;
 }
 
+// #8130: codes whose raw evaluated content must NEVER be captured into fired-event metadata. `secret_leak`
+// is permanently excluded by design: capturing the diff that triggered it would store the leaked credential
+// itself in the calibration audit trail — a real security regression, not an acceptable tradeoff for
+// backtest coverage. A future sensitive code gets ADDED here deliberately (with this reasoning re-applied);
+// per #8130's Boundaries, extending raw-context capture to secret_leak requires an explicit,
+// maintainer-reviewed redaction design first, never a quiet edit.
+export const RAW_CONTEXT_EXCLUDED_CODES = new Set<string>(["secret_leak"]);
+
+// #8130: mirror of src/services/ai-review.ts's own `input.diff.slice(0, 120000)` bound — the SAME number, so
+// the captured corpus reflects exactly what the AI reviewer saw. Keep the two in sync by hand.
+export const RAW_CONTEXT_MAX_DIFF_CHARS = 120000;
+
 /**
  * Record a {@link RuleFiredEvent} for every finding that `isConfiguredGateBlocker` would put into
  * `configuredBlockers`, excluding `linked_issue_scope_mismatch` (#8104 / complements #8101). Call from the
  * env-bearing gate path immediately after {@link evaluateGateCheck} with the SAME advisory + policy so the
  * filter matches `evaluateGateCheckCore`'s own. Best-effort: a SignalStore failure never throws and never
  * affects the gate verdict.
+ *
+ * #8130: non-excluded codes also capture the raw context their detection actually evaluated, so their
+ * corpora can backtest logic/detection changes rather than only thresholds:
+ *   • `ai_consensus_defect`/`ai_review_split` — the AI review's own diff (`context.aiReviewDiff`, threaded
+ *     from the caller that already holds it; bounded to {@link RAW_CONTEXT_MAX_DIFF_CHARS}).
+ *   • every other non-excluded code — audited individually (#8130): none of them evaluates raw diff content
+ *     (`missing_linked_issue` reads the PR's linkage state, `duplicate_pr_risk` reads sibling-PR overlap,
+ *     `pre_merge_check_required`/`cla_check_unresolved` read check-run conclusions, `manifest_missing_tests`
+ *     reads changed paths vs the manifest's expectations, the review-thread code reads unresolved-thread
+ *     state) — so the detection's own recorded `detail` string, which narrates exactly that evaluated
+ *     signal, is captured as `rawSignal` (same bound).
+ *   • `RAW_CONTEXT_EXCLUDED_CODES` (`secret_leak`) — confidence only, never raw content.
  */
 export async function recordConfiguredGateBlockerSignals(
   env: Env,
@@ -1066,6 +1090,7 @@ export async function recordConfiguredGateBlockerSignals(
   policy: GateCheckPolicy,
   repoFullName: string,
   prNumber: number,
+  context: { aiReviewDiff?: string } = {},
 ): Promise<void> {
   const effective = applyMergeReadinessGate(policy);
   const configuredBlockers = advisoryResult.findings.filter((finding) => isConfiguredGateBlocker(finding, effective));
@@ -1075,13 +1100,22 @@ export async function recordConfiguredGateBlockerSignals(
   await Promise.all(
     configuredBlockers.map((finding) => {
       if (finding.code === "linked_issue_scope_mismatch") return Promise.resolve();
+      const metadata: Record<string, unknown> = {};
+      if (finding.confidence !== undefined) metadata.confidence = finding.confidence;
+      if (!RAW_CONTEXT_EXCLUDED_CODES.has(finding.code)) {
+        if (AI_JUDGMENT_BLOCKER_CODES.has(finding.code)) {
+          if (context.aiReviewDiff !== undefined) metadata.diff = context.aiReviewDiff.slice(0, RAW_CONTEXT_MAX_DIFF_CHARS);
+        } else if (finding.detail) {
+          metadata.rawSignal = finding.detail.slice(0, RAW_CONTEXT_MAX_DIFF_CHARS);
+        }
+      }
       return store
         .recordRuleFired({
           ruleId: finding.code,
           targetKey,
           outcome: finding.severity ?? "blocker",
           occurredAt,
-          ...(finding.confidence !== undefined ? { metadata: { confidence: finding.confidence } } : {}),
+          ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
         })
         .catch(() => undefined);
     }),

--- a/test/unit/configured-gate-blocker-signals.test.ts
+++ b/test/unit/configured-gate-blocker-signals.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  RAW_CONTEXT_MAX_DIFF_CHARS,
   recordConfiguredGateBlockerSignals,
   type GateCheckPolicy,
 } from "../../src/rules/advisory";
@@ -163,5 +164,82 @@ describe("recordConfiguredGateBlockerSignals (#8104)", () => {
         7,
       ),
     ).resolves.toBeUndefined();
+  });
+});
+
+// ── #8130: bounded raw context in fired-event metadata (secret_leak permanently excluded) ───────────────────
+
+describe("recordConfiguredGateBlockerSignals — raw context capture (#8130)", () => {
+  it("SECURITY: secret_leak's fired event NEVER carries diff or rawSignal, even with confidence and detail present", async () => {
+    const env = createTestEnv();
+    await recordConfiguredGateBlockerSignals(
+      env,
+      advisory([finding({ code: "secret_leak", severity: "critical", confidence: 0.99, detail: "AKIA... committed in config.ts" })]),
+      {},
+      "owner/repo",
+      7,
+      { aiReviewDiff: "+const key = 'AKIA-REAL-SECRET';" },
+    );
+    const [fired] = (await createSignalStore(env).queryRuleHistory("secret_leak", 0)).fired;
+    expect(fired!.metadata).toEqual({ confidence: 0.99 });
+    expect(fired!.metadata).not.toHaveProperty("diff");
+    expect(fired!.metadata).not.toHaveProperty("rawSignal");
+  });
+
+  it("captures the AI review's diff (bounded to RAW_CONTEXT_MAX_DIFF_CHARS) for ai_consensus_defect", async () => {
+    const env = createTestEnv();
+    const oversized = "d".repeat(RAW_CONTEXT_MAX_DIFF_CHARS + 5000);
+    await recordConfiguredGateBlockerSignals(
+      env,
+      advisory([finding({ code: "ai_consensus_defect", confidence: 0.95 })]),
+      blockAi,
+      "owner/repo",
+      7,
+      { aiReviewDiff: oversized },
+    );
+    const [fired] = (await createSignalStore(env).queryRuleHistory("ai_consensus_defect", 0)).fired;
+    expect((fired!.metadata as { diff: string }).diff).toHaveLength(RAW_CONTEXT_MAX_DIFF_CHARS);
+    expect((fired!.metadata as { confidence: number }).confidence).toBe(0.95);
+  });
+
+  it("records no diff key for an AI code when the caller has no diff to thread", async () => {
+    const env = createTestEnv();
+    await recordConfiguredGateBlockerSignals(env, advisory([finding({ code: "ai_review_split", confidence: 0.9 })]), blockAi, "owner/repo", 7);
+    const [fired] = (await createSignalStore(env).queryRuleHistory("ai_review_split", 0)).fired;
+    expect(fired!.metadata).toEqual({ confidence: 0.9 });
+  });
+
+  it("captures a non-diff-based code's own evaluated signal (its detail) as rawSignal — the audited fallback", async () => {
+    const env = createTestEnv();
+    await recordConfiguredGateBlockerSignals(
+      env,
+      advisory([finding({ code: "missing_linked_issue", detail: "No linked issue reference found in the PR body." })]),
+      blockLinked,
+      "owner/repo",
+      7,
+      { aiReviewDiff: "+irrelevant" },
+    );
+    const [fired] = (await createSignalStore(env).queryRuleHistory("missing_linked_issue", 0)).fired;
+    expect(fired!.metadata).toEqual({ rawSignal: "No linked issue reference found in the PR body." });
+  });
+
+  it("records no metadata at all for a non-diff code with no confidence and an empty detail", async () => {
+    const env = createTestEnv();
+    await recordConfiguredGateBlockerSignals(env, advisory([finding({ code: "missing_linked_issue", detail: "" })]), blockLinked, "owner/repo", 7);
+    const [fired] = (await createSignalStore(env).queryRuleHistory("missing_linked_issue", 0)).fired;
+    expect(fired!.metadata).toBeUndefined();
+  });
+
+  it("still skips linked_issue_scope_mismatch entirely (#8101's own site records it)", async () => {
+    const env = createTestEnv();
+    await recordConfiguredGateBlockerSignals(
+      env,
+      advisory([finding({ code: "linked_issue_scope_mismatch" }), finding({ code: "missing_linked_issue" })]),
+      { ...blockLinked, linkedIssueSatisfactionGateMode: "block" },
+      "owner/repo",
+      7,
+    );
+    expect((await createSignalStore(env).queryRuleHistory("linked_issue_scope_mismatch", 0)).fired).toEqual([]);
+    expect((await createSignalStore(env).queryRuleHistory("missing_linked_issue", 0)).fired).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary

Closes #8130.

Extends #8104's generic `recordConfiguredGateBlockerSignals` (`src/rules/advisory.ts`) so every non-excluded configured-blocker code captures the raw context its detection actually evaluated — making those corpora rich enough to backtest logic/detection changes, not just thresholds — while **permanently excluding `secret_leak` by design**.

- **`RAW_CONTEXT_EXCLUDED_CODES`** — the exported, named constant the issue mandates (`secret_leak` inside), with the full security reasoning attached: capturing the diff that triggered a `secret_leak` finding would store the leaked credential itself in the calibration audit trail. The comment also carries the issue's Boundaries note (additions require an explicit, maintainer-reviewed redaction design — never a quiet edit).
- **`RAW_CONTEXT_MAX_DIFF_CHARS = 120000`** — mirrors `src/services/ai-review.ts`'s own `input.diff.slice(0, 120000)` bound exactly (the same number, with a keep-in-sync comment), never a newly invented bound.
- **AI-judgment codes** (`ai_consensus_defect`/`ai_review_split`): the metadata gains the AI review's own diff, threaded from the one caller (`src/queue/processors.ts`) via the already-memoized `getReviewFiles()` + the same `buildAiReviewDiff` the review consumed — never re-fetched or re-derived.
- **Every other non-excluded code** — audited individually per the issue's requirement (the audit is recorded in the function's doc comment): `missing_linked_issue` reads linkage state, `duplicate_pr_risk` reads sibling-PR overlap, `pre_merge_check_required`/`cla_check_unresolved` read check-run conclusions, `manifest_missing_tests` reads changed paths vs manifest expectations, the review-thread code reads unresolved-thread state — **none evaluates raw diff content**, so each captures its detection's own recorded `detail` (the narrative of exactly that evaluated signal) as `rawSignal`, same bound.
- `linked_issue_scope_mismatch` remains skipped entirely (#8101's own site records it — unchanged), and the #8104 behavior for confidence capture is preserved byte-for-byte.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran the directly-affected gates: `test/unit/configured-gate-blocker-signals.test.ts` — **14/14 green** (8 pre-existing #8104 cases unchanged + 6 new #8130 cases: the **security negative** asserting `secret_leak`'s event carries NO `diff`/`rawSignal` even with confidence, detail, and a threaded diff all present; the AI-code diff capture **with the truncation branch at the exact bound**; the no-diff-threaded branch; the audited `rawSignal` fallback; the empty-detail/no-metadata branch; the `linked_issue_scope_mismatch` skip) — plus `npm run engine-parity:drift-check` (**ok**: the advisory.ts↔gate-advisory.ts twin pair still agrees; the added recorder context is host-side-only, the same posture #8104 itself established). Real CI re-runs typecheck and the sharded suite here.
- workers/mcp/ui/audit/actionlint: untouched surfaces — two source files + one test file; zero dependency changes.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

The three unchecked Safety boxes are N/A: no auth/session/UI change. Note the change is itself security-motivated in part: the `secret_leak` exclusion exists precisely so no leaked credential can ever enter the calibration audit trail, and that property is pinned by a dedicated negative test.

## UI Evidence

N/A — no UI change.

## Notes

- The metadata builder intentionally emits NO `metadata` key at all (rather than an empty object) when nothing is captured — preserving #8104's exact optional-property behavior for that case.
