### PR TITLE
feat(calibration): register the slop gate score as the registry's first ceiling knob, report-only

### DIFF
--- a/packages/loopover-engine/src/advisory/gate-advisory.ts
+++ b/packages/loopover-engine/src/advisory/gate-advisory.ts
@@ -38,7 +38,9 @@ function sanitizeForCheckRun(text: string): string {
 }
 
 const DEFAULT_AI_REVIEW_CLOSE_CONFIDENCE = 0.93;
-const DEFAULT_SLOP_BLOCK_THRESHOLD = 60;
+/** Exported to mirror the src twin (#8224): loopover's LOOSENABLE_KNOBS registry anchors the slop knob's
+ *  shipped value on this constant (divided by 100 onto the corpus's confidence scale). Value unchanged. */
+export const DEFAULT_SLOP_BLOCK_THRESHOLD = 60;
 
 export type GateCheckConclusion = "success" | "failure" | "action_required" | "neutral" | "skipped";
 

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -322,7 +322,7 @@ import { loadPublicAccuracyTrend } from "../services/public-accuracy-trend";
 import { loadPublicRulePrecision } from "../review/public-rule-precision";
 import { loadCalibrationTrend } from "../services/rule-calibration-trend";
 import { isSatisfactionFloorAutotuneEnabled, loadSatisfactionFloorStatus, runSatisfactionFloorLoosening } from "../services/satisfaction-floor-loosening-run";
-import { loadLiveKnobStatuses } from "../services/knob-loosening-run";
+import { loadAllKnobStatuses } from "../services/knob-loosening-run";
 import { loadPublicReuseRateTrend } from "../services/public-reuse-rate-trend";
 import { loadPublicReviewVolumeTrend } from "../services/public-review-volume-trend";
 import { buildMaintainerQualityDashboard, isMaintainerQualityDataStale } from "../services/maintainer-quality-dashboard";
