### PR TITLE
feat(calibration): per-rule reliability curves with derived threshold suggestions

### DIFF
--- a/packages/loopover-engine/src/calibration/reliability-curve.ts
+++ b/packages/loopover-engine/src/calibration/reliability-curve.ts
@@ -1,0 +1,100 @@
+// Per-rule reliability curves (#8226, epic #8211 track E): claimed-confidence bucket → empirical precision
+// over decided cases, from which an optimal floor FALLS OUT of the labeled corpus instead of being guessed
+// from a hand-picked candidate ladder. Pure math beside the backtest primitives — no IO, no randomness, no
+// wall-clock reads — with the #8085 scorer's N/A-over-zero discipline everywhere: a bucket (or a pooled
+// candidate) with no decided cases reports null precision, never 0.
+
+import type { BacktestCase } from "./backtest-corpus.js";
+
+/** Default bucket edges: one collapsed sub-0.5 bucket (verdicts down there are rare and uninformative —
+ *  every live floor sits far above), then 0.1-wide steps through the mid-band and 0.05-wide steps across
+ *  the 0.8–1.0 band where the shipped floors (0.85/0.9/0.93/0.95) actually live — matching the granularity
+ *  of the knob ladders this curve is meant to replace. Each edge starts a bucket reaching to the next edge
+ *  (exclusive); the last bucket reaches 1 inclusive. */
+export const DEFAULT_RELIABILITY_BUCKET_EDGES: readonly number[] = [0, 0.5, 0.6, 0.7, 0.8, 0.85, 0.9, 0.95];
+
+export type ReliabilityBucket = {
+  /** Inclusive lower edge. */
+  from: number;
+  /** Exclusive upper edge — except the final bucket, which includes 1. */
+  to: number;
+  cases: number;
+  confirmed: number;
+  reversed: number;
+  /** confirmed / decided over this bucket, or null when the bucket decided nothing — never coerced to 0. */
+  precision: number | null;
+};
+
+/** The claimed confidence a case's firing carried, or null when it carried none (or a non-numeric /
+ *  out-of-range value) — such cases cannot be bucketed and are excluded from the curve, never guessed. */
+function claimedConfidence(backtestCase: BacktestCase): number | null {
+  const confidence = backtestCase.metadata?.confidence;
+  return typeof confidence === "number" && confidence >= 0 && confidence <= 1 ? confidence : null;
+}
+
+/**
+ * Compute the reliability curve for a labeled corpus: for each claimed-confidence bucket, how many decided
+ * cases landed there and how precise the rule empirically was ("confirmed" is the correct-firing class, so
+ * bucket precision = confirmed / (confirmed + reversed) — the same numerator discipline as
+ * `computeRulePrecision`). Cases without a usable claimed confidence are excluded. Deterministic: same
+ * corpus + edges ⇒ same curve, buckets in ascending edge order.
+ */
+export function computeReliabilityCurve(
+  cases: readonly BacktestCase[],
+  bucketEdges: readonly number[] = DEFAULT_RELIABILITY_BUCKET_EDGES,
+): ReliabilityBucket[] {
+  const buckets: ReliabilityBucket[] = bucketEdges.map((from, index) => ({
+    from,
+    to: index + 1 < bucketEdges.length ? bucketEdges[index + 1]! : 1,
+    cases: 0,
+    confirmed: 0,
+    reversed: 0,
+    precision: null,
+  }));
+  for (const backtestCase of cases) {
+    const confidence = claimedConfidence(backtestCase);
+    if (confidence === null) continue;
+    for (let index = buckets.length - 1; index >= 0; index -= 1) {
+      const bucket = buckets[index]!;
+      if (confidence >= bucket.from) {
+        bucket.cases += 1;
+        if (backtestCase.label === "confirmed") bucket.confirmed += 1;
+        else bucket.reversed += 1;
+        break;
+      }
+    }
+  }
+  for (const bucket of buckets) {
+    const decided = bucket.confirmed + bucket.reversed;
+    bucket.precision = decided > 0 ? bucket.confirmed / decided : null;
+  }
+  return buckets;
+}
+
+/**
+ * Derive the LOOSEST confidence floor whose at-or-above buckets' pooled precision meets `targetPrecision`
+ * (#8226) — candidates are the curve's own bucket edges, tried ascending so the first qualifying edge is the
+ * loosest; an edge below `hardMinimum` is never suggested, however good its evidence (the same
+ * no-evidence-crosses-the-floor rule as the knob evaluators). Null — deterministic and conservative, never a
+ * guess — when a candidate's pooled slice decided nothing (insufficient density) or no candidate's pooled
+ * precision reaches the target.
+ */
+export function deriveThresholdSuggestion(
+  curve: readonly ReliabilityBucket[],
+  targetPrecision: number,
+  hardMinimum: number,
+): number | null {
+  for (let index = 0; index < curve.length; index += 1) {
+    const floor = curve[index]!.from;
+    if (floor < hardMinimum) continue;
+    let confirmed = 0;
+    let decided = 0;
+    for (const bucket of curve.slice(index)) {
+      confirmed += bucket.confirmed;
+      decided += bucket.confirmed + bucket.reversed;
+    }
+    if (decided === 0) continue;
+    if (confirmed / decided >= targetPrecision) return floor;
+  }
+  return null;
+}

