### PR TITLE
fix(rules): disclose configured blockers omitted past the inline gate-check cap (#8323)

### DIFF
--- a/src/rules/advisory.ts
+++ b/src/rules/advisory.ts
@@ -387,6 +387,11 @@ function sanitizeForCheckRun(text: string): string {
 
 export const CHECK_RUN_ANNOTATION_LIMIT = 50;
 
+// Max configured hard-blocker lines rendered inline in the gate check-run text before truncation — a long
+// list is unreadable and risks GitHub's check-run output size limit. Overflow is disclosed via a
+// "…N more omitted" line (formatGateCheckOutput, #8323), the same transparency CHECK_RUN_ANNOTATION_LIMIT gets.
+const GATE_CHECK_BLOCKER_LIMIT = 8;
+
 export type CheckRunAnnotation = {
   path: string;
   start_line: number;
@@ -741,17 +746,24 @@ export function formatGateCheckOutput(gate: GateCheckEvaluation): { title: strin
       text: "LoopOver did not create a contributor-facing failure for this event.",
     };
   }
-  const blockerLines = gate.blockers.slice(0, 8).map((finding) => {
+  const blockerLines = gate.blockers.slice(0, GATE_CHECK_BLOCKER_LIMIT).map((finding) => {
     const action = finding.action ? ` Action: ${sanitizeForCheckRun(finding.action)}` : "";
     return `- ${sanitizeForCheckRun(finding.title)}.${action}`;
   });
+  // #8323: disclose truncation, mirroring buildCheckRunAnnotations' omittedCount line — a contributor with 9+
+  // genuine blockers must know more exist than are shown, not silently discover them on the next gate run.
+  const omittedCount = Math.max(0, gate.blockers.length - GATE_CHECK_BLOCKER_LIMIT);
+  let text = blockerLines.length > 0 ? blockerLines.join("\n") : "A configured hard blocker was found.";
+  if (omittedCount > 0) {
+    text = `${text}\n\n…${omittedCount} more configured blocker(s) omitted from inline check output.`;
+  }
   return {
     // GitHub's check-run output.title 422s when too long; cap it (matches the 255 cap used for annotations).
     // An unbounded title (e.g. when failing-check names are appended) threw a 422 that aborted the ENTIRE
     // review before the comment, audit, and auto-action — so red-CI PRs were never reviewed or closed.
     title: gate.title.slice(0, 255),
     summary: `${LOOPOVER_GATE_CHECK_NAME} found a repo-configured hard blocker.`,
-    text: blockerLines.length > 0 ? blockerLines.join("\n") : "A configured hard blocker was found.",
+    text,
   };
 }
 

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -696,6 +696,49 @@ describe("advisory rules", () => {
     expect(output.text).not.toMatch(/reward|wallet|hotkey|trust score|payout|farming/i);
   });
 
+  it("discloses how many configured blockers were omitted past the inline cap (#8323)", () => {
+    const blockers = Array.from({ length: 11 }, (_, i) => ({
+      code: `configured_blocker_${i}`,
+      title: `Configured blocker ${i}`,
+      severity: "warning" as const,
+      detail: `detail ${i}`,
+    }));
+    const output = formatGateCheckOutput({
+      enabled: true,
+      conclusion: "failure",
+      title: "LoopOver Orb Review Agent is blocking merge",
+      summary: "A configured merge-blocking issue was found.",
+      blockers,
+      warnings: [],
+    });
+
+    // Only the first 8 blocker lines are inlined, and the overflow (11 - 8 = 3) is disclosed, not silently dropped.
+    expect(output.text.match(/^- Configured blocker/gm)).toHaveLength(8);
+    expect(output.text).toContain("…3 more configured blocker(s) omitted from inline check output.");
+  });
+
+  it("does not add an omission-disclosure line when blockers are at or under the inline cap (#8323)", () => {
+    for (const count of [1, 8]) {
+      const blockers = Array.from({ length: count }, (_, i) => ({
+        code: `configured_blocker_${i}`,
+        title: `Configured blocker ${i}`,
+        severity: "warning" as const,
+        detail: `detail ${i}`,
+      }));
+      const output = formatGateCheckOutput({
+        enabled: true,
+        conclusion: "failure",
+        title: "LoopOver Orb Review Agent is blocking merge",
+        summary: "A configured merge-blocking issue was found.",
+        blockers,
+        warnings: [],
+      });
+
+      expect(output.text.match(/^- Configured blocker/gm), `count ${count}`).toHaveLength(count);
+      expect(output.text, `count ${count}`).not.toContain("omitted from inline check output");
+    }
+  });
+
   it("keeps private reviewability context out of check output", () => {
     const pr: PullRequestRecord = {
       repoFullName: repo.fullName,


### PR DESCRIPTION
## Summary
`formatGateCheckOutput` (`src/rules/advisory.ts`) renders configured hard-blocker lines with a bare `gate.blockers.slice(0, 8)` — no comment, no disclosure. A contributor with 9+ genuine configured blockers on one PR saw only the first 8, fixed them, then discovered the 9th (and beyond) on the *next* gate run — indistinguishable from the bot silently moving the goalposts. Its sibling `buildCheckRunAnnotations` already discloses truncation via an `omittedCount` "…N more … omitted from inline check output." line; this closes the gap.

- Extract the inline `8` to a named `GATE_CHECK_BLOCKER_LIMIT` constant with an explanatory comment.
- When `gate.blockers.length` exceeds the cap, append `"…N more configured blocker(s) omitted from inline check output."` to the check-run `text`, mirroring `buildCheckRunAnnotations`' omitted-count wording. The line is **not** added when blockers are at or under the cap.
- No other behavior changes — the title cap, summary, and the zero-blocker fallback are untouched.

## Validation
- `npm run typecheck` green; the full changed-graph `test:changed` net passes.
- `test/unit/rules.test.ts` extended with both branches (the deliverable + Codecov requirement — both must be independently covered): 11 blockers ⇒ exactly 8 inline lines + a "…3 more … omitted" disclosure; 1 and 8 blockers ⇒ the exact count of lines and **no** disclosure line. **100% line + branch coverage on every changed line** in `formatGateCheckOutput` (verified via `vitest --coverage` + the advisory.ts lcov block); the full `rules.test.ts` suite (99 tests) passes.

Closes #8323
