### PR TITLE
fix(github): reject malformed repoFullName in app.ts and comments.ts

### DIFF
--- a/src/github/app.ts
+++ b/src/github/app.ts
@@ -437,14 +437,30 @@ export type GitHubRepositoryCollaboratorPermission =
   | "none"
   | string;
 
+// Parse `owner/repo` into its two segments, rejecting any shape that is not exactly two non-empty,
+// whitespace-free segments -- the identical guard every sibling GitHub-write module in this directory keeps
+// its own local copy of (assignees.ts / labels.ts / issues.ts / milestones.ts, per this dir's house
+// convention). "owner/repo/extra" would otherwise silently drop the extra segment and hit a different repo;
+// "owner/ repo" / " owner/repo" would get encodeURIComponent-ed straight into a GitHub URL. Returns null so
+// each caller can map a malformed value to its own established failure contract (return null / error object /
+// throw) rather than sharing one.
+function parseRepoFullNameStrict(repoFullName: string): { owner: string; repo: string } | null {
+  const parts = repoFullName.split("/");
+  const owner = parts[0];
+  const repo = parts[1];
+  if (parts.length !== 2 || !owner || !repo || /\s/.test(repoFullName)) return null;
+  return { owner, repo };
+}
+
 export async function getRepositoryCollaboratorPermission(
   env: Env,
   installationId: number,
   repoFullName: string,
   login: string,
 ): Promise<GitHubRepositoryCollaboratorPermission | null> {
-  const [owner, name] = repoFullName.split("/");
-  if (!owner || !name || !login) return null;
+  const parsed = parseRepoFullNameStrict(repoFullName);
+  if (!parsed || !login) return null;
+  const { owner, repo: name } = parsed;
   const token = await createInstallationToken(env, installationId);
   const response = await timeoutFetch(
     `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/collaborators/${encodeURIComponent(login)}/permission`,
@@ -617,8 +633,9 @@ export async function cancelInFlightWorkflowRunsForHeadSha(
   headSha: string,
   pullNumber: number,
 ): Promise<CancelWorkflowRunsOutcome> {
-  const [owner, repo] = repoFullName.split("/");
-  if (!owner || !repo) return { kind: "error", warning: `Invalid repository full name: ${repoFullName}` };
+  const parsed = parseRepoFullNameStrict(repoFullName);
+  if (!parsed) return { kind: "error", warning: `Invalid repository full name: ${repoFullName}` };
+  const { owner, repo } = parsed;
   const repoPath = `${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
   try {
     const token = await createInstallationToken(env, installationId);
@@ -908,9 +925,9 @@ async function createOrUpdateNamedCheckRun(
   if (!advisory.headSha) return null;
   // Narrow once into a const so the postNewCheckRun closure below sees a string, not string | undefined.
   const headSha = advisory.headSha;
-  const [owner, repo] = repoFullName.split("/");
-  if (!owner || !repo)
-    throw new Error(`Invalid repository full name: ${repoFullName}`);
+  const parsed = parseRepoFullNameStrict(repoFullName);
+  if (!parsed) throw new Error(`Invalid repository full name: ${repoFullName}`);
+  const { owner, repo } = parsed;
 
   return await withInstallationTokenRetry(env, installationId, async (token) => {
     // makeInstallationOctokit injects the shared per-request timeout (a stalled PATCH can never orphan the

--- a/src/github/comments.ts
+++ b/src/github/comments.ts
@@ -86,8 +86,11 @@ async function createOrUpdateIssueCommentWithMarker(
   const repo = parts[1];
   // Reject anything that is not exactly two non-empty segments -- "owner/repo/extra" would otherwise pass
   // (the destructure silently drops the extra segment), issuing a call against a repo the caller never
-  // specified. Matches the segment-count guard in parseRepoFullName (assignees.ts / labels.ts).
-  if (parts.length !== 2 || !owner || !repo) throw new Error(`Invalid repository full name: ${repoFullName}`);
+  // specified -- and additionally reject whitespace (`owner/ repo`, ` owner/repo`) so a padded slug can never
+  // reach a GitHub call. Matches the full segment-count + whitespace guard in parseRepoFullName
+  // (assignees.ts / labels.ts, #6613).
+  if (parts.length !== 2 || !owner || !repo || /\s/.test(repoFullName))
+    throw new Error(`Invalid repository full name: ${repoFullName}`);
 
   return await withInstallationTokenRetry(env, installationId, async (token) => {
     // Non-live mode suppresses the comment create/update writes; the GET marker-search probe below still runs.

--- a/test/unit/github-app.test.ts
+++ b/test/unit/github-app.test.ts
@@ -2855,3 +2855,45 @@ describe("GitHub rate-limit handling (#ratelimit-resilience)", () => {
     expect(calls).toBe(4); // initial + GITHUB_RATE_LIMIT_MAX_RETRIES (3)
   });
 });
+
+describe("repoFullName segment-count + whitespace guard (#8311)", () => {
+  // Each of these malformed shapes must be rejected at every app.ts call site the same way the existing
+  // "invalid" (no-slash) case already is, matching the guard pr-actions.ts/assignees.ts/labels.ts share.
+  // The rejects happen before any GitHub call, so no fetch stub is needed. Inputs collectively exercise all
+  // four operands of the guard: parts.length !== 2 ("owner/repo/extra"), !owner ("/repo"), !repo ("owner/"),
+  // and the whitespace check ("owner/ repo", " owner/repo").
+  const MALFORMED = ["owner/repo/extra", "owner/ repo", " owner/repo", "/repo", "owner/"];
+
+  it("getRepositoryCollaboratorPermission returns null for extra-segment and whitespace-padded slugs", async () => {
+    const privateKey = await generatePrivateKeyPem();
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey });
+    for (const repoFullName of MALFORMED) {
+      await expect(
+        getRepositoryCollaboratorPermission(env, 123, repoFullName, "maintainer"),
+      ).resolves.toBeNull();
+    }
+    // A well-formed slug still passes the guard (and only then fails downstream on the un-stubbed fetch).
+    await expect(
+      getRepositoryCollaboratorPermission(env, 123, "JSONbored/gittensory", "maintainer"),
+    ).rejects.toThrow();
+  });
+
+  it("cancelInFlightWorkflowRunsForHeadSha returns an error outcome for extra-segment and whitespace-padded slugs", async () => {
+    const privateKey = await generatePrivateKeyPem();
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey });
+    for (const repoFullName of ["owner/repo/extra", "owner/ repo"]) {
+      const outcome = await cancelInFlightWorkflowRunsForHeadSha(env, 123, repoFullName, "abc123", 55);
+      expect(outcome).toEqual({ kind: "error", warning: `Invalid repository full name: ${repoFullName}` });
+    }
+  });
+
+  it("createOrUpdateCheckRun (createOrUpdateNamedCheckRun) throws for extra-segment and whitespace-padded slugs", async () => {
+    const privateKey = await generatePrivateKeyPem();
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey });
+    for (const repoFullName of ["owner/repo/extra", "owner/ repo"]) {
+      await expect(
+        createOrUpdateCheckRun(env, 123, repoFullName, gateAdvisory("abc123")),
+      ).rejects.toThrow(`Invalid repository full name: ${repoFullName}`);
+    }
+  });
+});

--- a/test/unit/github-comments.test.ts
+++ b/test/unit/github-comments.test.ts
@@ -519,3 +519,19 @@ async function generatePrivateKeyPem(): Promise<string> {
   const base64 = Buffer.from(exported as ArrayBuffer).toString("base64").replace(/(.{64})/g, "$1\n");
   return `-----BEGIN PRIVATE KEY-----\n${base64}\n-----END PRIVATE KEY-----`;
 }
+
+describe("createOrUpdateIssueCommentWithMarker repoFullName guard (#8311)", () => {
+  // The existing segment-count guard now also rejects whitespace, matching pr-actions.ts/assignees.ts/
+  // labels.ts (#6613). These malformed shapes reject before any GitHub call (no fetch stub needed) and
+  // collectively exercise all four operands: parts.length !== 2 ("owner/repo/extra"), !owner ("/repo"),
+  // !repo ("owner/"), and the newly-added whitespace check ("owner/ repo", " owner/repo").
+  it("throws for extra-segment and whitespace-padded slugs", async () => {
+    const privateKey = await generatePrivateKeyPem();
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey });
+    for (const repoFullName of ["owner/repo/extra", "/repo", "owner/", "owner/ repo", " owner/repo"]) {
+      await expect(
+        createOrUpdatePrIntelligenceComment(env, 123, repoFullName, 12, `${PR_INTELLIGENCE_COMMENT_MARKER}\nbody`),
+      ).rejects.toThrow(`Invalid repository full name: ${repoFullName}`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- `src/github/app.ts`'s three GitHub-write call sites did a bare two-variable destructure with only a truthiness check, so two failure modes every sibling module in `src/github/` already rejects got through: `"owner/repo/extra"` silently dropped the extra segment and issued the call against a **different repo** than the caller named, and a padded `"owner/ repo"` / `" owner/repo"` was `encodeURIComponent`-ed straight into a GitHub API URL.
  - `getRepositoryCollaboratorPermission` (:446), `cancelInFlightWorkflowRunsForHeadSha` (:620), `createOrUpdateNamedCheckRun` (:911 — the function backing every `createOrUpdate*GateCheckRun`/`createOrUpdateCheckRun`, i.e. the gate-check-posting path).
- `src/github/comments.ts` (`createOrUpdateIssueCommentWithMarker`) had the segment-count guard but was missing the `/\s/` whitespace check that `pr-actions.ts`/`assignees.ts`/`labels.ts` gained under #6613.
- Adds a small **local** `parseRepoFullNameStrict` helper inside `app.ts`, reused by its own three call sites, per this directory's stated house convention of a per-module copy of this tiny pure check rather than a shared cross-file export (`issues.ts:5-15`'s own comment). It returns `null` so each call site maps a malformed value to its **existing, unchanged** failure contract:
  - `getRepositoryCollaboratorPermission` → returns `null`
  - `cancelInFlightWorkflowRunsForHeadSha` → returns `{ kind: "error", warning: … }`
  - `createOrUpdateNamedCheckRun` → throws `Invalid repository full name: …`
  - `createOrUpdateIssueCommentWithMarker` → throws (already did; only the whitespace condition was added)
- No behavior change for any well-formed `owner/repo` value.
- Regression tests at all four call sites (`test/unit/github-app.test.ts`, `test/unit/github-comments.test.ts`) assert `"owner/repo/extra"` and whitespace-padded slugs are rejected exactly like the existing no-slash `"invalid"` case, and collectively exercise all four operands of the guard (`parts.length !== 2`, `!owner`, `!repo`, `/\s/`) plus the valid-input path.

Closes #8311

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This diff touches only `src/github/app.ts`, `src/github/comments.ts` and their two root test suites, so `actionlint` (no workflow change), `build:mcp`/`test:mcp-pack` (no MCP change), `ui:openapi:check`/`ui:lint`/`ui:typecheck`/`ui:build` (no UI or OpenAPI/route change), `test:workers` (no worker change), and `npm audit` (no dependency change) are not exercised by it.
- **Diff coverage verified at 100%**, lines *and* branches, via the scoped simulation CI actually runs (`vitest run --coverage --coverage.all=false --changed=origin/main`): the resulting `coverage/lcov.info` is non-empty, contains both changed source files, and every executable changed line and branch in them is hit (0 uncovered). `test/unit/github-app.test.ts` + `test/unit/github-comments.test.ts` pass in full (113 tests). Root `tsc --noEmit` is clean.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — backend-only input-validation hardening in `src/github/`; no visible UI, frontend, docs, or extension change.

## Notes

- This is a defense-in-depth tightening, not a bug with a known live trigger: every in-repo caller already passes a well-formed `owner/repo`, so no existing behavior changes. The value is closing the last inconsistency in this boundary — `pr-actions.ts`, `assignees.ts`, `labels.ts`, `issues.ts`, and `milestones.ts` all already reject these shapes, and `app.ts` carries the heaviest GitHub-write traffic (installation tokens, check-run creation, workflow-run cancellation).
- Per the issue's required pattern, no new shared cross-module helper was introduced in `client.ts` or elsewhere; the guard is a local helper within `app.ts` (its three call sites share a file) and an inline condition in `comments.ts`, matching the five existing per-module copies.
