### PR TITLE
docs(ui): document the backtest/calibration system as a fumadocs page

### DIFF
--- a/apps/loopover-ui/content/docs/backtest-calibration.mdx
+++ b/apps/loopover-ui/content/docs/backtest-calibration.mdx
@@ -1,0 +1,79 @@
+---
+title: Backtest & calibration
+description: How LoopOver measures whether its own review rules are right — and backtests threshold and logic changes against real history before they ship.
+---
+
+## What this is
+
+Every time a configured gate blocker fires, LoopOver records it. Every time a human later
+overrides that call (or confirms it), LoopOver records that too. Paired together, the two
+histories become a labeled corpus: _this rule fired against this PR, and a person later said it
+was right ("confirmed") or wrong ("reversed")_.
+
+That corpus makes a rule change **testable before it merges**. A PR that tunes a confidence
+threshold or rewrites detection logic gets scored against the real recorded history — the same
+targets, the same raw inputs — instead of being eyeballed.
+
+<Callout variant="note">
+  Everything on this page is advisory-only today. A backtest verdict — even a regression — never
+  blocks a merge. Whether a REGRESSED verdict should ever gate merges is a tracked, deliberately
+  separate decision that waits for real production track-record data.
+</Callout>
+
+## The corpus
+
+- **Fired events** — recorded when a configured blocker actually carries gate authority, with
+  bounded raw context: the issue text, PR title/body, and diff the rule evaluated, and (for the
+  AI-judgment rule `linked_issue_scope_mismatch`) the model's own raw response text.
+- **Override events** — recorded when a human reverses an automated call, or confirms one (for
+  example, an owner closing a PR that was held for low AI confidence confirms the hold).
+- **`secret_leak` is permanently excluded from raw-context capture.** Storing the diff that
+  triggered a leaked-credential finding would store the credential itself in the audit trail.
+  This rule can therefore never be logic-backtested — by design, not omission.
+
+## Two backtests, two mechanisms
+
+**Threshold changes** run inside LoopOver's own review pass. When a PR's diff changes a known
+confidence-threshold constant, the old and new values are replayed as classifiers over the
+rule's recorded history, and the comparison is rendered directly into the unified review
+comment. No code from the PR is ever executed — a threshold is just a number.
+
+**Logic/regex changes** run in a dedicated CI workflow instead, because honestly verifying a
+rewritten detection function requires _executing the PR's own code_ against history — something
+the production review service must never do. The workflow checks out both the PR's head and its
+base, replays each recorded case's captured raw context through both versions of the detection
+function, and posts its own clearly-labeled **"Logic backtest"** PR comment, separate from the
+unified review comment. It triggers only for PRs touching the watched detection-logic paths,
+skips drafts and forks (fork runs get no secrets), and fails open: an infrastructure problem
+produces a skip notice, never a red check.
+
+## Reading the comparison
+
+Both backtests score the same way:
+
+- **"Reversed" is the positive class.** A classifier predicting "reversed" is saying the rule's
+  original firing was wrong. Precision and recall are computed against the human labels, and
+  stay `N/A` when there is not enough decided data — unknown is never coerced to zero.
+- **The Pareto floor decides the verdict.** A candidate that regresses on _any_ axis is
+  **REGRESSED**, even if the other axis improved. Trading precision for recall is a regression,
+  not a net win. Otherwise the verdict is _improved_ (some axis moved up) or _unchanged_.
+- Cases recorded before raw-context capture existed are skipped and counted in the comment —
+  replaying them against empty inputs would bias both sides, so they are never scored.
+
+## The track record
+
+Every backtest run persists its comparison as structured audit data. The accumulated record —
+how often runs regress, per rule — is the evidence base for the pending merge-gating decision,
+readable at any time with the maintainer CLI:
+
+```bash
+npx tsx scripts/backtest-track-record.ts --db loopover --remote
+```
+
+The corpus itself can be exported as a versioned, checksummed snapshot:
+
+```bash
+npx tsx scripts/backtest-corpus-export.ts --rule-id <ruleId> --output corpus.json --remote
+```
+
+Both CLIs are strictly read-only against the database.

