### PR TITLE
fix(engine): add minRankAutotuneEnabled to the policy-spec dist-twin test's full-shape pin

### DIFF
--- a/packages/loopover-engine/test/ams-policy-spec-parser.test.ts
+++ b/packages/loopover-engine/test/ams-policy-spec-parser.test.ts
@@ -54,6 +54,7 @@ test("parseAmsPolicySpec: valid raw config normalizes every field and keeps non-
     maxTurnsPerIteration: 10,
     selfLoopAutonomy: "observe",
     networkAllowlist: { ecosystems: ["npm"], extraHosts: ["api.example.com"] },
+    minRankAutotuneEnabled: false,
   });
   assert.deepEqual(parsed.warnings, []);
 });


### PR DESCRIPTION
## Summary

#8270 added `minRankAutotuneEnabled` to `AmsPolicySpec` and updated the root vitest twin's full-shape pin, but missed this node:test **dist twin** — the engine workspace suite has been red on main since. Test-only, one line; the full engine suite passes with it (0 `not ok`). Caught by the next branch's full gate; fixing forward immediately per the fix-discovered-drift convention.

## Validation

`npm run test --workspace @loopover/engine` exit 0, zero failures.