### PR TITLE
fix(github): stop the open-issues GraphQL supplement when endCursor is missing

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -1828,7 +1828,7 @@ async function supplementOpenIssuesFromGraphQl(env: Env, repo: RepositoryRecord,
       existingNumbers.add(issue.number);
       supplemented += 1;
     }
-    if (!issues?.pageInfo?.hasNextPage) break;
+    if (!issues?.pageInfo?.hasNextPage || !issues.pageInfo.endCursor) break;
     after = `, after: ${JSON.stringify(issues.pageInfo.endCursor)}`;
   }
   return supplemented;

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -4266,6 +4266,49 @@ describe("GitHub backfill", () => {
     expect(await listPullRequests(env, "JSONbored/gittensory")).toEqual(expect.arrayContaining([expect.objectContaining({ number: 301, title: "Pull request #301", labels: ["bug"] })]));
   });
 
+  it("stops the open-issues supplement when GitHub reports hasNextPage with no endCursor, keeping the pages already fetched (#8312)", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+    await seedRegisteredRepo(env);
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      if (url === "https://api.github.com/graphql") {
+        const query = JSON.parse(String(init?.body ?? "{}")).query as string;
+        if (query.includes("LoopOverRepoTotals")) {
+          return githubTotalsResponse({ openIssues: 2, openPullRequests: 0, mergedPullRequests: 0, closedPullRequests: 0, labels: 0 });
+        }
+        // With the endCursor guard this follow-up page is never requested. Without it, the null cursor is
+        // serialized into a malformed `after:` argument; GitHub rejects the query, supplementOpenIssuesFromGraphQl
+        // throws, and supplementUnderCountIfNeeded's catch discards the WHOLE supplement -- losing issue 201 below.
+        if (query.includes("LoopOverOpenIssuesSupplement") && query.includes("after:")) {
+          return new Response("malformed cursor", { status: 502 });
+        }
+        if (query.includes("LoopOverOpenIssuesSupplement")) {
+          return Response.json({
+            data: {
+              repository: {
+                issues: {
+                  // The anomaly: more pages claimed, but no cursor to fetch them with.
+                  pageInfo: { hasNextPage: true, endCursor: null },
+                  nodes: [{ number: 201, labels: { nodes: [{ name: "bug" }] } }],
+                },
+              },
+            },
+          });
+        }
+      }
+      if (url.includes("/issues?")) return Response.json([]);
+      return Response.json([]);
+    });
+
+    const issuesResult = await backfillRepositorySegment(env, { repoFullName: "JSONbored/gittensory", segment: "open_issues", mode: "full", force: true });
+
+    // Graceful partial stop: the page already fetched is kept rather than thrown away.
+    expect(issuesResult).toMatchObject({ status: "partial", fetchedCount: 1, expectedCount: 2 });
+    expect(await listIssues(env, "JSONbored/gittensory")).toEqual(
+      expect.arrayContaining([expect.objectContaining({ number: 201, labels: ["bug"] })]),
+    );
+  });
+
   it("keeps unauthenticated open-data undercounts partial when GraphQL supplements are unavailable", async () => {
     const env = createTestEnv();
     await seedRegisteredRepo(env);


### PR DESCRIPTION
## Summary

- `supplementOpenIssuesFromGraphQl` (`src/github/backfill.ts:1831`) ended its pagination loop on `hasNextPage` alone. If GitHub reports `hasNextPage: true` with a null/absent `endCursor`, `JSON.stringify(undefined)` serializes to the string `undefined`, producing a malformed `, after: undefined` follow-up query. That request fails, the function throws, and `supplementUnderCountIfNeeded`'s `catch` discards the **entire** supplement attempt — including every issue already fetched on prior pages — leaving only a generic warning.
- Backports the guard its sibling `supplementOpenPullRequestsFromGraphQl` (:1897) already has: `if (!issues?.pageInfo?.hasNextPage || !issues.pageInfo.endCursor) break;` — the exact same condition shape. The PR-side function was added two days after the issues one as a close copy and picked up the guard; it was never backported.
- On the anomaly the loop now breaks and the existing `return supplemented;` keeps whatever prior pages accumulated — the graceful partial stop the sibling already achieves. No other logic change; the `/* v8 ignore start/stop */` scope is untouched.
- Adds a regression test to `test/unit/backfill.test.ts` alongside the existing sparse-payload supplement test: page 1 returns `pageInfo: { hasNextPage: true, endCursor: null }` with one issue, and the follow-up `after:`-bearing request is stubbed to fail (502). With the guard that request is never issued and the segment completes `partial` with `fetchedCount: 1`, the issue persisted; **without** the guard the malformed query fires, throws, and the whole supplement is discarded.

Closes #8312

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This diff touches only `src/github/backfill.ts` (one line) and `test/unit/backfill.test.ts`, so `actionlint` (no workflow change), `build:mcp`/`test:mcp-pack` (no MCP change), `ui:*` (no UI/OpenAPI change), `test:workers` (no worker change), and `npm audit` (no dependency change) are not exercised by it.
- **Codecov note (per the issue's own Test Coverage Requirements):** the changed line sits inside this function's pre-existing `/* v8 ignore start … stop */` block — the file's established convention for defensive GraphQL-payload-normalization code, matching the sibling PR-supplement function's identical treatment. It is therefore intentionally outside Codecov's branch-count gate and should not be read as uncovered patch code. The behavioral coverage is the real regression test above, which is exactly how this file already tests other ignored-block code (e.g. the `fetchLiveReviewThreadBlockers` cursor-guard test in `backfill-2.test.ts`).
- `test/unit/backfill.test.ts` passes in full (133 tests). I also verified the new test genuinely pins the fix: reverting the one-line guard makes it fail, restoring it makes it pass. Root `tsc --noEmit` is clean for the changed files.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — backend-only pagination guard in `src/github/backfill.ts`; no visible UI, frontend, docs, or extension change.

## Notes

- Pure parity backport: the fix is character-for-character the sibling's condition, so the two supplement helpers now handle the same GitHub GraphQL anomaly identically. The same anomaly class is already guarded a third time in this file by `fetchLiveReviewThreadBlockers`'s `if (!nextCursor || …) break;`.
