### PR TITLE
chore(ui): prettierignore locally generated coverage reports in all three UI workspaces

### DIFF
--- a/apps/loopover-miner-ui/.prettierignore
+++ b/apps/loopover-miner-ui/.prettierignore
@@ -4,3 +4,5 @@ dist
 .vinxi
 package-lock.json
 routeTree.gen.ts
+# Locally generated coverage reports (vitest --coverage) -- never formatter input.
+coverage

--- a/apps/loopover-ui/.prettierignore
+++ b/apps/loopover-ui/.prettierignore
@@ -12,3 +12,5 @@ public/openapi.json
 # <CodeBlock code={`...`}> attributes, destroying embedded YAML/compose indentation (#8182 fallout,
 # repaired once already). Docs mdx is deliberately formatter-free.
 content/docs
+# Locally generated coverage reports (vitest --coverage) -- never formatter input.
+coverage

--- a/packages/loopover-ui-kit/.prettierignore
+++ b/packages/loopover-ui-kit/.prettierignore
@@ -1,3 +1,5 @@
 node_modules
 dist
 CHANGELOG.md
+# Locally generated coverage reports (vitest --coverage) -- never formatter input.
+coverage


### PR DESCRIPTION
One-line follow-up to #8193: `coverage/` (vitest --coverage output) wasn't in the new `.prettierignore` files, so any worktree that had previously run coverage locally fails `format:check` on `coverage/lcov-report/**` artifacts. CI checkouts are clean, so this only bit local `npm run test:ci` runs — but local and CI enforcing the identical surface is the point of the alignment.