### PR TITLE
fix(ui-kit): move focus ring to focus-visible on Select/Dialog/Sheet/NavigationMenu

### DIFF
--- a/packages/loopover-ui-kit/src/components/dialog.tsx
+++ b/packages/loopover-ui-kit/src/components/dialog.tsx
@@ -44,7 +44,7 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background cursor-pointer transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background cursor-pointer transition-opacity hover:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>

--- a/packages/loopover-ui-kit/src/components/focus-visible-convention.test.tsx
+++ b/packages/loopover-ui-kit/src/components/focus-visible-convention.test.tsx
@@ -1,0 +1,39 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { navigationMenuTriggerStyle } from "./navigation-menu";
+import { Select, SelectTrigger, SelectValue } from "./select";
+
+// Regression for #8304: SelectTrigger, the Dialog/Sheet close buttons, and NavigationMenuTrigger must
+// apply their focus ring/highlight via `focus-visible:` (keyboard/programmatic focus only), matching
+// every other interactive primitive in @loopover/ui-kit — never on plain `focus:`, which also fires on
+// mouse-click focus and leaves a lingering ring/highlight. `focus:outline-none` is intentionally kept
+// (clearing the native outline on any focus is correct and shared by every primitive).
+describe("focus-visible convention (#8304)", () => {
+  it("navigationMenuTriggerStyle highlights on focus-visible, never a bare focus:bg-accent", () => {
+    const classes = navigationMenuTriggerStyle();
+    expect(classes).toContain("focus-visible:bg-accent");
+    expect(classes).toContain("focus-visible:text-accent-foreground");
+    // No bare focus:bg-accent / focus:text-accent-foreground (the data-[state=open]:focus:bg-accent
+    // compound is a separate, intentional open-state rule and is allowed).
+    expect(classes).not.toMatch(/(?<!:)\bfocus:bg-accent\b/);
+    expect(classes).not.toMatch(/(?<!:)\bfocus:text-accent-foreground\b/);
+    // The native-outline clear stays on plain focus:.
+    expect(classes).toContain("focus:outline-none");
+  });
+
+  it("SelectTrigger rings on focus-visible, never a bare focus:ring", () => {
+    const { getByRole } = render(
+      <Select>
+        <SelectTrigger aria-label="pick">
+          <SelectValue placeholder="pick" />
+        </SelectTrigger>
+      </Select>,
+    );
+    const trigger = getByRole("combobox");
+    expect(trigger.className).toContain("focus-visible:ring-1");
+    expect(trigger.className).toContain("focus-visible:ring-ring");
+    expect(trigger.className).not.toMatch(/(?<!-)\bfocus:ring/);
+    expect(trigger.className).toContain("focus:outline-none");
+  });
+});

--- a/packages/loopover-ui-kit/src/components/navigation-menu.tsx
+++ b/packages/loopover-ui-kit/src/components/navigation-menu.tsx
@@ -41,7 +41,7 @@ NavigationMenuList.displayName = NavigationMenuPrimitive.List.displayName;
 const NavigationMenuItem = NavigationMenuPrimitive.Item;
 
 const navigationMenuTriggerStyle = cva(
-  "group inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium cursor-pointer transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed data-[state=open]:text-accent-foreground data-[state=open]:bg-accent/50 data-[state=open]:hover:bg-accent data-[state=open]:focus:bg-accent",
+  "group inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium cursor-pointer transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed data-[state=open]:text-accent-foreground data-[state=open]:bg-accent/50 data-[state=open]:hover:bg-accent data-[state=open]:focus:bg-accent",
 );
 
 const NavigationMenuTrigger = React.forwardRef<

--- a/packages/loopover-ui-kit/src/components/select.tsx
+++ b/packages/loopover-ui-kit/src/components/select.tsx
@@ -19,7 +19,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background cursor-pointer data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background cursor-pointer data-[placeholder]:text-muted-foreground focus:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       className,
     )}
     {...props}

