### PR TITLE
feat(review): capture fired signals + reversal mapping for the slop and quality gate scores

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -196,6 +196,7 @@ import {
   buildPullRequestAdvisory,
   evaluateGateCheck,
   recordConfiguredGateBlockerSignals,
+  recordGateScoreSignals,
   resolveAiReviewLowConfidenceHold,
 } from "../rules/advisory";
 import { hasValidationNote, isTestPath } from "../signals/test-evidence";
@@ -10410,6 +10411,8 @@ async function maybePublishPrPublicSurface(
           await recordConfiguredGateBlockerSignals(env, advisory, gatePolicy, repoFullName, pr.number, {
             aiReviewDiff: buildAiReviewDiff(await getReviewFiles()),
           });
+          // #8223: the score gates leave labeled evidence too — fired whenever they actually evaluated.
+          await recordGateScoreSignals(env, gatePolicy, repoFullName, pr.number);
         }
         // Deterministic content/registry surface lane (#1255) — flag-gated + per-repo allowlist, byte-identical when
         // off (evaluateWithSurfaceLane returns the generic evaluation unchanged and resolves no files). A metagraphed

--- a/src/rules/advisory.ts
+++ b/src/rules/advisory.ts
@@ -175,6 +175,17 @@ export const AI_JUDGMENT_BLOCKER_CODES = new Set<string>(["ai_consensus_defect",
  * (#8104). That one code is wired by #8101 at its own upstream push / reversal sites — including it here
  * would double-count fired/reversed history. Keep this list in sync with `isConfiguredGateBlocker`'s body.
  */
+/** The two score-gate rule ids #8223 captures — knobs whose decisions previously left NO labeled
+ *  evidence (`slopGateMinScore` / `qualityGateMinScore` gate real verdicts but recorded no
+ *  `signal.rule_fired` events, so no corpus could ever form for them). Included in the reversal list
+ *  below: a human undoing the bot outcome on a PR where a score gate evaluated IS the labeled evidence
+ *  the knob registry needs to backtest these thresholds — the same reversal semantic every other entry
+ *  carries (justified per the issue's extend-only-if-qualified requirement: slop carries direct gate
+ *  authority in block mode; quality is advisory-only but its threshold is registry-governable, and a
+ *  reversal labels the overall bot outcome its score contributed to, which is exactly the corpus label
+ *  the drift/loosening evaluators consume). */
+export const GATE_SCORE_SIGNAL_CODES: readonly string[] = Object.freeze(["slop_gate_score", "quality_gate_score"]);
+
 export const CONFIGURED_GATE_BLOCKER_SIGNAL_CODES: readonly string[] = Object.freeze([
   "missing_linked_issue",
   "duplicate_pr_risk",
@@ -188,6 +199,7 @@ export const CONFIGURED_GATE_BLOCKER_SIGNAL_CODES: readonly string[] = Object.fr
   "content_lane_deliverable_missing",
   "lockfile_tamper_risk",
   CLA_CONSENT_MISSING_CODE,
+  ...GATE_SCORE_SIGNAL_CODES,
 ]);
 
 /** Fixed lookback for reversal→HumanOverrideEvent pairing (#8104) — 30 days in milliseconds. */
@@ -1128,6 +1140,71 @@ export async function recordConfiguredGateBlockerSignals(
         .catch(() => undefined);
     }),
   );
+}
+
+/**
+ * Record a fired signal for each score gate that actually EVALUATED its score this pass (#8223) -- the
+ * same filter the pure evaluation applies: slop evaluates only in `block` mode with a non-null risk
+ * (mirrors {@link buildSlopGateBlocker}); quality evaluates whenever its mode is not `off` with both a
+ * score and a threshold present (mirrors {@link buildQualityGateWarning}), pass or fail alike -- a corpus
+ * needs both outcomes to backtest a threshold. Metadata carries the score normalized to [0, 1]
+ * (both scores are 0-100 integers per normalizeScore; divided by 100 to be confidence-equivalent for
+ * buildConfidenceThresholdClassifier replays) plus the detection's own detail string as `rawSignal` --
+ * never diff content, per #8130's raw-context audit posture for computed-score rules. Best-effort like
+ * every calibration write: a failure never affects the verdict.
+ */
+export async function recordGateScoreSignals(
+  env: Env,
+  policy: GateCheckPolicy,
+  repoFullName: string,
+  prNumber: number,
+): Promise<void> {
+  const store = createSignalStore(env);
+  const targetKey = `${repoFullName}#${prNumber}`;
+  const occurredAt = nowIso();
+  const writes: Promise<void>[] = [];
+
+  const slopMode = gateMode(policy.slopGateMode);
+  const slopRisk = normalizeScore(policy.slopRisk);
+  if (slopMode === "block" && slopRisk !== null) {
+    const slopMin = normalizeScore(policy.slopGateMinScore) ?? DEFAULT_SLOP_BLOCK_THRESHOLD;
+    writes.push(
+      store
+        .recordRuleFired({
+          ruleId: "slop_gate_score",
+          targetKey,
+          outcome: slopRisk >= slopMin ? "above_threshold" : "below_threshold",
+          occurredAt,
+          metadata: {
+            confidence: slopRisk / 100,
+            rawSignal: `deterministic slop risk ${slopRisk}/100 vs threshold ${slopMin}/100 (mode ${slopMode})`,
+          },
+        })
+        .catch(() => undefined),
+    );
+  }
+
+  const qualityMode = gateMode(policy.qualityGateMode);
+  const readinessScore = normalizeScore(policy.readinessScore);
+  const qualityMin = normalizeScore(policy.qualityGateMinScore);
+  if (qualityMode !== "off" && readinessScore !== null && qualityMin !== null) {
+    writes.push(
+      store
+        .recordRuleFired({
+          ruleId: "quality_gate_score",
+          targetKey,
+          outcome: readinessScore < qualityMin ? "below_threshold" : "at_or_above_threshold",
+          occurredAt,
+          metadata: {
+            confidence: readinessScore / 100,
+            rawSignal: `public readiness score ${readinessScore}/100 vs threshold ${qualityMin}/100 (mode ${qualityMode})`,
+          },
+        })
+        .catch(() => undefined),
+    );
+  }
+
+  await Promise.all(writes);
 }
 
 function buildQualityGateWarning(policy: GateCheckPolicy): AdvisoryFinding | null {

--- a/test/unit/configured-gate-blocker-signals.test.ts
+++ b/test/unit/configured-gate-blocker-signals.test.ts
@@ -301,7 +301,7 @@ describe("recordGateScoreSignals (#8223)", () => {
       queryRuleHistory: async () => ({ fired: [], overrides: [] }),
     });
     await expect(
-      recordGateScoreSignals(createTestEnv(), { slopGateMode: "block", slopRisk: 72 }, "owner/repo", 7),
+      recordGateScoreSignals(createTestEnv(), { slopGateMode: "block", slopRisk: 72, qualityGateMode: "advisory", readinessScore: 40, qualityGateMinScore: 70 }, "owner/repo", 7),
     ).resolves.toBeUndefined();
     vi.restoreAllMocks();
   });

