### PR TITLE
fix(docs): repair #8182 fallout — audit manifest, mangled runner YAML snippet, kill-switch route assertion

### DIFF
--- a/apps/loopover-ui/content/docs/self-hosting-operations.mdx
+++ b/apps/loopover-ui/content/docs/self-hosting-operations.mdx
@@ -495,29 +495,31 @@ repeat the extension block in your override file:
   TEMP: /tmp/runner/tmp
 
 services:
-runner-2-tmp-init:
-image: alpine:3.20
-profiles: ["runners"]
-volumes: - runner-work-2:/tmp/runner
-command: ["sh", "-c", "mkdir -p /tmp/runner/tmp && chmod 1777 /tmp/runner/tmp"]
+  runner-2-tmp-init:
+    image: alpine:3.20
+    profiles: ["runners"]
+    volumes:
+      - runner-work-2:/tmp/runner
+    command: ["sh", "-c", "mkdir -p /tmp/runner/tmp && chmod 1777 /tmp/runner/tmp"]
 
-runner-2:
-image: myoung34/github-runner:ubuntu-jammy
-profiles: ["runners"]
-depends_on:
-runner-2-tmp-init:
-condition: service_completed_successfully
-environment:
-<<: \*runner-tmp-env
-RUNNER_NAME: loopover-runner-2
-RUNNER_SCOPE: \${RUNNER_SCOPE:-repo}
-REPO_URL: \${RUNNER_REPO_URL:-}
-RUNNER_TOKEN: \${RUNNER_TOKEN:-}
-RUNNER_WORKDIR: /tmp/runner
-volumes: - runner-work-2:/tmp/runner
+  runner-2:
+    image: myoung34/github-runner:ubuntu-jammy
+    profiles: ["runners"]
+    depends_on:
+      runner-2-tmp-init:
+        condition: service_completed_successfully
+    environment:
+      <<: *runner-tmp-env
+      RUNNER_NAME: loopover-runner-2
+      RUNNER_SCOPE: \${RUNNER_SCOPE:-repo}
+      REPO_URL: \${RUNNER_REPO_URL:-}
+      RUNNER_TOKEN: \${RUNNER_TOKEN:-}
+      RUNNER_WORKDIR: /tmp/runner
+    volumes:
+      - runner-work-2:/tmp/runner
 
 volumes:
-runner-work-2:`}
+  runner-work-2:`}
 />
 
 ## Enabling Sentry (your own DSN)

--- a/apps/loopover-ui/src/lib/selfhost-docs-audit.ts
+++ b/apps/loopover-ui/src/lib/selfhost-docs-audit.ts
@@ -3,75 +3,77 @@
 export type SelfHostDocsPageLink = {
   title: string;
   path: string;
-  routeFile: string;
+  /** The page's real source since the #8182 dynamic-route migration: content/docs/<slug>.mdx (the
+   *  one docs.$slug.tsx route serves every page — there is no per-page .tsx to point at anymore). */
+  contentFile: string;
 };
 
 export const SELFHOST_DOCS_PAGES = [
   {
     title: "Quickstart",
     path: "/docs/self-hosting-quickstart",
-    routeFile: "docs.self-hosting-quickstart.tsx",
+    contentFile: "self-hosting-quickstart.mdx",
   },
   {
     title: "Configuration",
     path: "/docs/self-hosting-configuration",
-    routeFile: "docs.self-hosting-configuration.tsx",
+    contentFile: "self-hosting-configuration.mdx",
   },
   {
     title: "GitHub App and Orb",
     path: "/docs/self-hosting-github-app",
-    routeFile: "docs.self-hosting-github-app.tsx",
+    contentFile: "self-hosting-github-app.mdx",
   },
   {
     title: "AI providers",
     path: "/docs/self-hosting-ai-providers",
-    routeFile: "docs.self-hosting-ai-providers.tsx",
+    contentFile: "self-hosting-ai-providers.mdx",
   },
   {
     title: "REES enrichment",
     path: "/docs/self-hosting-rees",
-    routeFile: "docs.self-hosting-rees.tsx",
+    contentFile: "self-hosting-rees.mdx",
   },
   {
     title: "REES analyzer reference",
     path: "/docs/self-hosting-rees-analyzers",
-    routeFile: "docs.self-hosting-rees-analyzers.tsx",
+    contentFile: "self-hosting-rees-analyzers.mdx",
   },
-  { title: "RAG indexing", path: "/docs/self-hosting-rag", routeFile: "docs.self-hosting-rag.tsx" },
+  { title: "RAG indexing", path: "/docs/self-hosting-rag", contentFile: "self-hosting-rag.mdx" },
   {
     title: "Operations",
     path: "/docs/self-hosting-operations",
-    routeFile: "docs.self-hosting-operations.tsx",
+    contentFile: "self-hosting-operations.mdx",
   },
   {
     title: "Backup and scaling",
     path: "/docs/self-hosting-backup-scaling",
-    routeFile: "docs.self-hosting-backup-scaling.tsx",
+    contentFile: "self-hosting-backup-scaling.mdx",
   },
   {
     title: "Releases and images",
     path: "/docs/self-hosting-releases",
-    routeFile: "docs.self-hosting-releases.tsx",
+    contentFile: "self-hosting-releases.mdx",
   },
   {
     title: "Release checklist",
     path: "/docs/self-hosting-release-checklist",
-    routeFile: "docs.self-hosting-release-checklist.tsx",
+    contentFile: "self-hosting-release-checklist.mdx",
   },
   {
     title: "Security",
     path: "/docs/self-hosting-security",
-    routeFile: "docs.self-hosting-security.tsx",
+    contentFile: "self-hosting-security.mdx",
   },
   {
     title: "Troubleshooting",
     path: "/docs/self-hosting-troubleshooting",
-    routeFile: "docs.self-hosting-troubleshooting.tsx",
+    contentFile: "self-hosting-troubleshooting.mdx",
   },
   {
     title: "Docs accuracy audit",
     path: "/docs/self-hosting-docs-audit",
-    routeFile: "docs.self-hosting-docs-audit.tsx",
+    contentFile: "self-hosting-docs-audit.mdx",
   },
 ] as const;
 

