### PR TITLE
fix(auth): stop auditing routine device-flow polls as denied, mark access_denied correctly

### DIFF
--- a/src/auth/github-oauth.ts
+++ b/src/auth/github-oauth.ts
@@ -83,11 +83,18 @@ export async function pollGitHubDeviceFlow(env: Env, deviceCode: string) {
   });
   const tokenPayload = (await tokenResponse.json().catch(() => ({}))) as GitHubAccessTokenResponse;
   if ("error" in tokenPayload) {
-    await recordAuditEvent(env, {
-      eventType: "auth.github_device_poll",
-      outcome: tokenPayload.error === "authorization_pending" || tokenPayload.error === "slow_down" ? "denied" : "error",
-      detail: tokenPayload.error,
-    });
+    // #8378: `authorization_pending`/`slow_down` are RFC 8628's routine "still waiting on the browser step"
+    // responses — a single successful login polls this dozens of times — so they are not audit-worthy at all
+    // (auditing them as `denied` buried the one row that matters under ~180 rows of in-progress noise).
+    // `access_denied` IS the genuine user rejection and is the only `denied` here, matching how the sibling
+    // web-OAuth callback (routes.ts) treats an OAuth `error` param; every other terminal code stays `error`.
+    if (tokenPayload.error !== "authorization_pending" && tokenPayload.error !== "slow_down") {
+      await recordAuditEvent(env, {
+        eventType: "auth.github_device_poll",
+        outcome: tokenPayload.error === "access_denied" ? "denied" : "error",
+        detail: tokenPayload.error,
+      });
+    }
     return {
       status: tokenPayload.error,
       message: tokenPayload.error_description,

--- a/test/unit/auth.test.ts
+++ b/test/unit/auth.test.ts
@@ -1199,6 +1199,34 @@ describe("private-beta auth and rate limiting", () => {
     await expect(pollGitHubDeviceFlow(createTestEnv(), "device-code")).rejects.toThrow(/not_configured/);
   });
 
+  // #8378: routine polling used to write an `outcome: "denied"` audit row on EVERY poll (~180 per successful
+  // login), while the one genuine user rejection (`access_denied`) was filed as a generic `error`.
+  it("REGRESSION (#8378): audits only terminal device-poll errors, with access_denied as the sole 'denied'", async () => {
+    const env = createTestEnv({ GITHUB_OAUTH_CLIENT_ID: "client-id" });
+    const pollWith = async (error: string) => {
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) =>
+        input.toString().includes("access_token") ? Response.json({ error, error_description: `${error} desc` }) : Response.json({}),
+      );
+      return pollGitHubDeviceFlow(env, "device-code");
+    };
+    const auditRows = async () =>
+      (await env.DB.prepare("select detail, outcome from audit_events where event_type = ?").bind("auth.github_device_poll").all<{ detail: string; outcome: string }>()).results;
+
+    // Routine, non-terminal polling states write NO audit row at all...
+    for (const routine of ["authorization_pending", "slow_down"]) {
+      await expect(pollWith(routine)).resolves.toMatchObject({ status: routine, message: `${routine} desc` });
+    }
+    expect(await auditRows()).toEqual([]);
+
+    // ...the user actually declining is the one genuine `denied`...
+    await expect(pollWith("access_denied")).resolves.toMatchObject({ status: "access_denied", message: "access_denied desc" });
+    expect(await auditRows()).toEqual([{ detail: "access_denied", outcome: "denied" }]);
+
+    // ...and every other terminal code stays `error`, unchanged.
+    await expect(pollWith("expired_token")).resolves.toMatchObject({ status: "expired_token" });
+    expect(await auditRows()).toContainEqual({ detail: "expired_token", outcome: "error" });
+  });
+
   it("rejects invalid GitHub tokens when creating sessions", async () => {
     const env = createTestEnv();
     vi.stubGlobal("fetch", async () => Response.json({ message: "bad credentials" }, { status: 401 }));


### PR DESCRIPTION
## Summary
`pollGitHubDeviceFlow` (`src/auth/github-oauth.ts`) audited **every** non-success device-token response, categorising RFC 8628's routine polling states as `denied` and the one genuine user rejection as a generic `error` — exactly backwards from how `outcome: "denied"` is used everywhere else in the codebase.

- `authorization_pending` / `slow_down` — the expected response on nearly every poll of a login still in progress (~180 rows per successful login at the 5s interval over the 900s window) — now write **no audit row at all**. They carry no information beyond "keep polling", so they aren't audit-worthy.
- `access_denied` — the actual "user declined" signal — is now the sole `outcome: "denied"`, matching how the sibling web-OAuth callback in `routes.ts` treats an OAuth `error` param.
- Every other terminal code (`expired_token`, `bad_verification_code`, `incorrect_client_credentials`, or anything else GitHub returns) keeps `outcome: "error"`, unchanged.

Audit-categorisation only: the returned `{ status, message }` shape, the token issued, the scopes granted, and every caller of `/v1/auth/github/device/poll` are all untouched.

Closes #8378

## Test plan
- [x] New regression test in `test/unit/auth.test.ts` asserting all three arms: both routine states produce **zero** `auth.github_device_poll` rows while still returning their `{ status, message }`; `access_denied` produces exactly one row with `outcome: "denied"`; `expired_token` still records `outcome: "error"`
- [x] The existing `pollGitHubDeviceFlow` coverage passes **unmodified** — including its `bad_verification_code` → `outcome: "error"` assertion and its `authorization_pending`/`slow_down` return-value assertions (this change is additive to expectations, it weakens nothing)
- [x] `test/unit/auth.test.ts` green (37/37); every changed line and both new branch arms are covered — the diff hunk (`src/auth/github-oauth.ts` lines 86-97) contains none of the file's pre-existing uncovered lines/branches
- [x] `npm run typecheck` clean
- [ ] CI validate