### PR TITLE
chore(ui): sync MCP_PACKAGE_KNOWN_LATEST_VERSION with npm dist-tags.latest 3.5.0

### DIFF
--- a/apps/loopover-ui/src/lib/mcp-package.ts
+++ b/apps/loopover-ui/src/lib/mcp-package.ts
@@ -8,7 +8,7 @@ export const MCP_PACKAGE_REGISTRY_URL = `https://registry.npmjs.org/${MCP_PACKAG
 export const MCP_PACKAGE_NPM_URL = `https://www.npmjs.com/package/${MCP_PACKAGE_NAME}`;
 // Tracks the latest PUBLISHED release: ui:version-audit requires this to equal npm dist-tags.latest, so it is
 // bumped to a new version only AFTER that version publishes (never ahead of npm).
-export const MCP_PACKAGE_KNOWN_LATEST_VERSION = "3.4.0";
+export const MCP_PACKAGE_KNOWN_LATEST_VERSION = "3.5.0";
 export const MCP_MINIMUM_SUPPORTED_VERSION = "0.5.0";
 
 export type NpmPackageMetadata = {


### PR DESCRIPTION
One-line sync: tonight's release automation published `@loopover/mcp` **3.5.0**, so `ui:version-audit` fails repo-wide against main's pinned 3.4.0 (#8149's sync). Verified locally: `MCP UI version copy ok: npm latest 3.5.0`. Same change shape as the automation's own sync PRs — merging this unblocks validate for every open branch tonight.