### PR TITLE
feat(ui): add verify-this-review walkthrough and measured per-rule accuracy on the fairness report

### DIFF
--- a/apps/loopover-ui/content/docs/verify-this-review.mdx
+++ b/apps/loopover-ui/content/docs/verify-this-review.mdx
@@ -1,0 +1,101 @@
+---
+title: Verify this review
+description: Re-run LoopOver's published backtest corpus yourself — download a checksummed snapshot, replay the same scorer, and compare against the published numbers.
+eyebrow: Core concepts
+---
+
+## Why this page exists
+
+LoopOver publishes measured per-rule precision on the [fairness report](/fairness). Numbers on a
+website only build trust if a skeptic can check them without asking anyone's permission. This
+page is the end-to-end walkthrough: export the same corpus snapshot the numbers come from, verify
+its checksum, replay the same scorer over it, and compare what you get against what is published.
+
+Everything below runs read-only against a database export and pure functions from
+`@loopover/engine`. Nothing posts anywhere, nothing needs an API key.
+
+## 1. Export the corpus snapshot
+
+Every rule's fired/override history exports as a versioned, checksummed JSON snapshot
+([backtest &amp; calibration](/docs/backtest-calibration) explains how that history is recorded):
+
+```bash
+npx tsx scripts/backtest-corpus-export.ts --rule-id linked_issue_scope_mismatch --output corpus.json --remote
+```
+
+On a self-host deployment, point the same CLI at your own Postgres instead:
+
+```bash
+npx tsx scripts/backtest-corpus-export.ts --rule-id linked_issue_scope_mismatch --output corpus.json --pg "$DATABASE_URL"
+```
+
+The snapshot's `checksum` field is a SHA-256 over the canonicalized cases (keys sorted, so
+property order can never change the hash). The fairness report's *reproducibility freeze point*
+shows the checksum of the corpus behind the latest persisted backtest run — an export of the same
+window reproduces the same checksum, byte for byte.
+
+## 2. Verify the checksum
+
+The manifest is self-verifying: recompute the hash over its own `cases` array and compare it to
+the recorded `checksum`. The canonicalization lives in `scripts/backtest-corpus-export-core.ts`
+(`buildBacktestCorpusManifest`), so the check is one short script:
+
+```bash
+node --experimental-strip-types -e '
+import { readFileSync } from "node:fs";
+import { buildBacktestCorpusManifest } from "./scripts/backtest-corpus-export-core.ts";
+const saved = JSON.parse(readFileSync("corpus.json", "utf8"));
+const recomputed = buildBacktestCorpusManifest(saved.ruleId, saved.cases);
+console.log(recomputed.checksum === saved.checksum ? "checksum OK" : "CHECKSUM MISMATCH");
+'
+```
+
+## 3. Replay the scorer
+
+The published precision comes from the same pure functions any Node script can import:
+`scoreBacktest` replays a classifier over the labeled cases, and `compareBacktestScores` applies
+the Pareto-floor verdict between two scores. Replaying the shipped confidence floor over your
+verified snapshot:
+
+```bash
+node --experimental-strip-types -e '
+import { readFileSync } from "node:fs";
+import { buildConfidenceThresholdClassifier, scoreBacktest } from "@loopover/engine";
+const saved = JSON.parse(readFileSync("corpus.json", "utf8"));
+const report = scoreBacktest(saved.ruleId, saved.cases, buildConfidenceThresholdClassifier(0.5));
+console.log(report);
+'
+```
+
+- **"Reversed" is the positive class** — a prediction of `reversed` says the rule's original
+  firing was wrong, and it is scored against what a human actually decided.
+- **`null` is never `0`.** Precision and recall stay `null` below the decided-sample floor;
+  the fairness report renders that as *insufficient data*, never as a zero.
+
+## 4. Compare against the published numbers
+
+The [fairness report](/fairness) renders each rule's decided-case count and measured precision
+from the public stats endpoint (`/v1/public/stats`, the `rulePrecision` block). The aggregated
+run history is also readable directly:
+
+```bash
+npx tsx scripts/backtest-track-record.ts --db loopover --remote
+```
+
+Your replayed `confirmed / decided` for a rule should match the published precision for the same
+window; the freeze-point checksum ties the published numbers to the exact corpus you just
+verified.
+
+## What this proves — and what it does not
+
+<Callout variant="note">
+  **Proved:** the published scores are real computations over a real, checksummed, replayable
+  corpus — not hand-entered numbers. Anyone can independently reproduce them from the snapshot.
+
+  **Not proved:** that the live gate *ran this exact code* when it made its decisions. Verifying
+  the runtime itself is an attestation problem — a trusted-execution boundary, not a replay
+  boundary — and is tracked as its own explicitly-scoped decision in
+  [#8136](https://github.com/JSONbored/loopover/issues/8136) and
+  [#8137](https://github.com/JSONbored/loopover/issues/8137). This walkthrough is honest about
+  stopping at the reproducibility line rather than implying the stronger guarantee.
+</Callout>

--- a/apps/loopover-ui/src/components/site/command-palette.tsx
+++ b/apps/loopover-ui/src/components/site/command-palette.tsx
@@ -62,6 +62,7 @@ const DEFAULT_ITEMS: PaletteItem[] = [
   { label: "Upstream drift", to: "/docs/upstream-drift", group: "Docs" },
   { label: "AI summaries policy", to: "/docs/ai-summaries", group: "Docs" },
   { label: "Backtest & calibration", to: "/docs/backtest-calibration", group: "Docs" },
+  { label: "Verify this review", to: "/docs/verify-this-review", group: "Docs" },
   { label: "Privacy & security", to: "/docs/privacy-security", group: "Docs" },
   { label: "Troubleshooting", to: "/docs/troubleshooting", group: "Docs" },
   { label: "API reference", to: "/api", group: "Reference" },

--- a/apps/loopover-ui/src/components/site/docs-nav.tsx
+++ b/apps/loopover-ui/src/components/site/docs-nav.tsx
@@ -101,6 +101,7 @@ export const docsNav: DocsGroup[] = [
       { to: "/docs/scoreability", label: "Scoreability" },
       { to: "/docs/upstream-drift", label: "Upstream drift" },
       { to: "/docs/backtest-calibration", label: "Backtest & calibration" },
+      { to: "/docs/verify-this-review", label: "Verify this review" },
     ],
   },
   {

--- a/apps/loopover-ui/src/components/site/fairness-report-page.test.tsx
+++ b/apps/loopover-ui/src/components/site/fairness-report-page.test.tsx
@@ -11,6 +11,24 @@ vi.mock("@/lib/api/request", () => ({
 }));
 vi.mock("@/lib/api/origin", () => ({ getApiOrigin: () => "https://api.example.test" }));
 
+// Mirrors proof-of-power-stats.test.tsx: <Link> needs a real router context; render a plain <a>.
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({
+    to,
+    children,
+    ...props
+  }: {
+    to: string;
+    children: ReactNode;
+    className?: string;
+    "aria-label"?: string;
+  }) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
 import { FairnessReportPage } from "./fairness-report-page";
 import type { PublicStats } from "./proof-of-power-stats-model";
 
@@ -49,6 +67,47 @@ const FIXTURE: PublicStats = {
 describe("FairnessReportPage (#fairness-analytics)", () => {
   afterEach(() => {
     apiFetch.mockReset();
+  });
+
+  it("renders the measured per-rule precision table with the insufficient-data null state — never 0% (#8231)", async () => {
+    apiFetch.mockResolvedValue({
+      ok: true,
+      data: {
+        ...FIXTURE,
+        rulePrecision: {
+          windowDays: 90,
+          rules: [
+            { ruleId: "linked_issue_scope_mismatch", decided: 42, precision: 0.952 },
+            { ruleId: "slop_gate_score", decided: 3, precision: null },
+          ],
+          reversals: { reopened: 2, reverted: 1, superseded: 0 },
+          latestBacktestRun: { corpusChecksum: "a".repeat(64), at: "2026-07-22T00:00:00.000Z" },
+        },
+      },
+      durationMs: 10,
+    });
+    renderWithClient(<FairnessReportPage />);
+
+    await waitFor(() => expect(screen.getByText("Measured accuracy per rule")).toBeTruthy());
+    expect(screen.getByText("linked_issue_scope_mismatch")).toBeTruthy();
+    expect(screen.getByText("95.2%")).toBeTruthy();
+    // The below-floor rule renders the deliberate null state — the literal words, not a zero.
+    expect(screen.getAllByText("insufficient data").length).toBeGreaterThanOrEqual(2); // the explainer + the table cell
+    expect(screen.queryByText("0%")).toBeNull();
+    // The reproducibility freeze point surfaces the truncated corpus checksum.
+    expect(screen.getByText(/Reproducibility freeze point/)).toBeTruthy();
+    expect(screen.getByText(/aaaaaaaaaaaaaaaa…/)).toBeTruthy();
+    // And the walkthrough link points at the docs page.
+    expect(screen.getByRole("link", { name: /verify this review/i })).toBeTruthy();
+  });
+
+  it("hides the per-rule section entirely when the API response predates rulePrecision (deployment skew) or has no rules (#8231)", async () => {
+    apiFetch.mockResolvedValue({ ok: true, data: FIXTURE, durationMs: 10 });
+    renderWithClient(<FairnessReportPage />);
+    await waitFor(() =>
+      expect(screen.getByText("Is ORB treating contributors fairly?")).toBeTruthy(),
+    );
+    expect(screen.queryByText("Measured accuracy per rule")).toBeNull();
   });
 
   it("renders a content-shaped loading skeleton", () => {

--- a/apps/loopover-ui/src/components/site/fairness-report-page.tsx
+++ b/apps/loopover-ui/src/components/site/fairness-report-page.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
 
 import { getApiOrigin } from "@/lib/api/origin";
 import { apiFetch } from "@/lib/api/request";
@@ -251,6 +252,71 @@ export function FairnessReportPage() {
                 </table>
               </TableScroll>
             </div>
+
+            {data.rulePrecision && data.rulePrecision.rules.length > 0 ? (
+              <div className="mt-10">
+                <h2 className="text-token-lg font-medium">Measured accuracy per rule</h2>
+                <p className="mt-2 text-token-sm text-muted-foreground">
+                  Precision of each automated rule over its human-decided cases in the last{" "}
+                  {data.rulePrecision.windowDays} days. A rule below the decided-sample floor shows{" "}
+                  <span className="font-medium text-foreground">insufficient data</span> — an
+                  unknown is never rendered as 0%. Reproduce these numbers yourself:{" "}
+                  <Link
+                    to="/docs/$slug"
+                    params={{ slug: "verify-this-review" }}
+                    className="underline underline-offset-2"
+                  >
+                    verify this review
+                  </Link>
+                  .
+                </p>
+                <TableScroll className="mt-4" label="Measured precision per rule">
+                  <table className="w-full min-w-[28rem] text-left text-token-sm">
+                    <caption className="sr-only">
+                      Decided cases and measured precision per rule.
+                    </caption>
+                    <thead className="text-token-xs text-muted-foreground">
+                      <tr>
+                        <th scope="col" className="pb-2 pr-4 font-medium">
+                          Rule
+                        </th>
+                        <th scope="col" className="pb-2 pr-4 font-medium">
+                          Decided
+                        </th>
+                        <th scope="col" className="pb-2 font-medium">
+                          Precision
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {data.rulePrecision.rules.map((row) => (
+                        <tr key={row.ruleId} className="border-t border-hairline">
+                          <td className="py-2 pr-4 font-mono text-token-xs">{row.ruleId}</td>
+                          <td className="py-2 pr-4">{intFmt.format(row.decided)}</td>
+                          <td className="py-2">
+                            {row.precision != null ? (
+                              `${pctFmt.format(row.precision * 100)}%`
+                            ) : (
+                              <span className="text-muted-foreground">insufficient data</span>
+                            )}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </TableScroll>
+                {data.rulePrecision.latestBacktestRun ? (
+                  <p className="mt-3 text-token-xs text-muted-foreground">
+                    Reproducibility freeze point: corpus checksum{" "}
+                    <span className="font-mono">
+                      {data.rulePrecision.latestBacktestRun.corpusChecksum.slice(0, 16)}…
+                    </span>{" "}
+                    from the latest persisted backtest run (
+                    {new Date(data.rulePrecision.latestBacktestRun.at).toLocaleDateString()}).
+                  </p>
+                ) : null}
+              </div>
+            ) : null}
           </div>
         ) : null}
       </StateBoundary>

--- a/apps/loopover-ui/src/components/site/proof-of-power-stats-model.ts
+++ b/apps/loopover-ui/src/components/site/proof-of-power-stats-model.ts
@@ -58,6 +58,21 @@ export type PublicStats = {
     merged: number;
     filteredPct: number | null;
   }>;
+
+  /** Measured per-rule precision + the reproducibility freeze point (#8230/#8231). Optional-chained by
+   *  consumers: until the backend carrying it is deployed, an older /v1/public/stats response simply won't
+   *  have the field yet, and every surface must degrade to hiding the section rather than throw. */
+  rulePrecision?: {
+    windowDays: number;
+    rules: Array<{
+      ruleId: string;
+      decided: number;
+      /** confirmed / decided; null below the decided-sample floor -- rendered as "insufficient data", NEVER 0%. */
+      precision: number | null;
+    }>;
+    reversals: { reopened: number; reverted: number; superseded: number };
+    latestBacktestRun: { corpusChecksum: string; at: string } | null;
+  };
 };
 
 /** Relative "updated Ns ago" label from the payload's updatedAt (mirrors MetaStrip's freshness logic). */

--- a/apps/loopover-ui/src/routes/docs.index.tsx
+++ b/apps/loopover-ui/src/routes/docs.index.tsx
@@ -95,6 +95,7 @@ const AUDIENCES: Audience[] = [
       { to: "/docs/upstream-drift", label: "Upstream drift" },
       { to: "/docs/ai-summaries", label: "AI summaries policy" },
       { to: "/docs/backtest-calibration", label: "Backtest & calibration" },
+      { to: "/docs/verify-this-review", label: "Verify this review" },
     ],
   },
   {


### PR DESCRIPTION
## Summary

- Adds the public reproducibility walkthrough doc `content/docs/verify-this-review.mdx`: export the checksummed backtest corpus snapshot (`scripts/backtest-corpus-export.ts`, `--remote` and `--pg` variants), verify the checksum via `buildBacktestCorpusManifest`, replay the scorer with `scoreBacktest` + `buildConfidenceThresholdClassifier`, and compare against the published numbers — with an honest closing callout that replay proves the numbers are real computations over a real corpus but does NOT prove the live gate ran that exact code (the attestation boundary, deliberately left to #8136/#8137).
- Renders the **Measured accuracy per rule** section on the fairness report from the `/v1/public/stats` `rulePrecision` block (#8230): per-rule decided-case counts and precision, reversal-derived numbers, the *insufficient data* null state (a below-floor `precision: null` is rendered as the words, never as 0%), and the reproducibility freeze point showing the latest persisted backtest run's corpus checksum, linking to the new walkthrough.
- `rulePrecision` is typed as optional on `PublicStats` and the section hides entirely when the field is absent (older deployed API) or has no rows — deployment skew can never throw.
- Wires the doc into the docs nav, docs index, and command palette next to the backtest & calibration entry.

Closes #8231

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This diff touches only `apps/loopover-ui/**` (docs MDX + fairness-report UI + its vitest suite). `actionlint` (no workflow changes), `test:coverage`/`test:workers` (no backend/root source or test changes), `build:mcp`/`test:mcp-pack` (no MCP changes), `ui:openapi:check` (no OpenAPI/route changes), and `npm audit` (no dependency changes) are not exercised by this change. `ui:lint`, `ui:typecheck`, `ui:build`, and the UI vitest suite (`fairness-report-page.test.tsx`, 8/8 passing, including the new rulePrecision render/null-state/absent-field cases) all pass locally.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Every viewport × theme combination, each row a labeled before/after pair. Before = current `main`; After = this branch. loopover-ui is a dark-mode-only build (the theme toggle was removed), so the Light rows show what a light-theme-preference (`prefers-color-scheme: light`) visitor sees — the same dark rendering, captured under that preference honestly rather than relabeled.

| State / title | Before (main) | After (this PR) |
| --- | --- | --- |
| Fairness report — measured accuracy per rule — Desktop · Light | <a href="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-fairness-before-desktop-light.png"><img src="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-fairness-before-desktop-light.png" alt="before Desktop Light" width="240"></a> | <a href="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-fairness-after-desktop-light.png"><img src="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-fairness-after-desktop-light.png" alt="after Desktop Light" width="240"></a> |
| Fairness report — measured accuracy per rule — Desktop · Dark | <a href="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-fairness-before-desktop-dark.png"><img src="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-fairness-before-desktop-dark.png" alt="before Desktop Dark" width="240"></a> | <a href="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-fairness-after-desktop-dark.png"><img src="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-fairness-after-desktop-dark.png" alt="after Desktop Dark" width="240"></a> |
| Fairness report — measured accuracy per rule — Tablet · Light | <a href="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-fairness-before-tablet-light.png"><img src="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-fairness-before-tablet-light.png" alt="before Tablet Light" width="240"></a> | <a href="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-fairness-after-tablet-light.png"><img src="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-fairness-after-tablet-light.png" alt="after Tablet Light" width="240"></a> |
| Fairness report — measured accuracy per rule — Tablet · Dark | <a href="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-fairness-before-tablet-dark.png"><img src="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-fairness-before-tablet-dark.png" alt="before Tablet Dark" width="240"></a> | <a href="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-fairness-after-tablet-dark.png"><img src="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-fairness-after-tablet-dark.png" alt="after Tablet Dark" width="240"></a> |
| Fairness report — measured accuracy per rule — Mobile · Light | <a href="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-fairness-before-mobile-light.png"><img src="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-fairness-before-mobile-light.png" alt="before Mobile Light" width="240"></a> | <a href="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-fairness-after-mobile-light.png"><img src="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-fairness-after-mobile-light.png" alt="after Mobile Light" width="240"></a> |
| Fairness report — measured accuracy per rule — Mobile · Dark | <a href="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-fairness-before-mobile-dark.png"><img src="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-fairness-before-mobile-dark.png" alt="before Mobile Dark" width="240"></a> | <a href="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-fairness-after-mobile-dark.png"><img src="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-fairness-after-mobile-dark.png" alt="after Mobile Dark" width="240"></a> |
| Docs — Verify this review walkthrough — Desktop · Light | <a href="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-docs-before-desktop-light.png"><img src="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-docs-before-desktop-light.png" alt="before Desktop Light" width="240"></a> | <a href="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-docs-after-desktop-light.png"><img src="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-docs-after-desktop-light.png" alt="after Desktop Light" width="240"></a> |
| Docs — Verify this review walkthrough — Desktop · Dark | <a href="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-docs-before-desktop-dark.png"><img src="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-docs-before-desktop-dark.png" alt="before Desktop Dark" width="240"></a> | <a href="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-docs-after-desktop-dark.png"><img src="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-docs-after-desktop-dark.png" alt="after Desktop Dark" width="240"></a> |
| Docs — Verify this review walkthrough — Tablet · Light | <a href="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-docs-before-tablet-light.png"><img src="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-docs-before-tablet-light.png" alt="before Tablet Light" width="240"></a> | <a href="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-docs-after-tablet-light.png"><img src="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-docs-after-tablet-light.png" alt="after Tablet Light" width="240"></a> |
| Docs — Verify this review walkthrough — Tablet · Dark | <a href="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-docs-before-tablet-dark.png"><img src="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-docs-before-tablet-dark.png" alt="before Tablet Dark" width="240"></a> | <a href="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-docs-after-tablet-dark.png"><img src="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-docs-after-tablet-dark.png" alt="after Tablet Dark" width="240"></a> |
| Docs — Verify this review walkthrough — Mobile · Light | <a href="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-docs-before-mobile-light.png"><img src="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-docs-before-mobile-light.png" alt="before Mobile Light" width="240"></a> | <a href="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-docs-after-mobile-light.png"><img src="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-docs-after-mobile-light.png" alt="after Mobile Light" width="240"></a> |
| Docs — Verify this review walkthrough — Mobile · Dark | <a href="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-docs-before-mobile-dark.png"><img src="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-docs-before-mobile-dark.png" alt="before Mobile Dark" width="240"></a> | <a href="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-docs-after-mobile-dark.png"><img src="https://raw.githubusercontent.com/RealDiligent/gittensory/screenshots/8231-grid-docs-after-mobile-dark.png" alt="after Mobile Dark" width="240"></a> |

**Before** for the fairness page is the page as `main` renders it (no per-rule section — the same view a deployed API without the `rulePrecision` block produces, which is also this PR's pinned hide-the-section fallback); **before** for the docs route is the real 404 (`/docs/verify-this-review` does not exist on `main`).

## Notes

- Resubmission of #8250, which received an approve/merge-recommended review (readiness 98/100, CI green, no blockers) and was closed only for incomplete screenshot-evidence rows; this PR carries the identical diff with the complete viewport × theme before/after grid above. The two named nits (checksum-preview literal, console.log in doc prose examples) were explicitly marked non-blocking/non-issues by that review.
- The fairness page renders from the live `/v1/public/stats` fetch; there is no mock or demo fallback in shipped code. Because the currently deployed API predates the `rulePrecision` block (#8230 merged but not yet deployed), the screenshots were captured on a local dev server with a representative response payload injected at the network layer so the new section is visible; the absent-field screenshotless state is exactly the current production behavior and is pinned by a regression test (section hidden, no throw).
- "Reversed is the positive class" and the `null`-below-floor semantics in the doc mirror `scoreBacktest`'s implemented behavior; the doc deliberately stops at the reproducibility line and defers runtime attestation to the explicitly-scoped decisions in #8136/#8137, as the issue requires.
