### PR TITLE
fix(db): add $defaultFn(nowIso) to upstreamDriftReports.updatedAt

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1034,7 +1034,9 @@ export const upstreamDriftReports = sqliteTable(
     issueUrl: text("issue_url"),
     payloadJson: text("payload_json").notNull().default("{}"),
     generatedAt: text("generated_at").notNull(),
-    updatedAt: text("updated_at").notNull(),
+    // Same $defaultFn house rule as every sibling updatedAt (#8369): an insert that omits the column
+    // must get a real ISO-8601 timestamp, not a schema-level gap waiting for a future writer to trip over.
+    updatedAt: text("updated_at").notNull().$defaultFn(() => nowIso()),
   },
   (table) => ({
     fingerprint: uniqueIndex("upstream_drift_reports_fingerprint_unique").on(table.fingerprint),

--- a/test/unit/schema-timestamp-defaults.test.ts
+++ b/test/unit/schema-timestamp-defaults.test.ts
@@ -1,7 +1,15 @@
 import { eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { getDb } from "../../src/db/client";
-import { aiReviewCache, aiSlopCache, linkedIssueSatisfactionCache, orbRelayPending, repositorySettings, webhookEvents } from "../../src/db/schema";
+import {
+  aiReviewCache,
+  aiSlopCache,
+  linkedIssueSatisfactionCache,
+  orbRelayPending,
+  repositorySettings,
+  upstreamDriftReports,
+  webhookEvents,
+} from "../../src/db/schema";
 import { createTestEnv } from "../helpers/d1";
 
 const ISO = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
@@ -101,5 +109,28 @@ describe("timestamp column defaults", () => {
     const [row] = await db.select().from(linkedIssueSatisfactionCache).where(eq(linkedIssueSatisfactionCache.repoFullName, "acme/widgets")).limit(1);
     expect(row?.createdAt).toMatch(ISO);
     expect(row?.createdAt).not.toBe("CURRENT_TIMESTAMP");
+  });
+
+  it("applies upstreamDriftReports.updatedAt default on omit (#8369)", async () => {
+    const env = createTestEnv();
+    const db = getDb(env.DB);
+    // Omit updatedAt — the schema $defaultFn must inject a real ISO timestamp (same house rule as every
+    // sibling updatedAt). generatedAt stays explicit; this issue only covers the updatedAt gap.
+    await db.insert(upstreamDriftReports).values({
+      id: "drift-ts-default-1",
+      fingerprint: "fp-ts-default-1",
+      severity: "low",
+      summary: "schema defaultFn regression",
+      generatedAt: "2026-07-24T00:00:00.000Z",
+    });
+    const [row] = await db
+      .select()
+      .from(upstreamDriftReports)
+      .where(eq(upstreamDriftReports.id, "drift-ts-default-1"))
+      .limit(1);
+    expect(row?.updatedAt).toMatch(ISO);
+    expect(row?.updatedAt).not.toBe("CURRENT_TIMESTAMP");
+    expect(row?.updatedAt).not.toBe("");
+    expect(row?.generatedAt).toBe("2026-07-24T00:00:00.000Z");
   });
 });


### PR DESCRIPTION
## What

`upstreamDriftReports.updatedAt` was the only `updatedAt` in `src/db/schema.ts` missing `.$defaultFn(() => nowIso())`, despite the file header's house rule (and ~30 sibling columns that already follow it). Current writers always pass `updatedAt` explicitly, so nothing breaks today — but any future insert that omits the column would hit the same client-side corruption class the header documents.

## Changes

- Added `.$defaultFn(() => nowIso())` to `upstreamDriftReports.updatedAt` only — `generatedAt` and repository writers left untouched.
- Regression in `test/unit/schema-timestamp-defaults.test.ts`: drizzle insert that omits `updatedAt` gets a real ISO-8601 timestamp (not `CURRENT_TIMESTAMP` / empty).

## Closes

Closes #8369

## Verification

- `npx vitest run test/unit/schema-timestamp-defaults.test.ts` — 7 passed (including the new omit-path case)
