### PR TITLE
test(calibration): make signal-tracking's real coverage visible to Codecov

### DIFF
--- a/test/unit/signal-tracking.test.ts
+++ b/test/unit/signal-tracking.test.ts
@@ -1,0 +1,165 @@
+// Root-level vitest coverage twin for `packages/loopover-engine/src/calibration/signal-tracking.ts` (#7982).
+//
+// The engine package already has a full, passing `node --test` suite at
+// `packages/loopover-engine/test/signal-tracking.test.ts`, but that runner is NOT part of the root vitest run
+// Codecov reads `codecov/patch` from — so `computeRulePrecision`/`computeRuleRepeatCount`/
+// `evaluateRuleRepeatAlarm` report as ~0% covered despite being genuinely tested (#8343, same blind spot as
+// #6250). This file re-exercises the same behavior through the engine barrel so vitest (and therefore Codecov)
+// sees it too, exactly like the sibling twins `test/unit/calibration-dashboard.test.ts` and
+// `test/unit/discovery-soft-claim.test.ts`. It intentionally mirrors every scenario in the package's own suite
+// and covers both arms of every branch in the three functions.
+import { describe, expect, it } from "vitest";
+import {
+  computeRulePrecision,
+  computeRuleRepeatCount,
+  evaluateRuleRepeatAlarm,
+} from "../../packages/loopover-engine/src/index";
+import type { HumanOverrideEvent, RuleFiredEvent } from "../../packages/loopover-engine/src/index";
+
+function fired(ruleId: string, targetKey: string, overrides: Partial<RuleFiredEvent> = {}): RuleFiredEvent {
+  return { ruleId, targetKey, outcome: "block", occurredAt: "2026-07-22T00:00:00.000Z", ...overrides };
+}
+
+function override(
+  ruleId: string,
+  targetKey: string,
+  verdict: HumanOverrideEvent["verdict"],
+  overrides: Partial<HumanOverrideEvent> = {},
+): HumanOverrideEvent {
+  return { ruleId, targetKey, verdict, occurredAt: "2026-07-22T00:00:00.000Z", ...overrides };
+}
+
+describe("barrel: signal-tracking primitives are re-exported from the engine entrypoint (#7982/#7983)", () => {
+  it("exposes the three primitives as functions", () => {
+    expect(typeof computeRulePrecision).toBe("function");
+    expect(typeof computeRuleRepeatCount).toBe("function");
+    expect(typeof evaluateRuleRepeatAlarm).toBe("function");
+  });
+});
+
+describe("computeRulePrecision", () => {
+  it("no overrides -> decided is 0 and precision is null (unknown stays unknown, never coerced)", () => {
+    const report = computeRulePrecision(
+      "missing_linked_issue",
+      [fired("missing_linked_issue", "a#1"), fired("missing_linked_issue", "a#2")],
+      [],
+    );
+    expect(report).toEqual({
+      ruleId: "missing_linked_issue",
+      fired: 2,
+      reversed: 0,
+      confirmed: 0,
+      decided: 0,
+      precision: null,
+    });
+  });
+
+  it("mixes confirmed and reversed verdicts into a real precision (decided > 0 arm)", () => {
+    const report = computeRulePrecision(
+      "missing_linked_issue",
+      [
+        fired("missing_linked_issue", "a#1"),
+        fired("missing_linked_issue", "a#2"),
+        fired("missing_linked_issue", "a#3"),
+      ],
+      [
+        override("missing_linked_issue", "a#1", "confirmed"),
+        override("missing_linked_issue", "a#2", "confirmed"),
+        override("missing_linked_issue", "a#3", "reversed"),
+      ],
+    );
+    expect(report.fired).toBe(3);
+    expect(report.confirmed).toBe(2);
+    expect(report.reversed).toBe(1);
+    expect(report.decided).toBe(3);
+    expect(report.precision).toBe(2 / 3);
+  });
+
+  it("100% reversed yields precision 0, not null (a real, scored bad outcome, not an unknown one)", () => {
+    const report = computeRulePrecision("bad_rule", [fired("bad_rule", "a#1")], [override("bad_rule", "a#1", "reversed")]);
+    expect(report.decided).toBe(1);
+    expect(report.precision).toBe(0);
+  });
+
+  it("ignores fired/override events for a DIFFERENT ruleId entirely (both operand branches)", () => {
+    const report = computeRulePrecision(
+      "rule_a",
+      [fired("rule_a", "a#1"), fired("rule_b", "a#2")],
+      [override("rule_a", "a#1", "confirmed"), override("rule_b", "a#2", "reversed")],
+    );
+    expect(report.fired).toBe(1);
+    expect(report.confirmed).toBe(1);
+    expect(report.reversed).toBe(0);
+  });
+
+  it("an override with no matching fired event still counts toward decided (no cross-validation between the two lists)", () => {
+    const report = computeRulePrecision("rule_a", [], [override("rule_a", "a#1", "confirmed")]);
+    expect(report.fired).toBe(0);
+    expect(report.decided).toBe(1);
+    expect(report.precision).toBe(1);
+  });
+});
+
+describe("computeRuleRepeatCount", () => {
+  it("counts only fires matching BOTH ruleId and targetKey (each && operand's false arm exercised)", () => {
+    const events = [
+      fired("rule_a", "a#1"),
+      fired("rule_a", "a#1"),
+      fired("rule_a", "a#2"), // same rule, different target -> targetKey operand false
+      fired("rule_b", "a#1"), // different rule, same target -> ruleId operand false
+    ];
+    expect(computeRuleRepeatCount("rule_a", "a#1", events)).toBe(2);
+    expect(computeRuleRepeatCount("rule_a", "a#2", events)).toBe(1);
+    expect(computeRuleRepeatCount("rule_b", "a#1", events)).toBe(1);
+    expect(computeRuleRepeatCount("rule_a", "a#3", events)).toBe(0);
+  });
+
+  it("zero fired events yields 0, not an error", () => {
+    expect(computeRuleRepeatCount("rule_a", "a#1", [])).toBe(0);
+  });
+});
+
+describe("evaluateRuleRepeatAlarm (#7983)", () => {
+  it("not triggered below the threshold", () => {
+    const verdict = evaluateRuleRepeatAlarm("rule_a", [fired("rule_a", "a#1"), fired("rule_a", "a#2")], 3);
+    expect(verdict.triggered).toBe(false);
+    expect(verdict.affectedTargets).toEqual(["a#1", "a#2"]);
+    expect(verdict.threshold).toBe(3);
+  });
+
+  it("triggers once distinct targets reach the threshold (boundary: exactly `threshold` distinct targets)", () => {
+    const verdict = evaluateRuleRepeatAlarm(
+      "rule_a",
+      [fired("rule_a", "a#1"), fired("rule_a", "a#2"), fired("rule_a", "a#3")],
+      3,
+    );
+    expect(verdict.triggered).toBe(true);
+    expect(verdict.affectedTargets).toEqual(["a#1", "a#2", "a#3"]);
+  });
+
+  it("the SAME target firing repeatedly counts once, deduplicated in first-seen order (seen.has arm)", () => {
+    const verdict = evaluateRuleRepeatAlarm(
+      "rule_a",
+      [fired("rule_a", "a#1"), fired("rule_a", "a#1"), fired("rule_a", "a#1")],
+      2,
+    );
+    expect(verdict.affectedTargets).toEqual(["a#1"]);
+    expect(verdict.triggered).toBe(false);
+  });
+
+  it("ignores fired events for a DIFFERENT ruleId entirely (ruleId mismatch arm)", () => {
+    const verdict = evaluateRuleRepeatAlarm(
+      "rule_a",
+      [fired("rule_a", "a#1"), fired("rule_b", "a#2"), fired("rule_b", "a#3")],
+      2,
+    );
+    expect(verdict.affectedTargets).toEqual(["a#1"]);
+    expect(verdict.triggered).toBe(false);
+  });
+
+  it("zero fired events never triggers", () => {
+    const verdict = evaluateRuleRepeatAlarm("rule_a", [], 1);
+    expect(verdict.triggered).toBe(false);
+    expect(verdict.affectedTargets).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- `packages/loopover-engine/src/calibration/signal-tracking.ts` (#7982) — `computeRulePrecision`, `computeRuleRepeatCount`, and `evaluateRuleRepeatAlarm` — is fully exercised by the engine package's own `node --test` suite (`packages/loopover-engine/test/signal-tracking.test.ts`), but that runner is **not** part of the root `vitest` run Codecov reads `codecov/patch` from, so the module reports as ~0% covered in Codecov's eyes despite being genuinely tested. Same blind spot as #6250 (`review-enrichment`); `packages/loopover-engine/src/**` is already in `vitest.config.ts`'s `coverage.include`, so the fix is per-file test coverage, not a wiring change.
- Adds one root-level vitest twin, `test/unit/signal-tracking.test.ts`, importing the three primitives via the engine barrel (`../../packages/loopover-engine/src/index`) and re-exercising every scenario the package suite covers — mirroring the existing sibling twins `test/unit/calibration-dashboard.test.ts` and `test/unit/discovery-soft-claim.test.ts`.
- **Test-only.** No change to any file under `packages/loopover-engine/src/**` or `packages/loopover-engine/test/**` — the only new artifact is the one vitest file the issue calls for.

Covers both arms of every branch in the three functions: `computeRulePrecision` (fired-rule filter both arms, override rule match/no-match, `reversed`/`confirmed` verdicts, `decided > 0 ? … : null` both arms), `computeRuleRepeatCount` (both `&&` operands' false arms via same-rule-different-target and same-target-different-rule, plus the empty-list case), and `evaluateRuleRepeatAlarm` (below/at threshold boundary, `seen`-dedup first-seen order, other-`ruleId` exclusion, empty list). Locally this brings the source module to 100% line + branch under vitest.

Closes #8343

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes — it is a single new test file.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves — `Closes #8343`.

## Validation

- [x] `git diff --check` — clean (no whitespace errors on the diff).
- [ ] `npm run actionlint` — N/A: no GitHub Actions workflow or composite-action changes.
- [x] `npm run typecheck` — green (after `npm run build --workspace @loopover/engine`, as the root `test:ci` sequence does before typecheck).
- [x] `npm run test:coverage` locally — green; the new file passes (13 tests) and reports 100% line + branch coverage of `signal-tracking.ts`. **`codecov/patch` note:** this PR changes **zero** lines under `src/**` (it only adds a `test/**` file), so `codecov/patch` has no changed production lines to grade — the coverage this adds is what makes a *future* PR touching `signal-tracking.ts` gate correctly.
- [ ] `npm run test:workers` — N/A: no worker code changed; this adds a root vitest unit test only.
- [ ] `npm run build:mcp` / `npm run test:mcp-pack` — N/A: no MCP changes.
- [ ] `npm run ui:openapi:check` / `npm run ui:lint` / `npm run ui:typecheck` / `npm run ui:build` — N/A: no UI, API, or OpenAPI surface changed.
- [ ] `npm audit --audit-level=moderate` — not run locally (the local sandbox's audit endpoint returns a lockfile 400); this PR makes **no dependency changes** (`package.json` / lockfiles untouched), so it cannot affect the audit result. CI runs it against a clean install.
- [x] New or changed behavior has unit tests — this PR *is* the added test coverage for existing, currently-Codecov-invisible behavior; no production behavior changed.

If any required check was skipped, explain why:

- All skipped checks are N/A for a test-only PR that adds a single root-level vitest file with no production, UI, MCP, API, workflow, or dependency changes (explanations inline above).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, private keys, trust scores, private rankings, or maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and implies no compensation or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests — N/A: none of these changed.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed — N/A: none changed.
- [x] UI changes use live API data / real empty/error/loading states — N/A: no UI changes.
- [x] Public docs/changelogs are updated where needed; `CHANGELOG.md` not edited (not a release-prep PR).

## Notes

- The test imports the primitives from the engine **barrel** (`../../packages/loopover-engine/src/index`), not via a relative path into the source file, matching every existing sibling root-level engine test.
- No behavior of `signal-tracking.ts` was changed, and its own `node --test` suite was left untouched, as the issue requires.
