### PR TITLE
fix(orb): drop unreachable bare ::1 branch in isLocalBrokerHost

### DIFF
--- a/src/orb/broker-client.ts
+++ b/src/orb/broker-client.ts
@@ -19,7 +19,9 @@ const BROKER_TIMEOUT_MS = 25_000;
 const ORB_RELAY_REGISTER_TIMEOUT_MS = 25_000;
 
 function isLocalBrokerHost(hostname: string): boolean {
-  return hostname === "localhost" || hostname === "127.0.0.1" || (hostname === "::1" || hostname === "[::1]");
+  // `hostname` is always a WHATWG URL's `.hostname`, which brackets an IPv6 literal ([::1], never bare ::1),
+  // so only the bracketed form is a reachable input here (#8334).
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]";
 }
 
 function orbBrokerBaseUrl(env: { ORB_BROKER_URL?: string | undefined }): string {


### PR DESCRIPTION
## What & why

Closes #8334.

`isLocalBrokerHost` (`src/orb/broker-client.ts`) checks `hostname === "::1"`, but `hostname` here is always a WHATWG `URL`'s `.hostname`, which always **brackets** an IPv6 literal — `new URL("http://[::1]:8787").hostname` is `"[::1]"`, never the bare `"::1"`. So the bare-`::1` arm is unreachable dead code given how the function is actually called, and `test/unit/orb-broker-client.test.ts:96` only ever exercises the bracketed form.

## The fix

Remove the unreachable bare `"::1"` comparison, leaving the three reachable forms (`localhost` / `127.0.0.1` / `[::1]`), and add a one-line comment noting why only the bracketed IPv6 form is checked (so a future reader doesn't reintroduce the bare form). This is a dead-code cleanup — **no externally-observable behavior change**.

## Validation

- `test/unit/orb-broker-client.test.ts` (40 tests) pass unchanged; the bracketed-`[::1]` case still exercises the simplified line.
- The changed line's remaining branches are all covered (`codecov/patch` 100% on the diff — removing a branch only improves coverage); `broker-client.ts` whole-file stays at ~99% branch / 100% lines.
- Typecheck clean; branched off current `main`, mergeable-clean.

Per the issue: this removes a branch rather than adding one, so no new test is required to hit the patch gate — the existing bracketed-form test keeps the real behavior covered.