### PR TITLE
feat(control-plane): persist provisioning and failed tenant lifecycle states for the customer status surface

### DIFF
--- a/control-plane/src/http-app.ts
+++ b/control-plane/src/http-app.ts
@@ -34,8 +34,15 @@ import {
   provisionTenant,
   type ProvisioningPagerDutyOptions,
 } from "./provisioning.js";
-import type { Product, TenantProvisioningDriver } from "./tenant-provisioning-driver.js";
+import type { Product, TenantLifecycleState, TenantProvisioningDriver } from "./tenant-provisioning-driver.js";
 import type { AmsCycleSchedule, TenantRegistry, TenantRegistryRecord } from "./tenant-registry.js";
+
+/** States that do NOT block re-creating a tenant of the same name+product (or re-claiming its installation
+ *  ID): `"torn down"` (the pre-existing rule — a terminated tenant may be recreated fresh) and, since #7677
+ *  persists failures, `"failed"` — "Setup failed" must invite a retry, never permanently squat on the name. */
+function isRecreatableState(state: TenantLifecycleState): boolean {
+  return state === "torn down" || state === "failed";
+}
 
 export type TenantHttpAppDeps = {
   driver: TenantProvisioningDriver;
@@ -165,16 +172,18 @@ export function createTenantHttpApp(deps: TenantHttpAppDeps): Hono {
     // Not idempotent by design (tenant-client.ts's own doc comment: "a create is not idempotent, so it must
     // not be silently re-sent") -- a currently-active tenant of the same name *and product* is a real conflict,
     // not a no-op (#8024: ORB "acme" must not block AMS "acme"). A previously torn-down tenant may be recreated
-    // (its createdAt is NOT preserved -- this is a fresh provision, not a resurrection of the old one).
+    // (its createdAt is NOT preserved -- this is a fresh provision, not a resurrection of the old one), and so
+    // may a "failed" one (#7677): persisting the failed state must not turn "Setup failed" into a permanent
+    // block on retrying the setup -- before #7677 a failed provision left NO record, so a retry always worked.
     const existing = await deps.registry.get(name, product);
-    if (existing && existing.state !== "torn down") return c.json({ error: "tenant_already_exists" }, 409);
+    if (existing && !isRecreatableState(existing.state)) return c.json({ error: "tenant_already_exists" }, 409);
 
     // A GitHub installation ID must resolve to exactly one hosted container (#7181's routing depends on this
     // being unambiguous) -- reject before ever provisioning anything, same posture as the name+product conflict
     // check just above.
     if (orbInstallationId !== undefined) {
       const conflicting = await deps.registry.getByOrbInstallationId(orbInstallationId);
-      if (conflicting && conflicting.state !== "torn down") {
+      if (conflicting && !isRecreatableState(conflicting.state)) {
         return c.json(
           { error: "installation_already_claimed", message: `installation ${orbInstallationId} is already claimed by tenant "${conflicting.tenant.name}"` },
           409,
@@ -182,16 +191,29 @@ export function createTenantHttpApp(deps: TenantHttpAppDeps): Hono {
       }
     }
 
-    const result = await provisionTenant({ name }, product, deps.driver, deps.pagerDuty ?? {});
-    const now = new Date().toISOString();
-    const record: TenantRegistryRecord = {
-      tenant: result.tenant,
-      product: result.product,
-      state: result.state,
-      createdAt: now,
-      updatedAt: now,
+    // #7677 (ratified 2026-07-21): persist the record in its transitional "provisioning" state BEFORE the
+    // (slow) container/DB/secret standup starts, so the customer-facing dashboard's poll of the existing
+    // GET /v1/tenants read path can actually observe "Setting up your instance" while it happens -- and hand
+    // provisionTenant the seam that flips this same record to a terminal "failed" before a step failure
+    // rethrows, so that poll ends at "Setup failed" instead of spinning on "provisioning" forever.
+    const startedAt = new Date().toISOString();
+    const pending: TenantRegistryRecord = {
+      tenant: { name },
+      product,
+      state: "provisioning",
+      createdAt: startedAt,
+      updatedAt: startedAt,
       ...(schedule ? { amsSchedule: schedule } : {}),
       ...(orbInstallationId !== undefined ? { orbInstallationId } : {}),
+    };
+    await deps.registry.upsert(pending);
+    const result = await provisionTenant({ name }, product, deps.driver, deps.pagerDuty ?? {}, async () => {
+      await deps.registry.upsert({ ...pending, state: "failed", updatedAt: new Date().toISOString() });
+    });
+    const record: TenantRegistryRecord = {
+      ...pending,
+      state: result.state,
+      updatedAt: new Date().toISOString(),
       ...(result.secretRef !== undefined ? { secretRef: result.secretRef } : {}),
     };
     await deps.registry.upsert(record);

--- a/control-plane/src/provisioning.ts
+++ b/control-plane/src/provisioning.ts
@@ -85,12 +85,15 @@ function pageAndRethrow(
  *  `product` is forwarded to every step, never branched on, so ORB and AMS share one call shape. `injectSecrets`
  *  is called with `database` already attached to the request (#8066) -- a real secret driver needs the
  *  connection details to actually store, not just the tenant identity every other step operates on. A step
- *  failure pages (#7667) and always rethrows — provisioning never fails silently. */
+ *  failure pages (#7667) and always rethrows — provisioning never fails silently. `onFailure` (#7677,
+ *  optional) runs first in that failure path — the caller's seam for persisting the `"failed"` lifecycle
+ *  state — and is best-effort: its own rejection is swallowed so it can never mask the step error. */
 export async function provisionTenant(
   tenant: Tenant,
   product: Product,
   driver: TenantProvisioningDriver,
   pagerDuty: ProvisioningPagerDutyOptions = {},
+  onFailure?: () => Promise<void>,
 ): Promise<TenantProvisioningResult> {
   const request: TenantProvisioningRequest = { tenant, product };
   let database: DatabaseConnectionDetails;
@@ -100,6 +103,11 @@ export async function provisionTenant(
     database = await driver.provisionDatabase(request);
     ({ secretRef } = await driver.injectSecrets({ ...request, database }));
   } catch (error) {
+    // #7677 (ratified 2026-07-21): give the caller its chance to transition the tenant's registry record to
+    // "failed" BEFORE the rethrow, so a customer polling the read path sees a terminal "Setup failed" instead
+    // of a record stuck at "provisioning" forever. Best-effort by design: a failure writing the failed state
+    // must never mask the provisioning error itself, which still pages and rethrows exactly as before.
+    if (onFailure) await onFailure().catch(() => undefined);
     pageAndRethrow(tenant, product, "provision", error, pagerDuty);
   }
   return { tenant, product, state: "active", database, ...(secretRef !== undefined ? { secretRef } : {}) };

--- a/control-plane/src/tenant-provisioning-driver.ts
+++ b/control-plane/src/tenant-provisioning-driver.ts
@@ -29,9 +29,12 @@ export type Tenant = {
 
 /** The full tenant lifecycle vocabulary the #7180 provisioning API reports, passed through verbatim by
  *  tenant-client.ts. provisionTenant/deprovisionTenant only ever produce the terminal `"active"` / `"torn down"`
- *  states; `"provisioning"` (transitional) and `"suspended"` (an operator action) round out the documented set. */
+ *  states; `"provisioning"` (transitional — written by the create route before orchestration starts, so a
+ *  polling customer can watch the standup, #7677) and `"failed"` (#7677: a provision-step failure, persisted
+ *  before the rethrow so that same polling customer sees a terminal "Setup failed" instead of a record stuck
+ *  at "provisioning" forever) and `"suspended"` (an operator action) round out the documented set. */
 export type TenantLifecycleState =
-  "provisioning" | "active" | "suspended" | "torn down";
+  "provisioning" | "active" | "suspended" | "failed" | "torn down";
 
 /** Everything one provision/deprovision step needs. A single request type flows through every driver method so a
  *  real and a fake driver see identical inputs, and so ORB and AMS calls are shaped identically. */

--- a/control-plane/test/http-app.test.ts
+++ b/control-plane/test/http-app.test.ts
@@ -13,6 +13,7 @@ import {
   type RouterNamespaceLike,
   type RouterStubLike,
   type TenantHttpAppDeps,
+  type TenantRegistryRecord,
   type TenantProvisioningDriver,
 } from "../dist/index.js";
 
@@ -579,6 +580,135 @@ test("a driver failure surfaces as a logged 500 via onError, not an unhandled re
   assert.equal(errors.length, 1);
   assert.match(errors[0]!, /control_plane_http_error/);
   assert.match(errors[0]!, /cloudflare containers api unavailable/);
+});
+
+// #7677 (ratified 2026-07-21): the provisioning-status surface. The record is written as "provisioning"
+// BEFORE the standup starts and transitions to a terminal "failed" before a step failure rethrows — all
+// observable via the same GET /v1/tenants read path a customer's dashboard polls.
+
+function swallowConsoleError() {
+  const originalError = console.error;
+  console.error = () => {};
+  consoleErrorRestore = () => {
+    console.error = originalError;
+  };
+}
+
+function failingCreateDriver(): TenantProvisioningDriver {
+  return {
+    ...createFakeTenantProvisioningDriver(),
+    async createContainer() {
+      throw new Error("container standup failed");
+    },
+  };
+}
+
+test("a provision failure transitions the record to 'failed', observable via the dashboard's own read path (#7677 acceptance)", async () => {
+  swallowConsoleError();
+  const registry = createFakeTenantRegistry();
+  const app = createTenantHttpApp(baseDeps({ driver: failingCreateDriver(), registry }));
+
+  const res = await app.request(
+    "/v1/tenants",
+    authed({ method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ name: "acme", product: "orb" }) }),
+  );
+
+  assert.equal(res.status, 500); // the failure itself still pages + rethrows exactly as before
+  assert.equal((await registry.get("acme", "orb"))?.state, "failed");
+  // The SAME read path a customer's dashboard polls (GET /v1/tenants) shows the terminal failed state —
+  // not a record stuck at "provisioning" forever.
+  const list = await app.request("/v1/tenants", authed());
+  const { tenants } = (await list.json()) as { tenants: Array<{ tenant: { name: string }; state: string }> };
+  assert.deepEqual(
+    tenants.map((t) => ({ name: t.tenant.name, state: t.state })),
+    [{ name: "acme", state: "failed" }],
+  );
+});
+
+test("the record is observable as 'provisioning' while the standup is still in flight (#7677 polling premise)", async () => {
+  const registry = createFakeTenantRegistry();
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const slowDriver: TenantProvisioningDriver = {
+    ...createFakeTenantProvisioningDriver(),
+    async createContainer() {
+      await gate;
+    },
+  };
+  const app = createTenantHttpApp(baseDeps({ driver: slowDriver, registry }));
+
+  const pending = app.request(
+    "/v1/tenants",
+    authed({ method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ name: "acme", product: "orb" }) }),
+  );
+  // Let the route reach the awaited (gated) driver step, then poll mid-standup like the dashboard would.
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal((await registry.get("acme", "orb"))?.state, "provisioning");
+  release();
+  const res = await pending;
+  assert.equal(res.status, 201);
+  assert.equal((await registry.get("acme", "orb"))?.state, "active");
+});
+
+test("a 'failed' tenant may be re-created — 'Setup failed' invites a retry, it never squats on the name (#7677)", async () => {
+  swallowConsoleError();
+  const registry = createFakeTenantRegistry();
+  const failOnce = failingCreateDriver();
+  const app = createTenantHttpApp(baseDeps({ driver: failOnce, registry }));
+  const body = { method: "POST" as const, headers: { "content-type": "application/json" }, body: JSON.stringify({ name: "acme", product: "orb", orbInstallationId: 77 }) };
+
+  assert.equal((await app.request("/v1/tenants", authed(body))).status, 500);
+  assert.equal((await registry.get("acme", "orb"))?.state, "failed");
+
+  // Retry with a healthy driver: neither the name+product conflict check nor the installation-ID claim check
+  // treats the failed record as a blocker (before #7677 a failure left NO record, so a retry always worked).
+  const healthy = createTenantHttpApp(baseDeps({ driver: createFakeTenantProvisioningDriver(), registry }));
+  const retry = await healthy.request("/v1/tenants", authed(body));
+  assert.equal(retry.status, 201);
+  assert.equal((await registry.get("acme", "orb"))?.state, "active");
+});
+
+test("an ACTIVE tenant still 409s a re-create — #7677 loosens only the failed/torn-down states", async () => {
+  const registry = createFakeTenantRegistry();
+  await registry.upsert({ tenant: { name: "acme" }, product: "orb", state: "active", createdAt: "t0", updatedAt: "t0", orbInstallationId: 77 });
+  const app = createTenantHttpApp(baseDeps({ registry }));
+
+  const sameName = await app.request(
+    "/v1/tenants",
+    authed({ method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ name: "acme", product: "orb" }) }),
+  );
+  assert.equal(sameName.status, 409);
+  const sameInstallation = await app.request(
+    "/v1/tenants",
+    authed({ method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ name: "other", product: "orb", orbInstallationId: 77 }) }),
+  );
+  assert.equal(sameInstallation.status, 409);
+});
+
+test("a rejection writing the 'failed' state never masks the provisioning error itself (#7677 best-effort seam)", async () => {
+  swallowConsoleError();
+  const registry = createFakeTenantRegistry();
+  const fragileRegistry = {
+    ...registry,
+    async upsert(record: TenantRegistryRecord) {
+      if (record.state === "failed") throw new Error("kv write outage");
+      await registry.upsert(record);
+    },
+  };
+  const app = createTenantHttpApp(baseDeps({ driver: failingCreateDriver(), registry: fragileRegistry }));
+
+  const res = await app.request(
+    "/v1/tenants",
+    authed({ method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ name: "acme", product: "orb" }) }),
+  );
+
+  // Still the ORIGINAL provisioning failure surfacing through onError — the failed-state write outage is
+  // swallowed, and the record is simply left at its pre-written "provisioning" state.
+  assert.equal(res.status, 500);
+  assert.deepEqual(await res.json(), { error: "internal_error" });
+  assert.equal((await registry.get("acme", "orb"))?.state, "provisioning");
 });
 
 // #4898: POST /v1/tenants/rollout — pin/unpin an explicit list of tenants' pinnedVersion, all-or-nothing.