--- a/packages/loopover-engine/src/index.ts
+++ b/packages/loopover-engine/src/index.ts
@@ -175,6 +175,7 @@ export * from "./calibration/backtest-track-record.js";
 // same way scripts/backtest-corpus-export.ts already imports BacktestCase.
 export * from "./calibration/backtest-split.js";
 export * from "./calibration/backtest-threshold.js";
+export * from "./calibration/reliability-curve.js";
 export {
   GOVERNOR_LEDGER_EVENT_TYPES,
   normalizeGovernorLedgerEvent,

--- a/packages/loopover-engine/test/reliability-curve.test.ts
+++ b/packages/loopover-engine/test/reliability-curve.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  computeReliabilityCurve,
+  DEFAULT_RELIABILITY_BUCKET_EDGES,
+  deriveThresholdSuggestion,
+  type BacktestCase,
+} from "../dist/index.js";
+
+function labeled(confidence: number, label: BacktestCase["label"], key: string): BacktestCase {
+  return {
+    ruleId: "ai_consensus_defect",
+    targetKey: `acme/widgets${key}`,
+    outcome: "close",
+    label,
+    firedAt: "2026-07-01T00:00:00.000Z",
+    decidedAt: "2026-07-02T00:00:00.000Z",
+    metadata: { confidence },
+  };
+}
+
+test("barrel: the public entrypoint re-exports the reliability-curve primitives (#8226)", () => {
+  assert.equal(typeof computeReliabilityCurve, "function");
+  assert.equal(typeof deriveThresholdSuggestion, "function");
+  assert.ok(DEFAULT_RELIABILITY_BUCKET_EDGES.length > 0);
+});
+
+test("curve + suggestion round-trip: buckets carry empirical precision and the loosest qualifying floor falls out", () => {
+  const cases = [
+    ...Array.from({ length: 10 }, (_, i) => labeled(0.87, i < 6 ? "confirmed" : "reversed", `#a${i}`)),
+    ...Array.from({ length: 10 }, (_, i) => labeled(0.97, i < 10 ? "confirmed" : "reversed", `#b${i}`)),
+  ];
+  const curve = computeReliabilityCurve(cases);
+  const band = curve.find((bucket) => bucket.from === 0.85)!;
+  assert.equal(band.cases, 10);
+  assert.equal(band.precision, 0.6);
+  const top = curve[curve.length - 1]!;
+  assert.equal(top.precision, 1);
+  // Pooled from the (empty) 0.9 bucket up is 10/10 = 1 — the loosest floor meeting a 0.99 target; pooled
+  // from 0.85 ((6+10)/20 = 0.8) meets 0.75.
+  assert.equal(deriveThresholdSuggestion(curve, 0.99, 0), 0.9);
+  assert.equal(deriveThresholdSuggestion(curve, 0.75, 0), 0);
+  assert.equal(deriveThresholdSuggestion(curve, 0.75, 0.6), 0.6);
+});
+
+test("null discipline: empty buckets and unmet targets report null, never 0", () => {
+  const curve = computeReliabilityCurve([]);
+  for (const bucket of curve) assert.equal(bucket.precision, null);
+  assert.equal(deriveThresholdSuggestion(curve, 0.5, 0), null);
+});