--- a/test/unit/docs-selfhost-audit-checklist.test.ts
+++ b/test/unit/docs-selfhost-audit-checklist.test.ts
@@ -11,6 +11,7 @@ import {
 
 const REPO_ROOT = resolve(import.meta.dirname, "../..");
 const ROUTES_DIR = resolve(REPO_ROOT, "apps/loopover-ui/src/routes");
+const CONTENT_DIR = resolve(REPO_ROOT, "apps/loopover-ui/content/docs");
 // SPIKE (#6037): these two pages' prose now lives in the migrated content/docs/*.mdx files, not
 // the route .tsx, which only orchestrates the fumadocs loader + client-loader -- point the drift
 // guard at the actual content source. docs.index.tsx (below, for the docs-hub link check) is the
@@ -28,9 +29,9 @@ describe("self-host docs accuracy audit (#1829)", () => {
   const maintainerSource = readFileSync(MAINTAINER_INDEX, "utf8");
   const packageJson = JSON.parse(readFileSync(PACKAGE_JSON, "utf8")) as { scripts: Record<string, string> };
 
-  it("manifest lists every self-host docs route file on disk", () => {
+  it("manifest lists every self-host docs content file on disk (pages are content/docs/*.mdx since the #8182 dynamic route)", () => {
     for (const page of SELFHOST_DOCS_PAGES) {
-      expect(existsSync(resolve(ROUTES_DIR, page.routeFile)), page.routeFile).toBe(true);
+      expect(existsSync(resolve(CONTENT_DIR, page.contentFile)), page.contentFile).toBe(true);
     }
   });
 

--- a/test/unit/kill-switch-incident-runbook.test.ts
+++ b/test/unit/kill-switch-incident-runbook.test.ts
@@ -10,7 +10,8 @@ import {
 
 const repoRoot = process.cwd();
 const runbookPath = join(repoRoot, "apps/loopover-ui/content/docs/ams-kill-switch-incident.mdx");
-const routePath = join(repoRoot, "apps/loopover-ui/src/routes/docs.ams-kill-switch-incident.tsx");
+// #8182 replaced the per-page thin route with the one dynamic docs route — that file now serves this page.
+const routePath = join(repoRoot, "apps/loopover-ui/src/routes/docs.$slug.tsx");
 const docsNavPath = join(repoRoot, "apps/loopover-ui/src/components/site/docs-nav.tsx");
 
 describe("kill-switch incident runbook (#4809)", () => {
@@ -20,7 +21,7 @@ describe("kill-switch incident runbook (#4809)", () => {
     const nav = readFileSync(docsNavPath, "utf8");
 
     expect(runbook).toContain("title: Kill-switch incident runbook");
-    expect(route).toContain('createFileRoute("/docs/ams-kill-switch-incident")');
+    expect(route).toContain('createFileRoute("/docs/$slug")');
     expect(nav).toContain('to: "/docs/ams-kill-switch-incident"');
   });
 


### PR DESCRIPTION
## What

Main has been red since #8182 (the dynamic docs.$slug.tsx migration). Three drift tests caught real fallout:

1. **selfhost-docs-audit manifest** listed the deleted per-page `docs.*.tsx` route files. Entries now name the pages' real sources since the migration: `content/docs/<slug>.mdx` (the field is renamed `routeFile` → `contentFile`; it had no other consumer).
2. **A real docs regression**: the whole-tree format pass in #8182 stripped all indentation out of `self-hosting-operations.mdx`'s multi-runner docker-compose example — invalid YAML an operator would copy-paste. Restored verbatim; the `docs-selfhost-operations-runner-tmpdir` drift test did exactly its job. (Scanned every other mdx that PR touched for the same class of damage — this was the only structured code block affected.)
3. **kill-switch runbook test** asserted `createFileRoute` in the deleted per-page route; it now checks the dynamic route that actually serves the page, keeping the nav-entry and content assertions unchanged.

## Validation

All three suites green locally (`docs-selfhost-audit-checklist`, `docs-selfhost-operations-runner-tmpdir`, `kill-switch-incident-runbook`); root + UI typecheck green. mdx code blocks are not formatter-enforced in CI (`ui:lint` is eslint-only), and the restored snippet matches the pre-#8182 content that CI accepted for months.