### PR DESCRIPTION
## Summary

Implements #7677's ratified decision (2026-07-21) — the provisioning-status state machine behind the customer-facing polling surface:

- **`"failed"` added to `TenantLifecycleState`** (`control-plane/src/tenant-provisioning-driver.ts`) — the spec's bolded gap: today a provision-step failure pages and rethrows but **persists nothing**, so a polling customer would watch a record stuck at `"provisioning"` forever with no signal.
- **`provisionTenant` transitions the record to `"failed"` before rethrowing** (`control-plane/src/provisioning.ts`): a new optional `onFailure` seam runs first in the existing catch — best-effort by design (its own rejection is swallowed), so a KV write outage can never mask the provisioning error, which still pages (#7667) and rethrows exactly as before.
- **The record is now written as `"provisioning"` BEFORE the standup starts** (`POST /v1/tenants`, `control-plane/src/http-app.ts`): without this pre-write, the transitional state the decision's polling loop watches ("Customer dashboard polls every 3-5s while in `provisioning`") was never observable at all — the old flow only ever wrote the record after success. Per the ratified decision, the polling surface is the **already-decided `GET /v1/tenants` transport (#7654) — no new endpoint is added.**
- **`"failed"` is re-creatable, like `"torn down"`** (`isRecreatableState`, both conflict sites — name+product and the #7181 installation-ID claim): before this PR a failure left NO record so a retry always worked; persisting the failure must not turn "Setup failed" into a permanent squat on the tenant name. An **active** tenant still 409s both checks, pinned by test. `DELETE` of a failed tenant needs no change — `deprovisionTenant` is idempotent by driver contract, so cleanup works as-is.

**Deliberate scope line, from the spec's own text:** the customer dashboard polling UI and its three-state copy ("Setting up your instance" / "Ready" / "Setup failed") live "alongside #4926/#4927" — both of which are **open and owner-assigned**; that surface is the maintainer's in-flight redesign, not contributor territory. This PR delivers the state machine and its observability through the exact read path that dashboard will poll — the acceptance test below is worded directly from the spec's own test deliverable: *"a provisioning failure transitions the record to `failed` and is observable via the same read path a customer's dashboard uses."* The state→copy mapping is preserved verbatim in the lifecycle type's doc comment for that follow-up to consume.

Closes #7677

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- The diff is entirely inside the self-contained `control-plane/` package (own npm package, own build, own `node:test` suite, own Codecov flag), so the checks that actually exercise it were run in full, not the root chain whose suites never import it:
  - **`npm --prefix control-plane test`** → build + **187/187 tests pass** (182 existing + the 5 added below).
  - **`npm --prefix control-plane run cf:typecheck`** (the Worker tsconfig) → clean.
  - **`npm run control-plane:coverage`** → package 99.94% lines / 99.05% functions; **empirically intersecting `lcov.info` with this diff's changed lines: 48/48 changed instrumented lines covered, zero uncovered branch arms — patch = 100% lines and branches** (measured per line/arm with max-merged DA/BRDA records, not inferred from file totals).
  - `npm audit --audit-level=moderate` → `found 0 vulnerabilities`; `git diff --check` clean.
- The unchecked root-chain boxes (`typecheck`, `test:coverage`, workers/mcp/ui/openapi) cover surfaces this PR does not touch — no `src/**`, `packages/**`, or `apps/**` file changes; root `tsconfig` does not include `control-plane/` (it typechecks under its own two tsconfigs, both run above). Also swept every repo-wide consumer of `TenantLifecycleState` before widening the union: no exhaustive switch/mapping exists (the miner's `tenant-client` passes states through verbatim with deliberately non-exhaustive docs), so nothing outside the package can be broken by the new member.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

Unchecked boxes above, and why — all N/A rather than skipped:

- **Auth/cookie/CORS/session:** no auth behavior changes — the routes keep their existing Bearer/503/401 gating, and the existing auth-branch tests pass unchanged. (The registry's own no-secret-values posture is untouched; the new states carry no payload.)
- **UI / UI Evidence:** no UI files are touched — the dashboard surface belongs to owner-assigned #4926/#4927, per the Summary's scope line. There is nothing visual to screenshot in a lifecycle-state persistence change.

## Notes

- **Tests added (`control-plane/test/http-app.test.ts`, +5, mirroring the existing driver-failure/onError idioms):**
  1. **The spec's acceptance test, verbatim in intent:** a provision failure → 500 (still pages + rethrows), registry shows `"failed"`, and **`GET /v1/tenants` — the dashboard's read path — returns the terminal failed state**, not a record stuck at `"provisioning"`.
  2. **The polling premise:** with the driver gated mid-standup, the record is observable as `"provisioning"` while provisioning is in flight, then `"active"` after release — the transitional state the 3-5s poll watches now actually exists on the wire.
  3. **Retry:** a `"failed"` tenant (including one holding an installation-ID claim) is re-creatable — 201 on retry with a healthy driver; before #7677 a failure left no record, so this pins that persisting failures doesn't regress retryability.
  4. **Conflicts unchanged for live tenants:** an `"active"` tenant still 409s both the name+product check and the installation-claim check.
  5. **The best-effort seam:** a registry that rejects the `"failed"` write still surfaces the ORIGINAL provisioning error (500 `internal_error`), with the record left at its pre-written `"provisioning"` state — the swallowed-rejection arm of the new catch path, covered explicitly.
- **State→copy mapping for the #4926/#4927 dashboard follow-up** (from the ratified decision, recorded in the lifecycle type's doc comment): `"provisioning"` → "Setting up your instance" (poll every 3-5s) · `"active"` → "Ready" (terminal, stop polling) · `"failed"` → "Setup failed" (terminal, stop polling) · `"suspended"`/`"torn down"` → post-provisioning operator states, out of the provisioning flow's scope.
