### PR TITLE
fix(scripts): include jwt in FORBIDDEN_CONTENT hard-block detector

### DIFF
--- a/scripts/forbidden-content.ts
+++ b/scripts/forbidden-content.ts
@@ -10,10 +10,11 @@
 // false-positive" subset). They are NOT imported directly: this file is a plain `.mjs` run via `node`
 // (test:miner-pack / test:mcp-pack), and secret-patterns.ts is TypeScript with no runtime `.js` sibling on this
 // path — a runtime `import` of it from node would fail, so the exact bodies are copied per the issue's stated
-// fallback. `jwt`, `seed_or_mnemonic`, and `bittensor_key` are deliberately NOT included: jwt is out of scope
-// for #7433, and seed_or_mnemonic/bittensor_key are documented in secret-patterns.ts as weak, false-positive-
-// prone heuristics intentionally excluded from HARD_SECRET_KINDS (an ordinary `coldkey:` / `hotkey =` line or
-// the word "mnemonic" in Bittensor docs is not a leaked credential).
+// fallback. `seed_or_mnemonic` and `bittensor_key` are deliberately NOT included: they are documented in
+// secret-patterns.ts as weak, false-positive-prone heuristics intentionally excluded from HARD_SECRET_KINDS
+// (an ordinary `coldkey:` / `hotkey =` line or the word "mnemonic" in Bittensor docs is not a leaked
+// credential). `jwt` IS in HARD_SECRET_KINDS today and is included here so packaged tarballs get the same
+// hard-block coverage as PR-diff / content-lane scanners (#8396).
 export const FORBIDDEN_CONTENT: RegExp = new RegExp(
   [
     // Already covered before #7433 (unchanged shapes):
@@ -35,5 +36,6 @@ export const FORBIDDEN_CONTENT: RegExp = new RegExp(
     "\\bfc-[A-Za-z0-9]{16,}(?![A-Za-z0-9_-])", // firecrawl_api_key
     "\\bsk-(?:proj-|svcacct-|admin-)?[A-Za-z0-9_-]{20,}T3BlbkFJ[A-Za-z0-9_-]{20,}\\b", // openai_api_key
     "\\bsk-ant-api03-[A-Za-z0-9_-]{93}AA\\b", // anthropic_api_key
+    "\\beyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}\\b", // jwt (#8396)
   ].join("|"),
 );

--- a/test/unit/forbidden-content.test.ts
+++ b/test/unit/forbidden-content.test.ts
@@ -119,13 +119,16 @@ describe("FORBIDDEN_CONTENT covers the concrete provider-key formats (#7433)", (
     expect(FORBIDDEN_CONTENT.test("MY" + "_TOKEN=" + "x")).toBe(true);
   });
 
-  it("does NOT hard-block the deliberately-excluded weak heuristics (jwt / seed / bittensor key shapes)", () => {
-    // These are intentionally kept out of the packaged-secret hard block (#7433) — an ordinary Bittensor
-    // coldkey/hotkey mention or a mnemonic word is not a leaked credential; a bare JWT is out of scope.
+  it("matches a jwt-shaped value (#8396)", () => {
+    // jwt is in HARD_SECRET_KINDS; packaged tarballs must catch the same shape.
+    expect(FORBIDDEN_CONTENT.test("eyJ" + A(20) + "." + a(20) + "." + a(20))).toBe(true);
+  });
+
+  it("does NOT hard-block the deliberately-excluded weak heuristics (seed / bittensor key shapes)", () => {
+    // These remain out of the packaged-secret hard block — ordinary Bittensor coldkey/hotkey
+    // mentions or a mnemonic word are not leaked credentials.
     expect(FORBIDDEN_CONTENT.test("coldkey: my-wallet-name")).toBe(false);
     expect(FORBIDDEN_CONTENT.test("the recovery mnemonic is stored offline")).toBe(false);
-    // A bare header-dot-payload JWT shape is not matched by the hard-block detector.
-    expect(FORBIDDEN_CONTENT.test("eyJ" + A(20) + "." + a(20) + "." + a(20))).toBe(false);
     expect(FORBIDDEN_CONTENT.global).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
\`jwt\` is in \`HARD_SECRET_KINDS\` but \`scripts/forbidden-content.ts\` omitted it, so miner/mcp pack checks missed JWT-shaped credentials.

Add the exact \`jwt\` regex from \`secret-patterns.ts\` and correct the header. \`seed_or_mnemonic\` / \`bittensor_key\` remain excluded.

Closes #8396

## Test plan
- [x] \`forbidden-content.test.ts\` — jwt matches; seed/bittensor still excluded

Made with [Cursor](https://cursor.com)