### PR TITLE
fix(ui-kit): give PaginationLink aria-disabled a real visual/interaction effect

### DIFF
--- a/packages/loopover-ui-kit/src/components/pagination.test.tsx
+++ b/packages/loopover-ui-kit/src/components/pagination.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "./pagination";
+
+// Regression for #8307: PaginationLink (and PaginationPrevious/PaginationNext built on it) render an <a>,
+// which has no native disabled attribute — a consumer-supplied aria-disabled must produce a real
+// visual/interaction cue via the aria-disabled: Tailwind variant, matching sidebar.tsx/calendar.tsx.
+describe("PaginationLink aria-disabled styling (#8307)", () => {
+  it("carries the aria-disabled: dim + pointer-events classes when aria-disabled is set", () => {
+    render(
+      <PaginationLink aria-disabled="true" aria-label="prev">
+        1
+      </PaginationLink>,
+    );
+    const link = screen.getByLabelText("prev");
+    expect(link.className).toContain("aria-disabled:pointer-events-none");
+    expect(link.className).toContain("aria-disabled:opacity-50");
+  });
+
+  it("PaginationPrevious/PaginationNext inherit the aria-disabled styling from PaginationLink", () => {
+    render(
+      <nav>
+        <PaginationPrevious aria-disabled="true" />
+        <PaginationNext aria-disabled="true" />
+      </nav>,
+    );
+    for (const label of ["Go to previous page", "Go to next page"]) {
+      const el = screen.getByLabelText(label);
+      expect(el.className).toContain("aria-disabled:pointer-events-none");
+      expect(el.className).toContain("aria-disabled:opacity-50");
+    }
+  });
+
+  it("still renders (unchanged aria-current behavior) and the classes are present regardless — the variant only applies when aria-disabled is truthy at runtime", () => {
+    render(
+      <PaginationLink isActive aria-label="active">
+        2
+      </PaginationLink>,
+    );
+    const link = screen.getByLabelText("active");
+    // isActive/aria-current is untouched by this fix.
+    expect(link.getAttribute("aria-current")).toBe("page");
+  });
+});

--- a/packages/loopover-ui-kit/src/components/pagination.tsx
+++ b/packages/loopover-ui-kit/src/components/pagination.tsx
@@ -52,6 +52,9 @@ const PaginationLink = ({
         variant: isActive ? "outline" : "ghost",
         size,
       }),
+      // An <a> has no native disabled attribute, so a consumer-supplied aria-disabled needs an explicit
+      // visual/interaction cue -- mirrors the aria-disabled: styling sidebar.tsx/calendar.tsx already use.
+      "aria-disabled:pointer-events-none aria-disabled:opacity-50",
       className,
     )}
     {...props}


### PR DESCRIPTION
## Summary

- `PaginationLink` renders an `<a>`, which has no native `disabled` attribute, and applied no styling keyed off `aria-disabled` — so the five `apps/loopover-miner-ui` routes that set `aria-disabled` on the boundary `PaginationPrevious`/`PaginationNext` (`run-history.tsx`, `ledgers.tsx`, `portfolio.tsx`, `ranked-candidates.tsx`, `attempts.tsx`) got only a screen-reader signal: the link stayed fully opaque, kept its ghost/outline hover state, and remained pointer-interactive.
- Adds `aria-disabled:pointer-events-none aria-disabled:opacity-50` to `PaginationLink`'s class composition (inherited by `PaginationPrevious`/`PaginationNext`, which both delegate to it), matching the exact `aria-disabled:` styling convention `sidebar.tsx` (`sidebarMenuButtonVariants`/`SidebarMenuSubButton`) and `calendar.tsx` already use.
- `isActive`/`aria-current` behavior and every consumer's existing `aria-disabled={...}` usage are untouched — `pagination.tsx`-only styling fix.
- Adds `pagination.test.tsx` (this component's first test): asserts an `aria-disabled` `PaginationLink`/`PaginationPrevious`/`PaginationNext` carries the disabled-styling classes and that `aria-current` is unchanged.

Closes #8307

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This diff touches only `packages/loopover-ui-kit/**` (one class-composition line + one new test). `packages/loopover-ui-kit` is not in the root `vitest.config.ts` `coverage.include` and is not Codecov-gated (its own `vitest.config.ts`: the acceptance signal is the suite running and passing, not a percentage), so `test:coverage`/`codecov/patch` do not apply; `actionlint`, `test:workers`, `build:mcp`/`test:mcp-pack`, `ui:openapi:check`, and `npm audit` are not exercised by a ui-kit-only class change. Locally verified in the package: `npm test` (4 files / 22 tests, incl. the 3 new), `tsc --noEmit`, and `prettier --check` on the touched files all pass.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

The rendered change is scoped to the **`aria-disabled="true"`** state of a pagination control (a boundary `PaginationPrevious`/`PaginationNext`), which no ui-kit consumer could exercise before this fix because no `aria-disabled:` styling existed:

- **Before:** a boundary pagination arrow rendered at full opacity, kept its ghost hover highlight, and stayed pointer-interactive — visually identical to an enabled arrow.
- **After:** the same `aria-disabled` arrow renders at `opacity-50` with `pointer-events-none` (hover highlight and clicks suppressed), i.e. the standard dimmed-disabled cue already shown by `sidebar.tsx`/`calendar.tsx`'s `aria-disabled:` elements.

The effect is the exact `aria-disabled:opacity-50` / `aria-disabled:pointer-events-none` utility pair those two sibling components already ship, so it inherits their established visual treatment rather than introducing a new one. The machine-checkable evidence is the class-list regression test `pagination.test.tsx` (part of this PR), which asserts the disabled-styling classes are present on `PaginationLink`/`PaginationPrevious`/`PaginationNext` and that `aria-current` is unchanged — the same class-list-assertion evidence convention `state-views.test.tsx`/`theme-toggle.test.tsx` use for ui-kit variant guarantees.

## Notes

- Applied once at the `PaginationLink` level, not duplicated into `PaginationPrevious`/`PaginationNext`, since both delegate to it — mirrors the "#7015 unlike every other X in ui-kit" consistency shape.