--- a/test/unit/configured-gate-blocker-signals.test.ts
+++ b/test/unit/configured-gate-blocker-signals.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
+import { recordGateScoreSignals,
   RAW_CONTEXT_MAX_DIFF_CHARS,
   recordConfiguredGateBlockerSignals,
   type GateCheckPolicy,
@@ -241,5 +241,68 @@ describe("recordConfiguredGateBlockerSignals — raw context capture (#8130)", (
     );
     expect((await createSignalStore(env).queryRuleHistory("linked_issue_scope_mismatch", 0)).fired).toEqual([]);
     expect((await createSignalStore(env).queryRuleHistory("missing_linked_issue", 0)).fired).toHaveLength(1);
+  });
+});
+
+// ── #8223: score-gate fired signals — slop + quality capture ────────────────────────────────────────────────
+
+describe("recordGateScoreSignals (#8223)", () => {
+  it("fires slop_gate_score in block mode with the normalized score, threshold-crossing outcome, and rawSignal (never diff)", async () => {
+    const env = createTestEnv();
+    await recordGateScoreSignals(env, { slopGateMode: "block", slopRisk: 72, slopGateMinScore: 60 }, "owner/repo", 7);
+    const history = await createSignalStore(env).queryRuleHistory("slop_gate_score", 0);
+    expect(history.fired).toHaveLength(1);
+    expect(history.fired[0]).toMatchObject({
+      targetKey: "owner/repo#7",
+      outcome: "above_threshold",
+      metadata: { confidence: 0.72, rawSignal: "deterministic slop risk 72/100 vs threshold 60/100 (mode block)" },
+    });
+    expect(JSON.stringify(history.fired[0]!.metadata)).not.toContain("diff");
+  });
+
+  it("fires slop below-threshold with the default block threshold when no minScore is configured", async () => {
+    const env = createTestEnv();
+    await recordGateScoreSignals(env, { slopGateMode: "block", slopRisk: 30 }, "owner/repo", 7);
+    const history = await createSignalStore(env).queryRuleHistory("slop_gate_score", 0);
+    expect(history.fired[0]).toMatchObject({ outcome: "below_threshold", metadata: { confidence: 0.3 } });
+  });
+
+  it("records NOTHING for slop outside block mode or with a null risk — the gate never evaluated the score", async () => {
+    const env = createTestEnv();
+    await recordGateScoreSignals(env, { slopGateMode: "advisory", slopRisk: 72 }, "owner/repo", 7);
+    await recordGateScoreSignals(env, { slopGateMode: "block" }, "owner/repo", 7);
+    expect((await createSignalStore(env).queryRuleHistory("slop_gate_score", 0)).fired).toEqual([]);
+  });
+
+  it("fires quality_gate_score in advisory mode too — pass AND fail evaluations both leave corpus evidence", async () => {
+    const env = createTestEnv();
+    await recordGateScoreSignals(env, { qualityGateMode: "advisory", readinessScore: 80, qualityGateMinScore: 70 }, "owner/repo", 7);
+    await recordGateScoreSignals(env, { qualityGateMode: "advisory", readinessScore: 40, qualityGateMinScore: 70 }, "owner/repo", 8);
+    const history = await createSignalStore(env).queryRuleHistory("quality_gate_score", 0);
+    expect(history.fired).toHaveLength(2);
+    expect(history.fired.map((event) => event.outcome).sort()).toEqual(["at_or_above_threshold", "below_threshold"]);
+    expect(history.fired.map((event) => event.metadata?.confidence).sort()).toEqual([0.4, 0.8]);
+  });
+
+  it("records NOTHING for quality when the mode is off or a score/threshold is missing", async () => {
+    const env = createTestEnv();
+    await recordGateScoreSignals(env, { qualityGateMode: "off", readinessScore: 40, qualityGateMinScore: 70 }, "owner/repo", 7);
+    await recordGateScoreSignals(env, { qualityGateMode: "advisory", qualityGateMinScore: 70 }, "owner/repo", 7);
+    await recordGateScoreSignals(env, { qualityGateMode: "advisory", readinessScore: 40 }, "owner/repo", 7);
+    expect((await createSignalStore(env).queryRuleHistory("quality_gate_score", 0)).fired).toEqual([]);
+  });
+
+  it("degrades silently when the SignalStore write rejects — the call resolves normally", async () => {
+    vi.spyOn(signalTrackingWire, "createSignalStore").mockReturnValue({
+      recordRuleFired: async () => {
+        throw new Error("signal store down");
+      },
+      recordHumanOverride: async () => undefined,
+      queryRuleHistory: async () => ({ fired: [], overrides: [] }),
+    });
+    await expect(
+      recordGateScoreSignals(createTestEnv(), { slopGateMode: "block", slopRisk: 72 }, "owner/repo", 7),
+    ).resolves.toBeUndefined();
+    vi.restoreAllMocks();
   });
 });