--- a/test/unit/reliability-curve-engine.test.ts
+++ b/test/unit/reliability-curve-engine.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+
+// Import the engine SOURCE directly (not the built dist) -- coverage.include lists
+// packages/loopover-engine/src/**, so only a source-path import exercises the .ts these branches live in
+// (the dist-importing twin in packages/loopover-engine/test/ covers the built barrel for the workspace
+// suite). Same pattern as backtest-corpus-engine.test.ts / repo-corpus-engine.test.ts.
+import {
+  computeReliabilityCurve,
+  DEFAULT_RELIABILITY_BUCKET_EDGES,
+  deriveThresholdSuggestion,
+} from "../../packages/loopover-engine/src/calibration/reliability-curve";
+import type { BacktestCase } from "../../packages/loopover-engine/src/calibration/backtest-corpus";
+
+function labeled(confidence: number | undefined, label: BacktestCase["label"], key = `t#${Math.trunc((confidence ?? 0) * 1000)}`): BacktestCase {
+  return {
+    ruleId: "ai_consensus_defect",
+    targetKey: `acme/widgets${key}`,
+    outcome: "close",
+    label,
+    firedAt: "2026-07-01T00:00:00.000Z",
+    decidedAt: "2026-07-02T00:00:00.000Z",
+    ...(confidence !== undefined ? { metadata: { confidence } } : {}),
+  };
+}
+
+describe("computeReliabilityCurve (#8226)", () => {
+  it("buckets decided cases by claimed confidence on the documented default edges, with per-bucket empirical precision", () => {
+    const curve = computeReliabilityCurve([
+      labeled(0.97, "confirmed", "#1"),
+      labeled(0.97, "confirmed", "#2"),
+      labeled(0.96, "reversed", "#3"),
+      labeled(0.87, "reversed", "#4"),
+      labeled(0.3, "confirmed", "#5"),
+    ]);
+    expect(curve.map((bucket) => [bucket.from, bucket.to])).toEqual([
+      [0, 0.5],
+      [0.5, 0.6],
+      [0.6, 0.7],
+      [0.7, 0.8],
+      [0.8, 0.85],
+      [0.85, 0.9],
+      [0.9, 0.95],
+      [0.95, 1],
+    ]);
+    const top = curve[curve.length - 1]!;
+    expect(top).toMatchObject({ cases: 3, confirmed: 2, reversed: 1, precision: 2 / 3 });
+    expect(curve.find((bucket) => bucket.from === 0.85)).toMatchObject({ cases: 1, confirmed: 0, reversed: 1, precision: 0 });
+    expect(curve[0]).toMatchObject({ cases: 1, confirmed: 1, precision: 1 });
+  });
+
+  it("reports null (never 0) precision for an empty bucket, and lands confidence 1.0 in the final inclusive bucket", () => {
+    const curve = computeReliabilityCurve([labeled(1, "confirmed", "#1")]);
+    expect(curve[curve.length - 1]).toMatchObject({ cases: 1, precision: 1 });
+    for (const bucket of curve.slice(0, -1)) {
+      expect(bucket.cases).toBe(0);
+      expect(bucket.precision).toBeNull();
+    }
+  });
+
+  it("excludes cases with a missing, non-numeric, or out-of-range claimed confidence — never guessed into a bucket", () => {
+    const curve = computeReliabilityCurve([
+      labeled(undefined, "confirmed", "#1"),
+      { ...labeled(0.9, "confirmed", "#2"), metadata: { confidence: "high" } },
+      labeled(1.5, "confirmed", "#3"),
+      labeled(-0.1, "confirmed", "#4"),
+      labeled(0.92, "reversed", "#5"),
+    ]);
+    expect(curve.reduce((sum, bucket) => sum + bucket.cases, 0)).toBe(1);
+    expect(curve.find((bucket) => bucket.from === 0.9)).toMatchObject({ cases: 1, reversed: 1 });
+  });
+
+  it("honors caller-supplied bucket edges and is deterministic for identical input", () => {
+    const cases = [labeled(0.25, "confirmed", "#1"), labeled(0.75, "reversed", "#2")];
+    const curve = computeReliabilityCurve(cases, [0, 0.5]);
+    expect(curve.map((bucket) => [bucket.from, bucket.to, bucket.cases])).toEqual([
+      [0, 0.5, 1],
+      [0.5, 1, 1],
+    ]);
+    expect(computeReliabilityCurve(cases, [0, 0.5])).toEqual(curve);
+  });
+});
+
+describe("deriveThresholdSuggestion (#8226)", () => {
+  // A monotone corpus: the higher the claimed confidence, the more precise the rule empirically was.
+  const monotone = [
+    ...Array.from({ length: 10 }, (_, i) => labeled(0.55, i < 4 ? "confirmed" : "reversed", `#a${i}`)), // 0.4
+    ...Array.from({ length: 10 }, (_, i) => labeled(0.82, i < 7 ? "confirmed" : "reversed", `#b${i}`)), // 0.7
+    ...Array.from({ length: 10 }, (_, i) => labeled(0.92, i < 9 ? "confirmed" : "reversed", `#c${i}`)), // 0.9
+    ...Array.from({ length: 10 }, (_, i) => labeled(0.97, i < 10 ? "confirmed" : "reversed", `#d${i}`)), // 1.0
+  ];
+  const curve = computeReliabilityCurve(monotone);
+
+  it("suggests the LOOSEST floor whose pooled at-or-above precision meets the target", () => {
+    // Pooled from 0.6 up already excludes the noisy 0.55 bucket: (7+9+10)/30 ≈ 0.867 meets a 0.85 target,
+    // and the empty 0.6–0.8 buckets make 0.6 the LOOSEST equivalent floor — not 0.8.
+    expect(deriveThresholdSuggestion(curve, 0.85, 0)).toBe(0.6);
+    // A stricter 0.95 target: pooling from the (empty) 0.85 bucket up gives (9+10)/20 = 0.95 exactly, so
+    // 0.85 is the loosest qualifying edge — the empty band widens the suggestion, it never blocks it.
+    expect(deriveThresholdSuggestion(curve, 0.95, 0)).toBe(0.85);
+  });
+
+  it("never suggests below the hard minimum even when a looser floor would meet the target", () => {
+    expect(deriveThresholdSuggestion(curve, 0.85, 0.85)).toBe(0.85);
+  });
+
+  it("monotonicity invariant: a stricter target never yields a looser suggestion", () => {
+    const targets = [0.5, 0.7, 0.85, 0.95, 1];
+    const suggestions = targets.map((target) => deriveThresholdSuggestion(curve, target, 0));
+    for (let i = 1; i < suggestions.length; i += 1) {
+      const previous = suggestions[i - 1];
+      const current = suggestions[i];
+      if (typeof previous === "number" && typeof current === "number") expect(current).toBeGreaterThanOrEqual(previous);
+    }
+  });
+
+  it("returns null when no candidate meets the target, and for an undecided (insufficient-density) curve", () => {
+    expect(deriveThresholdSuggestion(curve, 1.01, 0)).toBeNull(); // nothing can pool above 1
+    expect(deriveThresholdSuggestion(computeReliabilityCurve([]), 0.5, 0)).toBeNull(); // no decided cases anywhere
+  });
+
+  it("skips an insufficient-density candidate (empty pooled slice) instead of treating it as qualifying", () => {
+    // Only sub-0.5 evidence exists: every candidate at/above 0.5 pools zero decided cases and is skipped.
+    const lowOnly = computeReliabilityCurve([labeled(0.2, "confirmed", "#1")]);
+    expect(deriveThresholdSuggestion(lowOnly, 0.5, 0.5)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Add `packages/loopover-engine/src/calibration/reliability-curve.ts` (#8211 track E) with two pure functions beside the backtest primitives:
  - `computeReliabilityCurve(cases, bucketEdges?)` — per claimed-confidence bucket `{from, to, cases, confirmed, reversed, precision|null}` over decided cases; the documented `DEFAULT_RELIABILITY_BUCKET_EDGES` collapse the rare sub-0.5 band and step 0.05-wide across 0.8–1.0, matching where the shipped floors (0.85/0.9/0.93/0.95) actually live; the final bucket includes confidence 1.0; cases without a usable numeric claimed confidence are excluded, never guessed.
  - `deriveThresholdSuggestion(curve, targetPrecision, hardMinimum)` — the LOOSEST bucket-edge floor whose pooled at-or-above precision meets the target, never below the hard minimum; null (deterministic, conservative) when a candidate's pooled slice decided nothing or no candidate reaches the target.
- N/A-over-zero discipline throughout (#8085's rule): an undecided bucket or pooled slice reports `null`, never `0`.
- Both functions + the edges constant exported from the engine barrel; no consumer changes, per the issue's Boundaries.

Closes #8226

## Test plan
- [x] `test/unit/reliability-curve-engine.test.ts` (vitest, importing the engine **source** — the root mirror suite): default-edge bucket boundaries incl. the inclusive 1.0 top bucket; per-bucket empirical precision; null-precision empty buckets; exclusion of missing/non-numeric/out-of-range confidences; caller-supplied edges + determinism; loosest-qualifying-floor selection (incl. the empty-band-widens-the-floor cases); hard-minimum clamp; the monotonicity invariant (stricter target never yields a looser floor); no-qualifier and insufficient-density nulls
- [x] `packages/loopover-engine/test/reliability-curve.test.ts` (node:test vs dist): barrel re-export + curve/suggestion round-trip + null discipline
- [x] Local coverage on the new file: 29/29 lines, 22/22 branches; engine workspace suite 663 green; `npm run typecheck` clean
- [ ] CI validate