### PR TITLE
fix(review): remove structurally-unreachable branch in classifyChangedFile (#8353)

### DIFF
--- a/src/review/changed-files-classify.ts
+++ b/src/review/changed-files-classify.ts
@@ -1,6 +1,5 @@
 import { isConfigFile, isDocsFile, isGeneratedFile, isLockfile, isMinifiedFile, isVendoredFile } from "../signals/path-matchers";
 import { isTestFile } from "../signals/local-branch";
-import { isTestPath } from "../signals/test-evidence";
 
 // Deterministic changed-file classifier for the review changed-files summary (#2143, part of #1957). Maps a changed
 // file PATH to exactly one of five review-oriented buckets so the summary table (and future analytics) group
@@ -25,7 +24,7 @@ export type ReviewFileClass = "source" | "test" | "docs" | "config" | "generated
  */
 export function classifyChangedFile(path: string): ReviewFileClass {
   if (isGeneratedFile(path) || isVendoredFile(path) || isLockfile(path) || isMinifiedFile(path)) return "generated";
-  if (isTestFile(path) || isTestPath(path)) return "test";
+  if (isTestFile(path)) return "test";
   if (isDocsFile(path)) return "docs";
   if (isConfigFile(path)) return "config";
   return "source";


### PR DESCRIPTION
## Summary

- `classifyChangedFile`'s "test" check was `isTestFile(path) || isTestPath(path)`, but `isTestFile` (re-exported via `src/signals/local-branch.ts` from `packages/loopover-engine/src/signals/path-matchers.ts`) is itself defined as `return isTestPath(file)` — the same `isTestPath` imported here from `src/signals/test-evidence.ts`. The two operands are always equal, so the `||`'s right-hand side can never independently flip the result: one truth-table combination of this line is structurally unreachable by any input.
- Under this repo's 99%-branch-counted Codecov patch gate, that permanently uncoverable branch is a hazard for any future contributor who touches this line for an unrelated reason.
- Removes the redundant `isTestPath(path)` disjunct (keeping `isTestFile(path)`) and its now-unused import. No behavior change: the documented five-way precedence (`generated > test > docs > config > source`) and every existing "test" classification case are unchanged.

Closes #8353

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This change touches only `src/review/changed-files-classify.ts` (pure logic, no UI/MCP/workers/OpenAPI surface). Confirmed via `npx vitest run test/unit/changed-files-classify.test.ts` — all 7 existing tests pass unmodified, with 100% line and 100% branch coverage on the changed file (verified directly against `coverage/lcov.info`: 5/5 lines, 12/12 branches on `src/review/changed-files-classify.ts`), which is the change's entire test-relevant surface. `npm run typecheck` passes clean, confirming the now-unused import was fully removed with no dangling reference. The UI/MCP/workers checks are unaffected by a change confined to this one backend-only file.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session/CORS changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP surface changed.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes.)
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots. (N/A — no visible UI changes.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (N/A.)

## Notes

- Pure redundant-code removal per the issue's own requirement: "this is a pure redundant-code removal, not a classification change."
