### PR TITLE
fix(mcp): align read report tools with requireRepoAccess

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -3456,8 +3456,10 @@ export class LoopoverMcp {
   }
 
   private async getMaintainerNoise(input: { owner: string; repo: string }): Promise<ToolPayload> {
+    // (#8338) Mirrors GET /v1/repos/:owner/:repo/maintainer-noise: same requireRepoAccess gate as sibling
+    // read-only maintainer reports (and REST requireRepoMaintainer) — not the live-write approval-queue gate.
     const fullName = `${input.owner}/${input.repo}`;
-    await this.requireRepoApprovalQueueAccess(fullName);
+    await this.requireRepoAccess(fullName);
     const report = await loadMaintainerNoiseReport(this.env, fullName);
     return {
       summary: maintainerNoiseSummary(report),
@@ -3466,10 +3468,11 @@ export class LoopoverMcp {
   }
 
   private async getAmsMinerCohort(input: { owner: string; repo: string }): Promise<ToolPayload> {
-    // Mirrors GET /v1/repos/:owner/:repo/ams-miner-cohort: same maintainer gate as getMaintainerNoise
-    // (requireRepoApprovalQueueAccess) and the same buildAmsMinerCohortComparison service the REST route uses.
+    // (#8338) Mirrors GET /v1/repos/:owner/:repo/ams-miner-cohort: same requireRepoAccess gate as
+    // getMaintainerNoise / other read-only maintainer reports, and the same buildAmsMinerCohortComparison
+    // service the REST route uses.
     const fullName = `${input.owner}/${input.repo}`;
-    await this.requireRepoApprovalQueueAccess(fullName);
+    await this.requireRepoAccess(fullName);
     const report = await buildAmsMinerCohortComparison(this.env, fullName);
     // Single summary template (no present-branch) so patch coverage stays complete under the 99% gate; the
     // structured payload still carries `present` for clients that need the empty vs populated distinction.
@@ -3492,12 +3495,13 @@ export class LoopoverMcp {
     };
   }
 
-  // (#7799) MCP surface for GET /v1/repos/:owner/:repo/activation-preview. Assembles the same inputs the REST
+  // (#7799/#8338) MCP surface for GET /v1/repos/:owner/:repo/activation-preview. Same requireRepoAccess gate
+  // as sibling read-only maintainer reports (REST requireRepoMaintainer). Assembles the same inputs the REST
   // route does (getRepository + resolveRepositorySettings + listPullRequests) and defers to the guarded
   // buildMaintainerActivationPreview service. Deterministic and advisory-only -- never runs AI.
   private async getActivationPreview(input: { owner: string; repo: string }): Promise<ToolPayload> {
     const fullName = `${input.owner}/${input.repo}`;
-    await this.requireRepoApprovalQueueAccess(fullName);
+    await this.requireRepoAccess(fullName);
     const [repo, settings, pullRequests] = await Promise.all([
       getRepository(this.env, fullName),
       resolveRepositorySettings(this.env, fullName),

--- a/test/unit/mcp-output-schemas.test.ts
+++ b/test/unit/mcp-output-schemas.test.ts
@@ -343,7 +343,8 @@ describe("MCP tool calls return schema-valid structured content", () => {
     });
     const result = await client.callTool({ name: "loopover_get_ams_miner_cohort", arguments: { owner: "victim-org", repo: "private-repo" } });
     expect(result.isError).toBe(true);
-    expect(JSON.stringify(result.content)).toContain("maintainer access is required");
+    // (#8338) requireRepoAccess denial — matches sibling read tools (not the live-write approval-queue message).
+    expect(JSON.stringify(result.content)).toContain("session cannot access this repository");
     expect(result.structuredContent).toBeUndefined();
   });
 
@@ -515,7 +516,8 @@ describe("MCP tool calls return schema-valid structured content", () => {
     const result = await client.callTool({ name: "loopover_get_activation_preview", arguments: { owner: "victim-org", repo: "private-repo" } });
 
     expect(result.isError).toBe(true);
-    expect(JSON.stringify(result.content)).toContain("maintainer access is required");
+    // (#8338) requireRepoAccess denial — matches sibling read tools (not the live-write approval-queue message).
+    expect(JSON.stringify(result.content)).toContain("session cannot access this repository");
     expect(result.structuredContent).toBeUndefined();
   });
 
@@ -547,7 +549,8 @@ describe("MCP tool calls return schema-valid structured content", () => {
     const result = await client.callTool({ name: "loopover_get_maintainer_noise", arguments: { owner: "victim-org", repo: "private-repo" } });
 
     expect(result.isError).toBe(true);
-    expect(JSON.stringify(result.content)).toContain("maintainer access is required");
+    // (#8338) MEMBER on a non-installed repo does not grant requireRepoAccess scope; message matches sibling reads.
+    expect(JSON.stringify(result.content)).toContain("session cannot access this repository");
     expect(result.structuredContent).toBeUndefined();
   });
 

--- a/test/unit/mcp-read-report-gate-parity.test.ts
+++ b/test/unit/mcp-read-report-gate-parity.test.ts
@@ -1,0 +1,104 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { LoopoverMcp } from "../../src/mcp/server";
+import { getRepositoryCollaboratorPermission } from "../../src/github/app";
+import { upsertInstallation, upsertPullRequestFromGitHub, upsertRepositoryFromGitHub } from "../../src/db/repositories";
+import type { AuthIdentity } from "../../src/auth/security";
+import { createTestEnv } from "../helpers/d1";
+
+// #8338: getMaintainerNoise / getAmsMinerCohort / getActivationPreview must use requireRepoAccess
+// (cached maintainer/owner/operator scope), matching their REST mirrors and sibling read tools — not the
+// live-write requireRepoApprovalQueueAccess gate reserved for approval-queue / write tools.
+
+vi.mock("../../src/github/app", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/github/app")>()),
+  getRepositoryCollaboratorPermission: vi.fn(),
+  createInstallationToken: vi.fn(async () => "test-installation-token"),
+}));
+
+const mockedPermission = vi.mocked(getRepositoryCollaboratorPermission);
+
+const READ_REPORT_TOOLS = ["loopover_get_maintainer_noise", "loopover_get_ams_miner_cohort", "loopover_get_activation_preview"] as const;
+
+beforeEach(() => {
+  mockedPermission.mockReset();
+  // Fail closed on live collaborator lookup — the regression is that these three tools used to deny
+  // when this failed even though cached maintainer scope was enough for every sibling read tool.
+  mockedPermission.mockRejectedValue(new Error("github collaborator lookup unavailable"));
+});
+
+async function connect(env: Env, identity?: AuthIdentity) {
+  const server = (identity ? new LoopoverMcp(env, identity) : new LoopoverMcp(env)).createServer();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  const client = new Client({ name: "loopover-read-report-gate-test", version: "0.1.0" }, { capabilities: {} });
+  await client.connect(clientTransport);
+  return client;
+}
+
+async function seedOwnedRepo(env: Env): Promise<void> {
+  await upsertInstallation(env, {
+    installation: {
+      id: 5,
+      account: { login: "owner", id: 1, type: "User" },
+      repository_selection: "selected",
+      permissions: { metadata: "read", contents: "read", pull_requests: "read", issues: "read" },
+      events: ["pull_request"],
+    },
+    repositories: [{ name: "repo", full_name: "owner/repo", private: false, owner: { login: "owner" } }],
+  });
+  await upsertRepositoryFromGitHub(env, { name: "repo", full_name: "owner/repo", private: false, owner: { login: "owner" } }, 5);
+}
+
+describe("MCP read-only maintainer report gate parity (#8338)", () => {
+  it("REGRESSION (#8338): cached maintainer scope succeeds even when live collaborator lookup fails", async () => {
+    const env = createTestEnv();
+    await seedOwnedRepo(env);
+    // Cached COLLABORATOR association grants maintainer scope via canLoginAccessRepo / requireRepoAccess,
+    // but is intentionally insufficient for requireRepoApprovalQueueAccess (live write required).
+    await upsertPullRequestFromGitHub(env, "owner/repo", {
+      number: 7,
+      title: "x",
+      state: "open",
+      user: { login: "reader" },
+      author_association: "COLLABORATOR",
+      head: { sha: "sha" },
+    });
+
+    const client = await connect(env, { kind: "session", actor: "reader" } as AuthIdentity);
+    for (const name of READ_REPORT_TOOLS) {
+      const result = await client.callTool({ name, arguments: { owner: "owner", repo: "repo" } });
+      expect(result.isError, name).toBeFalsy();
+      const text = JSON.stringify(result);
+      expect(text, name).toContain("owner/repo");
+      expect(text, name).not.toMatch(/wallet|hotkey|raw trust|payout|reward estimate/i);
+    }
+    // Live lookup must not be required for these read tools after the fix (sibling write tools still use it).
+    expect(mockedPermission).not.toHaveBeenCalled();
+  });
+
+  it("rejects a session with no cached maintainer/owner scope on all three tools", async () => {
+    const env = createTestEnv();
+    await seedOwnedRepo(env);
+
+    const client = await connect(env, { kind: "session", actor: "rando" } as AuthIdentity);
+    for (const name of READ_REPORT_TOOLS) {
+      const result = await client.callTool({ name, arguments: { owner: "owner", repo: "repo" } });
+      expect(result.isError, name).toBe(true);
+      expect(JSON.stringify(result), name).toMatch(/Forbidden: session cannot access this repository/i);
+    }
+  });
+
+  it("allows the owning session when live collaborator lookup is unavailable", async () => {
+    const env = createTestEnv();
+    await seedOwnedRepo(env);
+
+    const client = await connect(env, { kind: "session", actor: "owner" } as AuthIdentity);
+    for (const name of READ_REPORT_TOOLS) {
+      const result = await client.callTool({ name, arguments: { owner: "owner", repo: "repo" } });
+      expect(result.isError, name).toBeFalsy();
+    }
+    expect(mockedPermission).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Closes #8338: `getMaintainerNoise`, `getAmsMinerCohort`, and `getActivationPreview` use `requireRepoAccess` (matching REST `requireRepoMaintainer` and sibling read tools), not live-write `requireRepoApprovalQueueAccess`.
- Updates `mcp-output-schemas` member-deny assertions to the `requireRepoAccess` error string (the mismatch failed CI shard 3 on #8375 and left Codecov patch at 0%).
- In-process regression: cached maintainer/owner succeeds when live collaborator lookup fails; non-maintainers still denied.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Focused: `mcp-read-report-gate-parity` (3) + affected `mcp-output-schemas` cases (6) all green after the denial-message fix. Full unsharded `test:coverage` deferred to Linux CI; prior #8375 failure was shard-3 test assertion mismatch, not missing handler coverage.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — MCP auth gate alignment only.

## Notes

- Replaces closed #8375 (shard failure from stale `maintainer access is required` expectations).