### PR TITLE
chore(orb): target 3.4.0 for the next beta channel

### DIFF
--- a/orb-manifest.json
+++ b/orb-manifest.json
@@ -1,4 +1,4 @@
 {
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Source of truth for the self-hostable loopover-orb container image's target release version (ghcr.io/jsonbored/loopover-selfhost). Bumped by a maintainer when a feat/fix/breaking change since the last stable orb-v tag warrants moving to a new target version -- scripts/orb-release-core.ts and .github/workflows/orb-beta-release.yml read this file to decide what version the next automated beta snapshot targets. Promoting a beta to a stable orb-vX.Y.Z release is still a manual `git tag` -- this manifest only drives the automated beta channel."
 }


### PR DESCRIPTION
## Summary

One-line manifest bump. `orb-v3.3.0` shipped stable, so `orb-beta-release.yml`'s cutter reports `due: false` (it refuses to cut a beta for an already-released target) until the maintainer moves `orb-manifest.json` forward. The epic's merged feats (#8264, #8265, #8267, #8270, #8271) infer a minor bump, so the next automated snapshot targets **orb-v3.4.0-beta.1** — verified locally: the due-check flips to `due: true, nextTag: orb-v3.4.0-beta.1, manifestStale: false` with this change.

## Validation

JSON-only change; `scripts/check-orb-release-due.ts` run against the bumped manifest confirms the cutter's next decision. No code paths touched.