### PR TITLE
fix(config-lint): recognize fairnessAnalytics as a top-level field

### DIFF
--- a/packages/loopover-engine/src/config-lint.ts
+++ b/packages/loopover-engine/src/config-lint.ts
@@ -28,6 +28,7 @@ const TOP_LEVEL_FIELDS = [
   "activeReviewReconciliation",
   "loopEscalation",
   "federatedIntelligence",
+  "fairnessAnalytics",
 ] as const;
 
 const TOP_LEVEL_FIELD_SET = new Set<string>(TOP_LEVEL_FIELDS);

--- a/test/unit/selfhost-config-lint.test.ts
+++ b/test/unit/selfhost-config-lint.test.ts
@@ -86,6 +86,16 @@ reviewRecap:
     expect(result.recognizedFields).toEqual(["experimental"]);
   });
 
+  it("REGRESSION: recognizes a standalone fairnessAnalytics: block instead of flagging it as unknown (#8365)", () => {
+    // fairnessAnalytics is fully parsed by focus-manifest.ts but was missing from TOP_LEVEL_FIELDS,
+    // so operators got a spurious unknown-field warning for a supported config-as-code block.
+    const result = lintManifestText("fairnessAnalytics:\n  enabled: true\n");
+
+    expect(result.ok).toBe(true);
+    expect(result.warnings).toEqual([]);
+    expect(result.recognizedFields).toEqual(["fairnessAnalytics"]);
+  });
+
   it("recognizes a standalone reviewRecap: block instead of flagging it as unknown (#1963)", () => {
     const result = lintManifestText("reviewRecap:\n  enabled: true\n  cadenceDays: 14\n");
 


### PR DESCRIPTION
## Summary
\`fairnessAnalytics\` is parsed by \`focus-manifest.ts\` but was missing from \`TOP_LEVEL_FIELDS\` in \`config-lint.ts\`, producing a false \"unknown top-level field\" warning.

Closes #8365

## Test plan
- [x] Regression in \`selfhost-config-lint.test.ts\`

Made with [Cursor](https://cursor.com)