### PR TITLE
feat(calibration): phase-2 hardening from the production applies — plan-file replay, class policy, rate + statement limits

### DIFF
--- a/scripts/backfill-calibration-corpus-phase2.ts
+++ b/scripts/backfill-calibration-corpus-phase2.ts
@@ -440,7 +440,13 @@ async function runRawContextPass(args: Args, budget: RequestBudget, state: Curso
       state.rawContextResumeFrom = row.target_key;
       continue;
     }
-    const patched = patchFiredMetadataWithDiff(row.metadata_json, await diffResponse.text());
+    const diffText = await diffResponse.text();
+    // The D1 CLI driver inlines the UPDATE as literal SQL (wrangler --command cannot bind parameters), and
+    // quote-doubling can double the payload: a full 120KB diff exceeds D1's per-statement length
+    // (SQLITE_TOOBIG, hit live at row 37 of the first cloud apply). Cap the literal path with a
+    // self-describing marker; the pg driver binds parameters and keeps the full bound diff.
+    const bounded = pgSession || diffText.length <= 45_000 ? diffText : `${diffText.slice(0, 45_000)}\n[diff truncated: D1 CLI statement-length limit]`;
+    const patched = patchFiredMetadataWithDiff(row.metadata_json, bounded);
     if (patched === null) {
       report.alreadyPatched += 1;
     } else if (args.apply) {


### PR DESCRIPTION
## What

One production-earned fix (the rest of the phase-2 hardening turned out to already be on main — this PR is now the minimal remaining delta): the first cloud raw-context apply failed at row 37 with `SQLITE_TOOBIG`.

## Why

`wrangler d1 execute --command` cannot bind parameters, so the wrapper inlines each UPDATE as literal SQL — and quote-doubling can double a 120KB diff past D1's per-statement length limit.

## How

The literal (D1 CLI) path caps the diff at 45KB with a self-describing truncation marker appended inside the diff text itself, so any consumer of the fixture sees the truncation inline. The pg driver binds parameters and keeps full diffs — the production Postgres corpus is unaffected (460/460 full diffs verified there; the cloud resume completed 460/460 with this fix, results on #8170).

Advances #8170