@@ -4840,7 +4840,7 @@ export function createApp() {
   // The #8161 surface generalized across EVERY live registry knob (#8176): one endpoint, one projector,
   // per-knob flag state + shipped/live/override values + applied history (both split verdicts). Same
   // deliberate non-flag-gating and INTERNAL_JOB_TOKEN posture as the satisfaction-floor read above.
-  app.get("/v1/internal/calibration/knobs", async (c) => c.json({ knobs: await loadLiveKnobStatuses(c.env) }));
+  app.get("/v1/internal/calibration/knobs", async (c) => c.json({ knobs: await loadAllKnobStatuses(c.env) }));
 
   app.post("/v1/internal/jobs/refresh-registry", async (c) => {
     const message: JobMessage = { type: "refresh-registry", requestedBy: "api" };

--- a/src/rules/advisory.ts
+++ b/src/rules/advisory.ts
@@ -1227,7 +1227,9 @@ function buildQualityGateWarning(policy: GateCheckPolicy): AdvisoryFinding | nul
 }
 
 // Default block threshold = the `high` band (60), used when a maintainer sets slop: block without a minScore.
-const DEFAULT_SLOP_BLOCK_THRESHOLD = 60;
+/** Exported for the LOOSENABLE_KNOBS registry (#8224): the slop knob's shipped value anchors on this
+ *  constant (divided by 100 onto the corpus's confidence scale). */
+export const DEFAULT_SLOP_BLOCK_THRESHOLD = 60;
 
 function buildSlopGateBlocker(policy: GateCheckPolicy): AdvisoryFinding | null {
   if (gateMode(policy.slopGateMode) !== "block") return null;

--- a/src/services/knob-loosening-run.ts
+++ b/src/services/knob-loosening-run.ts
@@ -476,6 +476,9 @@ export type KnobRepoOverride = { repoFullName: string; value: number };
 
 export type KnobStatus = {
   knobId: string;
+  /** The registry's apply contract for this knob (#8224): report_only knobs surface evidence here and in
+   *  the advisor but their apply path refuses — the operator sees WHAT would move before anything can. */
+  applyMode: "live" | "report_only";
   flagEnabled: boolean;
   /** The tighten direction's own flag (#8225) — null for a knob that declares no tightening ladder. */
   tightenFlagEnabled: boolean | null;
@@ -620,6 +623,7 @@ export async function loadKnobStatus(env: Env, knob: LoosenableKnob): Promise<Kn
 
   return {
     knobId: knob.knobId,
+    applyMode: knob.applyMode,
     flagEnabled,
     tightenFlagEnabled,
     shippedValue: knob.shippedValue,
@@ -633,12 +637,21 @@ export async function loadKnobStatus(env: Env, knob: LoosenableKnob): Promise<Kn
 }
 
 /** Every live knob's status (satisfaction floor included — the generic projector reads its legacy
- *  proposal spelling), for GET /v1/internal/calibration/knobs. */
+ *  proposal spelling). Consumed by the advisor's reliability recs, which stay live-only by design. */
 export async function loadLiveKnobStatuses(env: Env, knobs: readonly LoosenableKnob[] = Object.values(LOOSENABLE_KNOBS)): Promise<KnobStatus[]> {
   const statuses: KnobStatus[] = [];
   for (const knob of knobs) {
     if (knob.applyMode !== "live") continue;
     statuses.push(await loadKnobStatus(env, knob));
   }
+  return statuses;
+}
+
+/** EVERY registry knob's status, report-only included (#8224), for GET /v1/internal/calibration/knobs —
+ *  the operator must see a report-only knob's evidence (drift, reliability, proposals-to-be) with its
+ *  applyMode label, not discover it only when someone files the flip-to-live issue. */
+export async function loadAllKnobStatuses(env: Env, knobs: readonly LoosenableKnob[] = Object.values(LOOSENABLE_KNOBS)): Promise<KnobStatus[]> {
+  const statuses: KnobStatus[] = [];
+  for (const knob of knobs) statuses.push(await loadKnobStatus(env, knob));
   return statuses;
 }

--- a/src/services/loosening-knobs.ts
+++ b/src/services/loosening-knobs.ts
@@ -20,17 +20,28 @@ import {
   type BacktestComparison,
 } from "@loopover/engine";
 import { LINKED_ISSUE_SATISFACTION_CONFIDENCE_FLOOR } from "./linked-issue-satisfaction";
-import { DEFAULT_AI_REVIEW_CLOSE_CONFIDENCE } from "../rules/advisory";
+import { DEFAULT_AI_REVIEW_CLOSE_CONFIDENCE, DEFAULT_SLOP_BLOCK_THRESHOLD } from "../rules/advisory";
 
 export type LoosenableKnob = {
   /** Stable id — used in override flag keys, audit events, and advisor labels. Never rename. */
   knobId: string;
   ruleId: string;
   shippedValue: number;
-  /** Candidate loosened values, nearest-to-shipped first — the smallest evidence-cleared step wins. */
+  /** Which way LOOSER points (#8224): a `floor` knob (a rule fires at/above the value; every pre-#8224
+   *  entry) loosens DOWNWARD; a `ceiling` knob (a gate blocks at/above the value — slop) loosens UPWARD,
+   *  raising the cap so fewer PRs block. The classifier math is identical either way (both knob families
+   *  fire on value >= threshold, so buildConfidenceThresholdClassifier applies unchanged) — orientation
+   *  only decides which side of shipped the candidates sit on and which hard bound applies. */
+  orientation: "floor" | "ceiling";
+  /** Candidate loosened values, nearest-to-shipped first — the smallest evidence-cleared step wins.
+   *  Floor knobs: strictly below shipped, descending. Ceiling knobs: strictly above shipped, ascending. */
   candidates: readonly number[];
-  /** No backtest result, however good, may loosen below this. */
+  /** Floor knobs: no backtest result, however good, may loosen below this. Ceiling knobs declare the
+   *  mirror bound in {@link LoosenableKnob.hardMaximum} instead and set this to the shipped value (it
+   *  still bounds the drift pool's tighter side). */
   hardMinimum: number;
+  /** Ceiling knobs only (#8224): no backtest result may loosen (raise) the cap above this. */
+  hardMaximum?: number;
   minVisibleCases: number;
   minHeldOutCases: number;
   heldOutFraction: number;
@@ -76,6 +87,7 @@ export const LOOSENABLE_KNOBS: Readonly<Record<string, LoosenableKnob>> = Object
   satisfaction_floor: {
     knobId: "satisfaction_floor",
     ruleId: "linked_issue_scope_mismatch",
+    orientation: "floor",
     shippedValue: LINKED_ISSUE_SATISFACTION_CONFIDENCE_FLOOR,
     candidates: [0.45, 0.4, 0.35, 0.3],
     hardMinimum: 0.3,
@@ -99,6 +111,7 @@ export const LOOSENABLE_KNOBS: Readonly<Record<string, LoosenableKnob>> = Object
   ai_review_close_confidence: {
     knobId: "ai_review_close_confidence",
     ruleId: "ai_consensus_defect",
+    orientation: "floor",
     shippedValue: DEFAULT_AI_REVIEW_CLOSE_CONFIDENCE,
     candidates: [0.9, 0.85],
     hardMinimum: 0.85,
@@ -124,6 +137,36 @@ export const LOOSENABLE_KNOBS: Readonly<Record<string, LoosenableKnob>> = Object
       autotuneEnvVar: "AI_REVIEW_CLOSE_CONFIDENCE_TIGHTEN_ENABLED",
       eventType: "calibration.ai_review_close_confidence_tightened",
     },
+  },
+  // #8224: the slop gate's block threshold enters REPORT-ONLY — proposals surface with full evidence in
+  // the advisor and the knobs endpoint; the apply path refuses until a flip-to-live ships as its own
+  // reviewed change, and per #8224 that issue gets filed only AFTER proposals with real evidence exist.
+  // The registry's first CEILING knob: the gate blocks when slopRisk/100 >= this value (advisory.ts's
+  // recordRuleFired writes confidence = risk/100 with shipped DEFAULT_SLOP_BLOCK_THRESHOLD), so LOOSER
+  // means RAISING the cap. Bounds rationale (tighter than close-confidence's, per the issue): this value
+  // gates contributor-facing verdicts directly, so two small steps (+0.05, +0.10) and a hard ceiling of
+  // 0.70 — beyond that a "slop gate" that only blocks 70+/100 risk isn't gating. Sample floors match the
+  // close-confidence knob's strictest-in-registry 50/12 given score noisiness.
+  //
+  // quality_gate_score deliberately does NOT enter (#8224's recorded finding): qualityGateMinScore is
+  // per-repo nullable with NO global shipped default, and a registry entry anchors the whole discipline
+  // on the shipped constant. It stays out until a global default exists.
+  slop_gate_score: {
+    knobId: "slop_gate_score",
+    ruleId: "slop_gate_score",
+    orientation: "ceiling",
+    shippedValue: DEFAULT_SLOP_BLOCK_THRESHOLD / 100,
+    candidates: [0.65, 0.7],
+    hardMinimum: DEFAULT_SLOP_BLOCK_THRESHOLD / 100,
+    hardMaximum: 0.7,
+    minVisibleCases: 50,
+    minHeldOutCases: 12,
+    heldOutFraction: 0.25,
+    splitSeed: "slop-gate-loosening-v1",
+    applyMode: "report_only",
+    overrideFlagKey: "slop_gate_score_override",
+    looseningEventType: "calibration.slop_gate_score_loosened",
+    autotuneEnvVar: "SLOP_GATE_SCORE_AUTOTUNE_ENABLED",
   },
 });
 
@@ -155,7 +198,13 @@ export function evaluateKnobLoosening(
   if (visible.length < knob.minVisibleCases || heldOut.length < knob.minHeldOutCases) return null;
 
   for (const candidate of knob.candidates) {
-    if (candidate >= currentValue || candidate < knob.hardMinimum) continue;
+    // Orientation decides which way "looser" points (#8224): floor knobs step DOWN toward hardMinimum,
+    // ceiling knobs step UP toward hardMaximum. Same evidence discipline either way.
+    const loosens =
+      knob.orientation === "ceiling"
+        ? candidate > currentValue && candidate <= (knob.hardMaximum ?? currentValue)
+        : candidate < currentValue && candidate >= knob.hardMinimum;
+    if (!loosens) continue;
     const visibleComparison = compareOnSlice(knob.ruleId, visible, currentValue, candidate);
     if (visibleComparison.verdict !== "improved") continue;
     const heldOutComparison = compareOnSlice(knob.ruleId, heldOut, currentValue, candidate);
@@ -268,8 +317,11 @@ export function evaluateKnobDrift(
 
   // #8225: a declared tightening ladder joins the pool, so the sentinel's tighter findings and the tighten
   // apply path judge the SAME candidate values (bounded by the ladder's own hard maximum via declaration).
+  // #8224: ceiling knobs bound the pool from above (hardMaximum) instead of below.
   const alternatives = [...new Set([knob.shippedValue, ...knob.candidates, ...(knob.tightening?.candidates ?? [])])]
-    .filter((value) => value !== liveValue && value >= knob.hardMinimum)
+    .filter((value) =>
+      value !== liveValue && (knob.orientation === "ceiling" ? value <= (knob.hardMaximum ?? knob.shippedValue) : value >= knob.hardMinimum),
+    )
     .sort((left, right) => Math.abs(left - liveValue) - Math.abs(right - liveValue) || right - left);
 
   for (const alternative of alternatives) {
@@ -282,7 +334,13 @@ export function evaluateKnobDrift(
       ruleId: knob.ruleId,
       liveValue,
       dominatingValue: alternative,
-      direction: alternative === knob.shippedValue ? "shipped" : alternative < liveValue ? "looser" : "tighter",
+      // Orientation decides the label (#8224): for a ceiling knob a HIGHER alternative is the looser one.
+      direction:
+        alternative === knob.shippedValue
+          ? "shipped"
+          : (knob.orientation === "ceiling" ? alternative > liveValue : alternative < liveValue)
+            ? "looser"
+            : "tighter",
       visibleCases: visible.length,
       heldOutCases: heldOut.length,
       visible: visibleComparison,

--- a/test/unit/knob-loosening-run.test.ts
+++ b/test/unit/knob-loosening-run.test.ts
@@ -278,9 +278,14 @@ describe("processor + endpoint wiring (#8176)", () => {
     expect((await app.request("/v1/internal/calibration/knobs", {}, env)).status).toBe(401);
     const res = await app.request("/v1/internal/calibration/knobs", { headers: { authorization: `Bearer ${env.INTERNAL_JOB_TOKEN}` } }, env);
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { knobs: Array<{ knobId: string; flagEnabled: boolean }> };
-    expect(body.knobs.map((knob) => knob.knobId).sort()).toEqual(["ai_review_close_confidence", "satisfaction_floor"]);
+    const body = (await res.json()) as { knobs: Array<{ knobId: string; flagEnabled: boolean; applyMode: string }> };
+    // #8224: report-only knobs list too, labeled by applyMode — the operator sees evidence surfaces
+    // before any flip-to-live exists.
+    expect(body.knobs.map((knob) => knob.knobId).sort()).toEqual(["ai_review_close_confidence", "satisfaction_floor", "slop_gate_score"]);
     expect(body.knobs.every((knob) => knob.flagEnabled === false)).toBe(true);
+    const byId = Object.fromEntries(body.knobs.map((knob) => [knob.knobId, knob]));
+    expect(byId.slop_gate_score!.applyMode).toBe("report_only");
+    expect(byId.ai_review_close_confidence!.applyMode).toBe("live");
     expect(JSON.stringify(body)).not.toMatch(/reward|payout|trust|wallet|hotkey|issueText|modelResponse/i);
   });
 });

--- a/test/unit/loosening-knobs.test.ts
+++ b/test/unit/loosening-knobs.test.ts
@@ -11,7 +11,7 @@ import {
   SATISFACTION_FLOOR_SPLIT_SEED,
 } from "../../src/services/satisfaction-floor-loosening";
 import { LINKED_ISSUE_SATISFACTION_CONFIDENCE_FLOOR } from "../../src/services/linked-issue-satisfaction";
-import { DEFAULT_AI_REVIEW_CLOSE_CONFIDENCE } from "../../src/rules/advisory";
+import { DEFAULT_AI_REVIEW_CLOSE_CONFIDENCE, DEFAULT_SLOP_BLOCK_THRESHOLD } from "../../src/rules/advisory";
 import { buildKnobReliabilityRecs, buildReportOnlyKnobRecs } from "../../src/review/loosening-recs";
 
 const AI_KNOB = LOOSENABLE_KNOBS.ai_review_close_confidence!;
@@ -21,6 +21,7 @@ describe("LOOSENABLE_KNOBS registry invariants (#8159)", () => {
     expect(LOOSENABLE_KNOBS.satisfaction_floor).toEqual({
       knobId: "satisfaction_floor",
       ruleId: SATISFACTION_FLOOR_RULE_ID,
+      orientation: "floor",
       shippedValue: LINKED_ISSUE_SATISFACTION_CONFIDENCE_FLOOR,
       candidates: SATISFACTION_FLOOR_LOOSENING_CANDIDATES,
       hardMinimum: SATISFACTION_FLOOR_HARD_MINIMUM,
@@ -50,11 +51,25 @@ describe("LOOSENABLE_KNOBS registry invariants (#8159)", () => {
     const knobs = Object.values(LOOSENABLE_KNOBS);
     for (const knob of knobs) {
       expect(knob.candidates.length).toBeGreaterThan(0);
-      for (const candidate of knob.candidates) {
-        expect(candidate).toBeLessThan(knob.shippedValue);
-        expect(candidate).toBeGreaterThanOrEqual(knob.hardMinimum);
+      // #8224: orientation decides which side of shipped the loosening ladder sits on.
+      if (knob.orientation === "ceiling") {
+        expect(typeof knob.hardMaximum).toBe("number"); // a ceiling knob MUST declare its upper bound
+        for (const candidate of knob.candidates) {
+          expect(candidate).toBeGreaterThan(knob.shippedValue);
+          expect(candidate).toBeLessThanOrEqual(knob.hardMaximum!);
+        }
+        expect([...knob.candidates].sort((a, b) => a - b)).toEqual([...knob.candidates]); // nearest-first (ascending)
+        // The live apply path and the tightening ladder are floor-only machinery today — a ceiling knob
+        // may not go live (or declare a ladder) until their storage/validation generalizes.
+        expect(knob.applyMode).toBe("report_only");
+        expect(knob.tightening).toBeUndefined();
+      } else {
+        for (const candidate of knob.candidates) {
+          expect(candidate).toBeLessThan(knob.shippedValue);
+          expect(candidate).toBeGreaterThanOrEqual(knob.hardMinimum);
+        }
+        expect([...knob.candidates].sort((a, b) => b - a)).toEqual([...knob.candidates]); // nearest-first (descending)
       }
-      expect([...knob.candidates].sort((a, b) => b - a)).toEqual([...knob.candidates]); // nearest-first
       expect(knob.minVisibleCases).toBeGreaterThan(0);
       expect(knob.minHeldOutCases).toBeGreaterThan(0);
       expect(["live", "report_only"]).toContain(knob.applyMode);
@@ -377,3 +392,125 @@ describe("evaluateKnobDrift on the close-confidence knob (#8212)", () => {
     );
   });
 });
+
+// ── #8224: the slop ceiling knob — report-only registration + orientation-aware evaluation ─────────────────
+
+const SLOP_KNOB = LOOSENABLE_KNOBS.slop_gate_score!;
+
+function slopCase(targetKey: string, confidence: number, label: "reversed" | "confirmed"): BacktestCase {
+  return {
+    ruleId: SLOP_KNOB.ruleId,
+    targetKey,
+    outcome: "above_threshold",
+    label,
+    firedAt: "2026-06-01T00:00:00.000Z",
+    decidedAt: "2026-06-02T00:00:00.000Z",
+    metadata: { confidence },
+  };
+}
+
+const slopProbe = POOL.map((key) => slopCase(key, 0.99, "confirmed"));
+const slopSplit = splitBacktestCorpus(slopProbe, SLOP_KNOB.heldOutFraction, SLOP_KNOB.splitSeed);
+const slopVisibleKeys = slopSplit.visible.map((c) => c.targetKey);
+const slopHeldOutKeys = slopSplit.heldOut.map((c) => c.targetKey);
+
+// Band blocks at 0.62 the humans REVERSED (the gate over-blocked): shipped 0.60 fires them; raising the
+// cap to 0.65 stops firing exactly those — precision up. A deep-high confirmed anchor per slice keeps a
+// true positive on both sides of every comparison.
+function slopLooseningFriendlyCorpus(): BacktestCase[] {
+  const cases: BacktestCase[] = [];
+  for (const key of slopVisibleKeys.slice(0, SLOP_KNOB.minVisibleCases + 6)) cases.push(slopCase(key, 0.62, "reversed"));
+  for (const key of slopHeldOutKeys.slice(0, SLOP_KNOB.minHeldOutCases + 3)) cases.push(slopCase(key, 0.62, "reversed"));
+  cases.push(slopCase(slopVisibleKeys[SLOP_KNOB.minVisibleCases + 10]!, 0.9, "confirmed"));
+  cases.push(slopCase(slopHeldOutKeys[SLOP_KNOB.minHeldOutCases + 6]!, 0.9, "confirmed"));
+  return cases;
+}
+
+describe("slop_gate_score registry entry (#8224)", () => {
+  it("pins the ceiling entry: shipped from the gate constant, ascending ladder, report-only, no autonomy plumbing implied", () => {
+    expect(SLOP_KNOB).toEqual({
+      knobId: "slop_gate_score",
+      ruleId: "slop_gate_score",
+      orientation: "ceiling",
+      shippedValue: DEFAULT_SLOP_BLOCK_THRESHOLD / 100,
+      candidates: [0.65, 0.7],
+      hardMinimum: DEFAULT_SLOP_BLOCK_THRESHOLD / 100,
+      hardMaximum: 0.7,
+      minVisibleCases: 50,
+      minHeldOutCases: 12,
+      heldOutFraction: 0.25,
+      splitSeed: "slop-gate-loosening-v1",
+      applyMode: "report_only",
+      overrideFlagKey: "slop_gate_score_override",
+      looseningEventType: "calibration.slop_gate_score_loosened",
+      autotuneEnvVar: "SLOP_GATE_SCORE_AUTOTUNE_ENABLED",
+    });
+    expect(LOOSENABLE_KNOBS.quality_gate_score).toBeUndefined(); // stays out until a global shipped default exists
+  });
+
+  it("evaluateKnobLoosening proposes the smallest RAISE for a ceiling knob when both splits support it", () => {
+    const proposal = evaluateKnobLoosening(SLOP_KNOB, slopLooseningFriendlyCorpus());
+    expect(proposal).not.toBeNull();
+    expect(proposal!.currentValue).toBe(0.6);
+    expect(proposal!.proposedValue).toBe(0.65); // the smaller of the two raises
+    expect(proposal!.visible.verdict).toBe("improved");
+    expect(proposal!.heldOut.verdict).not.toBe("regressed");
+  });
+
+  it("refuses to raise past the hard maximum, even from an already-raised current value", () => {
+    expect(evaluateKnobLoosening(SLOP_KNOB, slopLooseningFriendlyCorpus(), SLOP_KNOB.hardMaximum!)).toBeNull();
+  });
+
+  it("never proposes on a sample below the knob's floors", () => {
+    expect(evaluateKnobLoosening(SLOP_KNOB, slopLooseningFriendlyCorpus().slice(0, 10))).toBeNull();
+  });
+
+  it("drift labels are orientation-aware: an ABOVE-live dominating alternative reads LOOSER for a ceiling knob (and is suppressible)", () => {
+    const report = evaluateKnobDrift(SLOP_KNOB, slopLooseningFriendlyCorpus());
+    expect(report).not.toBeNull();
+    expect(report!.dominatingValue).toBe(0.65);
+    expect(report!.direction).toBe("looser"); // a floor knob would have labeled the same move "tighter"
+  });
+
+  it("DEFENSIVE: a ceiling knob missing its hardMaximum can never loosen and its drift pool collapses to at-or-below shipped", () => {
+    // The structural invariant forbids this shape in the shipped registry; the evaluators still refuse
+    // rather than treat an absent bound as infinity.
+    const { hardMaximum: _dropped, ...rest } = SLOP_KNOB;
+    const unbounded = rest as LoosenableKnob;
+    expect(evaluateKnobLoosening(unbounded, slopLooseningFriendlyCorpus())).toBeNull();
+    const report = evaluateKnobDrift(unbounded, slopLooseningFriendlyCorpus());
+    expect(report).toBeNull(); // every above-shipped alternative is filtered out; shipped === live
+  });
+
+  it("the generic report-only proposals path picks the slop knob up with zero new plumbing", async () => {
+    const proposals = await loadReportOnlyKnobProposalsForTest();
+    expect(proposals.some((proposal) => proposal.knobId === "slop_gate_score")).toBe(true);
+  });
+});
+
+// Seed a friendly corpus into a real signal store and run the SHIPPED default-registry path — the exact
+// call selftune-wire makes each pass.
+async function loadReportOnlyKnobProposalsForTest() {
+  const { createTestEnv } = await import("../helpers/d1");
+  const { createSignalStore } = await import("../../src/review/signal-tracking-wire");
+  const { loadReportOnlyKnobProposals } = await import("../../src/services/satisfaction-floor-loosening-run");
+  const env = createTestEnv();
+  const store = createSignalStore(env);
+  const now = Date.now();
+  for (const [i, backtestCase] of slopLooseningFriendlyCorpus().entries()) {
+    await store.recordRuleFired({
+      ruleId: SLOP_KNOB.ruleId,
+      targetKey: backtestCase.targetKey,
+      outcome: "above_threshold",
+      occurredAt: new Date(now - 10_000 - i).toISOString(),
+      metadata: { confidence: backtestCase.metadata!.confidence as number },
+    });
+    await store.recordHumanOverride({
+      ruleId: SLOP_KNOB.ruleId,
+      targetKey: backtestCase.targetKey,
+      verdict: backtestCase.label,
+      occurredAt: new Date(now - i).toISOString(),
+    });
+  }
+  return loadReportOnlyKnobProposals(env, now);
+}


### PR DESCRIPTION
## Summary

Closes #8224 (per its recorded re-scope: quality stays out, slop enters via the orientation axis).

- **Orientation axis:** `LoosenableKnob` gains `orientation: "floor" | "ceiling"` — a floor knob (every prior entry) loosens DOWNWARD toward `hardMinimum`; a ceiling knob loosens UPWARD toward a new `hardMaximum`. The classifier math is unchanged (both knob families fire on value ≥ threshold — verified against the #8223 capture: `confidence = slopRisk/100`, block at ≥ threshold), so only the candidate direction, the bound, and the drift direction LABEL branch (above-live is `looser` for a ceiling — the inverted label the issue's design finding flagged as the blocker to registering slop honestly).
- **`slop_gate_score` enters report-only:** shipped 0.60 (`DEFAULT_SLOP_BLOCK_THRESHOLD / 100`, now exported with the matching engine-twin edit), raises `[0.65, 0.70]`, hard ceiling 0.70, the registry's strictest 50/12 sample floors — written bounds rationale in the entry comment. The generic report-only proposals path picks it up with zero new plumbing (pinned by a test seeding a real signal store and running the shipped default-registry path).
- **Structural invariants:** ceiling entries must declare `hardMaximum`, stay `report_only`, and carry no tightening ladder until the live storage generalizes; defensive nullish arms proven to refuse rather than treat a missing bound as infinity.
- **Knobs endpoint:** now lists EVERY registry knob labeled by a new `applyMode` field (`loadAllKnobStatuses`), so operators see report-only evidence surfaces before any flip-to-live exists. The advisor's reliability recs stay live-only by design.
- `quality_gate_score` stays out (no global shipped default to anchor on) — recorded in the registry comment; the flip-to-live issue gets filed only after proposals with real evidence exist, per the issue's boundary.

## Validation

- Full local gate `npm run test:ci` on the pre-rebase base: green except (a) three engine-parity tests that were correctly demanding the matching gate-decision twin edit — now committed (`gate-advisory.ts` mirrors the export; parity suite 14/14 green) — and (b) the known `satisfaction-floor-loosening-run` first-test load-timeout flake, 23/23 standalone. `npm audit --audit-level=moderate` clean.
- Rebased onto current main (engine 3.11.0); post-rebase typecheck clean; parity + both loosening suites green.
- 100% line+branch on every changed range in `loosening-knobs.ts`, `knob-loosening-run.ts`, `advisory.ts`, and the routes line (lcov vs exact diff hunks), including both defensive nullish arms and the orientation branches on both sides.