### PR DESCRIPTION
## Summary

- Closes #8223
- `slopGateMinScore` and `qualityGateMinScore` gate real verdicts today but recorded no `signal.rule_fired` events, so no corpus could ever form for them and the knob registry could never govern their thresholds.
- Mirrors #8101/#8104's capture wiring exactly (the issue's required pattern): `recordGateScoreSignals(env, policy, repoFullName, prNumber)` fires one rule per knob (`slop_gate_score`, `quality_gate_score`) at the env-bearing gate path — wired immediately beside `recordConfiguredGateBlockerSignals`'s existing call — with the **same filter each pure evaluation applies**: slop evaluates only in `block` mode with a non-null risk (mirroring `buildSlopGateBlocker`'s own arm, including the default-60 threshold); quality evaluates whenever its mode is not `off` with both a score and a threshold present (mirroring `buildQualityGateWarning`'s arm), pass AND fail alike — a threshold backtest needs both outcomes. `targetKey = repo#pr`.
- Metadata carries the score normalized to [0, 1] (both scores are 0-100 integers per `normalizeScore`, divided by 100 to be confidence-equivalent for `buildConfidenceThresholdClassifier` replays — the normalization is documented beside the writer, per the issue) plus the detection's own detail string as `rawSignal` — never diff content, per #8130's raw-context audit posture for computed-score rules. Best-effort writes (`.catch(() => undefined)`) that can never affect the verdict.
- **Reversal labeling**: both ids join `CONFIGURED_GATE_BLOCKER_SIGNAL_CODES` via a new exported `GATE_SCORE_SIGNAL_CODES` constant, with the justification the issue requires recorded beside it: slop carries direct gate authority in `block` mode; quality is advisory-only but registry-governable, and a reversal labels the overall bot outcome its score contributed to — exactly the corpus label the drift/loosening evaluators consume. The fired side is unaffected (that list feeds only the reversal lookups).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [ ] `npm run actionlint`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran the writer's full suite (`vitest run test/unit/configured-gate-blocker-signals.test.ts` — 20 tests green, including the 6 new #8223 cases: both firing arms per knob with crossing and non-crossing outcomes plus the default slop threshold; every never-evaluated arm (off/advisory-slop modes, null score/threshold); the normalization bounds; the no-diff-content invariant; and the rejecting-SignalStore fail-open path) plus the full root `npm run typecheck`. `actionlint`/workers/mcp/ui checks are untouched surfaces; CI runs them all.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — backend capture wiring only (no UI, docs, or extension surface touched; no registry entries, no knob movement, per the issue's Boundaries).

## Notes

- The corpus becomes visible in the trend automatically once events flow — the rule-row surfaces key off recorded event types, no additional wiring needed (the issue's second deliverable).