### PR TITLE
fix(selfhost): make PgStatement.first() coalesce to null like the D1 adapter

### DIFF
--- a/src/selfhost/pg-adapter.ts
+++ b/src/selfhost/pg-adapter.ts
@@ -39,7 +39,10 @@ class PgStatement implements SelfHostD1PreparedStatement {
     const { rows } = await this.exec();
     const row = rows[0];
     if (!row) return null;
-    return (colName ? row[colName] : row) as T;
+    // Coalesce to null so a SQL NULL (or an absent key) never leaks `undefined` through the documented
+    // Promise<T | null> contract -- matches d1-adapter.ts's first(), the reference implementation callers
+    // rely on when treating the two backends interchangeably (backend-contracts.ts).
+    return ((colName != null ? row[colName] : row) ?? null) as T | null;
   }
 
   async run(): Promise<{ success: true; meta: Record<string, unknown> }> {

--- a/test/unit/selfhost-pg-adapter.test.ts
+++ b/test/unit/selfhost-pg-adapter.test.ts
@@ -46,6 +46,20 @@ describe("createPgAdapter (#977 self-host D1-over-Postgres)", () => {
     expect(await db.prepare("SELECT name FROM t").first("name")).toBe("a");
   });
 
+  it("first(colName) returns null when the row exists but the column value is NULL (#8361 D1 parity)", async () => {
+    // pg represents a SQL NULL as null; the adapter must surface null, never undefined, per its
+    // documented Promise<T | null> contract -- the same guarantee d1-adapter.ts's first() already makes.
+    const db = createPgAdapter(makeMockPool([{ name: null }]));
+    expect(await db.prepare("SELECT name FROM t").first("name")).toBeNull();
+  });
+
+  it("first(colName) returns null when the column is absent from the row entirely (#8361 D1 parity)", async () => {
+    // A driver/query shape that omits the key would previously return `undefined` cast as T, breaking the
+    // contract for callers that treat the Postgres and D1 backends interchangeably.
+    const db = createPgAdapter(makeMockPool([{ other: "a" }]));
+    expect(await db.prepare("SELECT name FROM t").first("name")).toBeNull();
+  });
+
   it("run() reports success:true and a meta object carrying the row count", async () => {
     const db = createPgAdapter(makeMockPool([]));
     const result = await db.prepare("INSERT INTO t (name) VALUES (?)").bind("x").run();


### PR DESCRIPTION
## Summary

- `PgStatement.first(colName)` (`src/selfhost/pg-adapter.ts`) returned `(colName ? row[colName] : row) as T` with no coalesce, so when the requested key is absent from the row (or a driver represents SQL `NULL` as `undefined`) it returned `undefined` cast as `T` — breaking its own documented `Promise<T | null>` contract and diverging from the D1 sibling that callers rely on when treating the two backends interchangeably via `backend-contracts.ts`.
- Applies the exact coalesce `d1-adapter.ts:57-61` already uses: `return ((colName != null ? row[colName] : row) ?? null) as T | null;`. `d1-adapter.ts` is untouched (it is the correct reference), and no other `PgStatement` method is changed.
- Closes the test asymmetry the issue calls out: `selfhost-d1-adapter.test.ts` has had a "returns null when the row exists but the column value is NULL" test all along, while the pg suite never exercised a NULL/absent-column case. Adds both parity cases.

Closes #8361

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This diff touches only `src/selfhost/pg-adapter.ts` (one return statement) and `test/unit/selfhost-pg-adapter.test.ts`, so `actionlint` (no workflow change), `build:mcp`/`test:mcp-pack` (no MCP change), `ui:*` (no UI/OpenAPI change), `test:workers` (no worker change), and `npm audit` (no dependency change) are not exercised by it.
- **Diff coverage verified at 100%**, lines and branches, via the scoped simulation CI runs (`vitest run --coverage --coverage.all=false`): the changed line is hit and every branch on it is taken — the `colName != null` true arm (`first("name")`), its false arm (the existing no-arg `first()` test), the `?? null` defined arm (a real value), and its nullish arm (the two new tests). `test/unit/selfhost-pg-adapter.test.ts` passes in full (11 tests) and root `tsc --noEmit` is clean.
- I also confirmed the new tests genuinely pin the fix: reverting the coalesce makes the absent-column test fail, restoring it makes it pass.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — backend adapter contract fix in `src/selfhost/`; no visible UI, frontend, docs, or extension change.

## Notes

- The condition is `colName != null` rather than a bare truthiness check specifically to match the D1 implementation character-for-character, as the issue requires — the two adapters' `first()` bodies are now identical in behavior.
- Of the two added tests, the absent-column one is the true regression pin (it fails without the fix); the SQL-`NULL` one passes either way with the current `pg` driver and is kept as an explicit contract/parity assertion mirroring the D1 suite's existing test.