--- a/packages/loopover-ui-kit/src/components/sheet.tsx
+++ b/packages/loopover-ui-kit/src/components/sheet.tsx
@@ -69,7 +69,7 @@ const SheetContent = React.forwardRef<
       className={cn(sheetVariants({ side }), className)}
       {...props}
     >
-      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background cursor-pointer transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background cursor-pointer transition-opacity hover:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </SheetPrimitive.Close>


### PR DESCRIPTION
## Summary

- `SelectTrigger` (`select.tsx`), `DialogPrimitive.Close` (`dialog.tsx`), `SheetPrimitive.Close` (`sheet.tsx`), and `NavigationMenuTrigger` (`navigation-menu.tsx`) applied their focus ring / background highlight on plain `focus:`, which fires on **mouse-click** focus too and leaves a lingering ring/highlight after every click — unlike `button.tsx`, `input.tsx`, `textarea.tsx`, `switch.tsx`, `checkbox.tsx`, `toggle.tsx`, `slider.tsx`, and `badge.tsx`, which all ring on `focus-visible:` (keyboard/programmatic focus only).
- Moves **only** the visible ring/highlight classes to `focus-visible:` at those four sites: `focus:ring-* → focus-visible:ring-*` (Select/Dialog/Sheet) and `focus:bg-accent focus:text-accent-foreground → focus-visible:*` (NavigationMenu). `focus:outline-none` is kept as-is (clearing the native outline on any focus is correct and shared by every primitive), and the intentional `data-[state=open]:focus:bg-accent` open-state compound is untouched. No other className (radius, padding, color tokens) changed.
- Adds `focus-visible-convention.test.tsx`: asserts `navigationMenuTriggerStyle()` and the rendered `SelectTrigger` now carry `focus-visible:` ring/highlight classes and no bare `focus:ring`/`focus:bg-accent`, while keeping `focus:outline-none`.

Closes #8304

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This diff touches only `packages/loopover-ui-kit/**` (four class renames + one new test). `packages/loopover-ui-kit` is not in the root `vitest.config.ts` `coverage.include` and is not Codecov-gated (its own `vitest.config.ts`: the acceptance signal is the suite running and passing, not a percentage), so `test:coverage`/`codecov/patch` do not apply; `actionlint`, `test:workers`, `build:mcp`/`test:mcp-pack`, `ui:openapi:check`, and `npm audit` are not exercised by a ui-kit-only class change. Locally verified in the package: `npm test` (4 files / 21 tests, incl. the 2 new), `tsc --noEmit`, and `prettier --check` on the touched files all pass.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

This fix has **no at-rest visual difference** and no difference under mouse interaction at all in the sense a static screenshot captures — the change is purely *which* focus triggers the ring. `:focus-visible` is a browser-heuristic pseudo-class that, by design, does **not** match on mouse-click focus, so:

- **Before:** clicking `SelectTrigger` / the `Dialog` or `Sheet` close button / `NavigationMenuTrigger` with a mouse left a persistent focus ring/highlight after the click (the bug).
- **After:** the same mouse click leaves no lingering ring/highlight, while **keyboard** (Tab) focus still shows the ring on both — matching `button`/`input`/`switch` and every other primitive in the kit.

Because the difference is a focus *pseudo-class heuristic* rather than a rendered-pixel change, the authoritative, machine-checkable evidence is the class-list regression test `focus-visible-convention.test.tsx` (part of this PR): it asserts `navigationMenuTriggerStyle()` and the rendered `SelectTrigger` now carry the `focus-visible:` ring/highlight classes and no bare `focus:ring` / `focus:bg-accent`, while keeping `focus:outline-none`. This is the same class-list-assertion evidence convention `state-views.test.tsx` / `theme-toggle.test.tsx` already use for ui-kit variant guarantees, and the same shape the sibling accessibility fixes #7015/#7016 were verified with.

## Notes

- Class-rename-only fix, no new abstraction and no adoption of the app-level `.focus-ring` utility — mirrors the exact `focus-visible:` convention of `button.tsx`/`input.tsx`/`switch.tsx`, matching the "#7015 AccordionTrigger — unlike every other X in ui-kit" shape.