--- a/apps/loopover-ui/src/components/site/command-palette.tsx
+++ b/apps/loopover-ui/src/components/site/command-palette.tsx
@@ -61,6 +61,7 @@ const DEFAULT_ITEMS: PaletteItem[] = [
   { label: "Scoreability", to: "/docs/scoreability", group: "Docs" },
   { label: "Upstream drift", to: "/docs/upstream-drift", group: "Docs" },
   { label: "AI summaries policy", to: "/docs/ai-summaries", group: "Docs" },
+  { label: "Backtest & calibration", to: "/docs/backtest-calibration", group: "Docs" },
   { label: "Privacy & security", to: "/docs/privacy-security", group: "Docs" },
   { label: "Troubleshooting", to: "/docs/troubleshooting", group: "Docs" },
   { label: "API reference", to: "/api", group: "Reference" },

--- a/apps/loopover-ui/src/components/site/docs-nav.tsx
+++ b/apps/loopover-ui/src/components/site/docs-nav.tsx
@@ -99,6 +99,7 @@ export const docsNav: DocsGroup[] = [
       { to: "/docs/branch-analysis", label: "Branch analysis" },
       { to: "/docs/scoreability", label: "Scoreability" },
       { to: "/docs/upstream-drift", label: "Upstream drift" },
+      { to: "/docs/backtest-calibration", label: "Backtest & calibration" },
     ],
   },
   {

--- a/apps/loopover-ui/src/lib/docs-source-server-isolation.test.ts
+++ b/apps/loopover-ui/src/lib/docs-source-server-isolation.test.ts
@@ -29,7 +29,7 @@ describe("docs.*.tsx routes never import docs-source(.server) directly", () => {
   const inScope = docsRouteFiles.filter((name) => !outOfScope.has(name));
 
   it("found the expected set of in-scope docs route files", () => {
-    expect(inScope.length).toBe(48);
+    expect(inScope.length).toBe(49);
   });
 
   it.each(inScope)(

--- a/apps/loopover-ui/src/routeTree.gen.ts
+++ b/apps/loopover-ui/src/routeTree.gen.ts
@@ -63,6 +63,7 @@ import { Route as DocsFederatedFleetIntelligenceRouteImport } from './routes/doc
 import { Route as DocsCapacityRouteImport } from './routes/docs.capacity'
 import { Route as DocsBranchAnalysisRouteImport } from './routes/docs.branch-analysis'
 import { Route as DocsBetaOnboardingRouteImport } from './routes/docs.beta-onboarding'
+import { Route as DocsBacktestCalibrationRouteImport } from './routes/docs.backtest-calibration'
 import { Route as DocsAmsUnattendedSchedulingRouteImport } from './routes/docs.ams-unattended-scheduling'
 import { Route as DocsAmsSizingRouteImport } from './routes/docs.ams-sizing'
 import { Route as DocsAmsOperationsRunbookRouteImport } from './routes/docs.ams-operations-runbook'
@@ -376,6 +377,11 @@ const DocsBetaOnboardingRoute = DocsBetaOnboardingRouteImport.update({
   path: '/beta-onboarding',
   getParentRoute: () => DocsRoute,
 } as any)
+const DocsBacktestCalibrationRoute = DocsBacktestCalibrationRouteImport.update({
+  id: '/backtest-calibration',
+  path: '/backtest-calibration',
+  getParentRoute: () => DocsRoute,
+} as any)
 const DocsAmsUnattendedSchedulingRoute =
   DocsAmsUnattendedSchedulingRouteImport.update({
     id: '/ams-unattended-scheduling',
@@ -554,6 +560,7 @@ export interface FileRoutesByFullPath {
   '/docs/ams-operations-runbook': typeof DocsAmsOperationsRunbookRoute
   '/docs/ams-sizing': typeof DocsAmsSizingRoute
   '/docs/ams-unattended-scheduling': typeof DocsAmsUnattendedSchedulingRoute
+  '/docs/backtest-calibration': typeof DocsBacktestCalibrationRoute
   '/docs/beta-onboarding': typeof DocsBetaOnboardingRoute
   '/docs/branch-analysis': typeof DocsBranchAnalysisRoute
   '/docs/capacity': typeof DocsCapacityRoute
@@ -633,6 +640,7 @@ export interface FileRoutesByTo {
   '/docs/ams-operations-runbook': typeof DocsAmsOperationsRunbookRoute
   '/docs/ams-sizing': typeof DocsAmsSizingRoute
   '/docs/ams-unattended-scheduling': typeof DocsAmsUnattendedSchedulingRoute
+  '/docs/backtest-calibration': typeof DocsBacktestCalibrationRoute
   '/docs/beta-onboarding': typeof DocsBetaOnboardingRoute
   '/docs/branch-analysis': typeof DocsBranchAnalysisRoute
   '/docs/capacity': typeof DocsCapacityRoute
@@ -717,6 +725,7 @@ export interface FileRoutesById {
   '/docs/ams-operations-runbook': typeof DocsAmsOperationsRunbookRoute
   '/docs/ams-sizing': typeof DocsAmsSizingRoute
   '/docs/ams-unattended-scheduling': typeof DocsAmsUnattendedSchedulingRoute
+  '/docs/backtest-calibration': typeof DocsBacktestCalibrationRoute
   '/docs/beta-onboarding': typeof DocsBetaOnboardingRoute
   '/docs/branch-analysis': typeof DocsBranchAnalysisRoute
   '/docs/capacity': typeof DocsCapacityRoute
@@ -802,6 +811,7 @@ export interface FileRouteTypes {
     | '/docs/ams-operations-runbook'
     | '/docs/ams-sizing'
     | '/docs/ams-unattended-scheduling'
+    | '/docs/backtest-calibration'
     | '/docs/beta-onboarding'
     | '/docs/branch-analysis'
     | '/docs/capacity'
@@ -881,6 +891,7 @@ export interface FileRouteTypes {
     | '/docs/ams-operations-runbook'
     | '/docs/ams-sizing'
     | '/docs/ams-unattended-scheduling'
+    | '/docs/backtest-calibration'
     | '/docs/beta-onboarding'
     | '/docs/branch-analysis'
     | '/docs/capacity'
@@ -964,6 +975,7 @@ export interface FileRouteTypes {
     | '/docs/ams-operations-runbook'
     | '/docs/ams-sizing'
     | '/docs/ams-unattended-scheduling'
+    | '/docs/backtest-calibration'
     | '/docs/beta-onboarding'
     | '/docs/branch-analysis'
     | '/docs/capacity'
@@ -1405,6 +1417,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DocsBetaOnboardingRouteImport
       parentRoute: typeof DocsRoute
     }
+    '/docs/backtest-calibration': {
+      id: '/docs/backtest-calibration'
+      path: '/backtest-calibration'
+      fullPath: '/docs/backtest-calibration'
+      preLoaderRoute: typeof DocsBacktestCalibrationRouteImport
+      parentRoute: typeof DocsRoute
+    }
     '/docs/ams-unattended-scheduling': {
       id: '/docs/ams-unattended-scheduling'
       path: '/ams-unattended-scheduling'
@@ -1658,6 +1677,7 @@ interface DocsRouteChildren {
   DocsAmsOperationsRunbookRoute: typeof DocsAmsOperationsRunbookRoute
   DocsAmsSizingRoute: typeof DocsAmsSizingRoute
   DocsAmsUnattendedSchedulingRoute: typeof DocsAmsUnattendedSchedulingRoute
+  DocsBacktestCalibrationRoute: typeof DocsBacktestCalibrationRoute
   DocsBetaOnboardingRoute: typeof DocsBetaOnboardingRoute
   DocsBranchAnalysisRoute: typeof DocsBranchAnalysisRoute
   DocsCapacityRoute: typeof DocsCapacityRoute
@@ -1711,6 +1731,7 @@ const DocsRouteChildren: DocsRouteChildren = {
   DocsAmsOperationsRunbookRoute: DocsAmsOperationsRunbookRoute,
   DocsAmsSizingRoute: DocsAmsSizingRoute,
   DocsAmsUnattendedSchedulingRoute: DocsAmsUnattendedSchedulingRoute,
+  DocsBacktestCalibrationRoute: DocsBacktestCalibrationRoute,
   DocsBetaOnboardingRoute: DocsBetaOnboardingRoute,
   DocsBranchAnalysisRoute: DocsBranchAnalysisRoute,
   DocsCapacityRoute: DocsCapacityRoute,

--- a/apps/loopover-ui/src/routes/docs-routes-loading-state.test.tsx
+++ b/apps/loopover-ui/src/routes/docs-routes-loading-state.test.tsx
@@ -45,7 +45,7 @@ describe("docs route Suspense fallback (#6982)", () => {
       "docs.tsx",
     ]);
     const inScope = docsRouteFiles.filter((name) => !outOfScope.has(name));
-    expect(inScope.length).toBe(48);
+    expect(inScope.length).toBe(49);
 
     for (const file of inScope) {
       const source = readFileSync(join(routesDir, file), "utf8");

--- a/apps/loopover-ui/src/routes/docs.backtest-calibration.tsx
+++ b/apps/loopover-ui/src/routes/docs.backtest-calibration.tsx
@@ -1,0 +1,50 @@
+import { createFileRoute, notFound } from "@tanstack/react-router";
+import { Suspense } from "react";
+
+import { DocsPage } from "@/components/site/docs-page";
+import { LoadingState } from "@/components/site/state-views";
+import { docsClientLoader } from "@/lib/docs-client-loader";
+import { getDocPage } from "@/lib/docs-source.functions";
+
+// Rendered from content/docs/backtest-calibration.mdx via fumadocs-mdx's browser entry
+// (docsClientLoader), through the existing DocsPage/Callout/CodeBlock primitives -- not fumadocs-ui's
+// bundled components. See docs-source.server.ts's comment for why the loader below resolves only a
+// plain, serializable path string.
+export const Route = createFileRoute("/docs/backtest-calibration")({
+  loader: async () => {
+    const page = await getDocPage({ data: { slugs: ["backtest-calibration"] } });
+    if (!page) throw notFound();
+    return page;
+  },
+  head: () => ({
+    meta: [
+      { title: "Backtest & calibration — LoopOver docs" },
+      {
+        name: "description",
+        content:
+          "How LoopOver measures whether its own review rules are right, and backtests threshold and logic changes against real recorded history before they ship.",
+      },
+      { property: "og:title", content: "Backtest & calibration — LoopOver docs" },
+      {
+        property: "og:description",
+        content:
+          "How LoopOver measures whether its own review rules are right, and backtests threshold and logic changes against real recorded history before they ship.",
+      },
+      { property: "og:url", content: "/docs/backtest-calibration" },
+    ],
+    links: [{ rel: "canonical", href: "/docs/backtest-calibration" }],
+  }),
+  component: BacktestCalibrationDoc,
+});
+
+function BacktestCalibrationDoc() {
+  const { path, title, description } = Route.useLoaderData();
+  const Content = docsClientLoader.getComponent(path);
+  return (
+    <DocsPage eyebrow="Core concepts" title={title} description={description}>
+      <Suspense fallback={<LoadingState />}>
+        <Content />
+      </Suspense>
+    </DocsPage>
+  );
+}

--- a/apps/loopover-ui/src/routes/docs.index.tsx
+++ b/apps/loopover-ui/src/routes/docs.index.tsx
@@ -94,6 +94,7 @@ const AUDIENCES: Audience[] = [
       { to: "/docs/self-hosting-rees-analyzers", label: "REES analyzers" },
       { to: "/docs/upstream-drift", label: "Upstream drift" },
       { to: "/docs/ai-summaries", label: "AI summaries policy" },
+      { to: "/docs/backtest-calibration", label: "Backtest & calibration" },
     ],
   },
   {


### PR DESCRIPTION
## Summary

- Adds the backtest/calibration docs page (#8114) now that both features it documents have actually shipped and stabilized: #8138's threshold backtest (ORB-native, #8142) and #8139's logic-backtest CI check (#8147) — per the issue's own "don't write against a moving target" boundary.
- `content/docs/backtest-calibration.mdx` (fumadocs entry, standard frontmatter) covers: the labeled corpus model (fired + human-override history), the two backtest mechanisms and *why they run where they run* (threshold = no code execution, lives in the Worker's unified comment; logic = executes the PR's own code, so it lives in CI and posts its own comment), how to read the Pareto-floor comparison ("reversed" as positive class, N/A-never-zero, any-regressed-axis ⇒ REGRESSED), the pre-#8139 skipped-cases rule, `secret_leak`'s permanent exclusion and its reason, the read-only track-record/corpus-export CLIs, and the advisory-only guarantee with the #8105 gating decision explicitly noted as pending.
- Thin route `docs.backtest-calibration.tsx` mirrors `docs.ai-summaries.tsx` exactly (getDocPage loader, head/og meta, DocsPage + Suspense/LoadingState). Nav entries added in `docs-nav.tsx` (Core concepts), `docs.index.tsx` (Maintainers card), and `command-palette.tsx`; route tree regenerated; the two pinned docs-route-count tests move 48 → 49.

Closes #8114

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:test`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- `npm run test:ci` on this branch was green through every step except `ui:version-audit`, which failed on the pre-#8149 fork point (npm published @loopover/mcp 3.4.0 mid-session; main fixed the pinned copy in #8149). After rebasing onto that fix: `ui:version-audit` and every remaining step (`manifest`/`engine-parity`/`nvmrc`/`release-manifest`/`command-reference` drift checks, plus `ui:lint`/`ui:typecheck`/`ui:test`/`ui:build`) re-ran green individually. All touched paths are under `apps/**` (outside coverage.include), so Codecov imposes nothing; the docs-route policy suites (server-isolation, loading-state, eager-scope) cover the new page, and the vite build compiled the MDX end-to-end.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Deliberately omitted (maintainer PR): the page is pure MDX rendered through the exact `DocsPage` template all 48 existing docs pages use — no new visual surface, no layout change. Preview locally with `npm --prefix apps/loopover-ui run dev` → `/docs/backtest-calibration`.

## Notes

- Filed #8151 in the same session: replace all 49 hand-rolled `docs.*.tsx` thin routes with one dynamic `docs.$slug.tsx` (this PR adds route #49 the old way deliberately — consistency first, consolidation as its own change).

