### PR TITLE
fix(selfhost): record an error metric when the webhook-dedup Redis cache fails

### DIFF
--- a/src/selfhost/metrics.ts
+++ b/src/selfhost/metrics.ts
@@ -96,6 +96,7 @@ export const DEFAULT_METRIC_META: readonly (readonly [string, MetricMeta])[] = [
   ["loopover_redis_gh_response_cache_total", { help: "Redis-backed GitHub response cache outcomes.", type: "counter" }],
   ["loopover_redis_gh_response_cache_hit_ratio", { help: "Redis GitHub response cache hit ratio (hits / (hits + misses)) at scrape time.", type: "gauge" }],
   ["loopover_redis_token_cache_total", { help: "Redis-backed GitHub token cache outcomes.", type: "counter" }],
+  ["loopover_redis_webhook_dedup_cache_total", { help: "Redis-backed webhook-dedup cache outcomes.", type: "counter" }],
   ["loopover_qdrant_queries_total", { help: "Qdrant vector query attempts.", type: "counter" }],
   ["loopover_qdrant_upserts_total", { help: "Qdrant vector upserted item count.", type: "counter" }],
   ["loopover_qdrant_errors_total", { help: "Qdrant vector operation errors.", type: "counter" }],

--- a/src/selfhost/redis-cache.ts
+++ b/src/selfhost/redis-cache.ts
@@ -8,6 +8,17 @@ import { incr } from "./metrics";
 
 const WEBHOOK_DELIVERY_CACHE_PREFIX = "delivery:";
 
+const REDIS_WEBHOOK_DEDUP_CACHE_METRIC = "loopover_redis_webhook_dedup_cache_total";
+
+/** Records a webhook-dedup Redis cache outcome. Mirrors redis-token-cache.ts's recordTokenCacheMetric /
+ *  redis-response-cache.ts's recordRedisResponseCacheMetric: a named recorder over a `{result}`-labeled
+ *  counter, so a sustained Redis outage on this cache is as visible as one on either sibling. Kept separate
+ *  from `loopover_webhook_dedup_total{backend="redis"}`, which counts actual dedup HITS -- folding errors
+ *  into that counter would conflate "deliveries deduplicated" with "cache unavailable". */
+function recordWebhookDedupCacheMetric(result: "error"): void {
+  incr(REDIS_WEBHOOK_DEDUP_CACHE_METRIC, { result });
+}
+
 export function webhookDeliveryCacheKey(deliveryId: string): string {
   return `${WEBHOOK_DELIVERY_CACHE_PREFIX}${deliveryId}`;
 }
@@ -24,6 +35,9 @@ export async function isWebhookDeliveryDuplicate(cache: RedisCache, deliveryId: 
     }
     return false;
   } catch {
+    // Fail open (unchanged): a cache outage must never block webhook processing -- but record it so the
+    // outage is visible, matching both sibling Redis caches.
+    recordWebhookDedupCacheMetric("error");
     return false;
   }
 }
@@ -33,7 +47,9 @@ export async function rememberWebhookDelivery(cache: RedisCache, deliveryId: str
   try {
     await cache.set(webhookDeliveryCacheKey(deliveryId), "1", ttlSeconds);
   } catch {
-    // best-effort — never block the response on a cache write failure
+    // best-effort — never block the response on a cache write failure (unchanged), but make the failure
+    // observable on the same metric surface as the sibling caches.
+    recordWebhookDedupCacheMetric("error");
   }
 }
 

--- a/test/unit/selfhost-redis-cache.test.ts
+++ b/test/unit/selfhost-redis-cache.test.ts
@@ -121,11 +121,22 @@ describe("isWebhookDeliveryDuplicate (#2075)", () => {
     expect(await renderMetrics()).toContain('loopover_webhook_dedup_total{backend="redis"} 1');
   });
 
-  it("returns false without incrementing when Redis get throws", async () => {
+  it("returns false without counting a dedup hit, and records an error metric, when Redis get throws (#8363)", async () => {
     const brokenRedis = { async get() { throw new Error("connection refused"); } } as unknown as Redis;
     const cache = createRedisCache(brokenRedis);
     await expect(isWebhookDeliveryDuplicate(cache, "delivery-3")).resolves.toBe(false);
-    expect(await renderMetrics()).not.toContain('loopover_webhook_dedup_total{backend="redis"}');
+    const rendered = await renderMetrics();
+    // Fail-open behavior is unchanged: a cache outage is never counted as a deduplicated delivery.
+    expect(rendered).not.toContain('loopover_webhook_dedup_total{backend="redis"}');
+    // ...but the outage is now observable, matching redis-token-cache / redis-response-cache.
+    expect(rendered).toContain('loopover_redis_webhook_dedup_cache_total{result="error"} 1');
+  });
+
+  it("rememberWebhookDelivery records an error metric when the Redis set throws, and still resolves (#8363)", async () => {
+    const brokenRedis = { async set() { throw new Error("connection refused"); } } as unknown as Redis;
+    const cache = createRedisCache(brokenRedis);
+    await expect(rememberWebhookDelivery(cache, "delivery-5")).resolves.toBeUndefined();
+    expect(await renderMetrics()).toContain('loopover_redis_webhook_dedup_cache_total{result="error"} 1');
   });
 
   it("rememberWebhookDelivery stores the delivery key for later dedup", async () => {


### PR DESCRIPTION
## Summary

- `isWebhookDeliveryDuplicate` and `rememberWebhookDelivery` (`src/selfhost/redis-cache.ts`) wrapped their Redis calls in a catch that swallowed the error with no metric, so a sustained Redis outage affecting webhook dedup was completely invisible in metrics — unlike the identical failure mode in this file's two siblings, which both record an `"error"` result (`redis-token-cache.ts`'s `recordTokenCacheMetric`, `redis-response-cache.ts`'s `recordRedisResponseCacheMetric`).
- Adds a named `recordWebhookDedupCacheMetric(result)` recorder over a new `loopover_redis_webhook_dedup_cache_total{result}` counter — the same named-recorder-over-a-`{result}`-labeled-counter shape both siblings use — and calls it from both catch blocks. Registers the counter in `metrics.ts`'s meta map directly beside `loopover_redis_token_cache_total` / `loopover_redis_gh_response_cache_total`, matching their naming and help-text convention.
- **Fail-open behavior is unchanged**: `isWebhookDeliveryDuplicate` still returns `false` and `rememberWebhookDelivery` is still a no-op on error. This issue is scoped to observability only.
- Deliberately kept **separate** from the existing `loopover_webhook_dedup_total{backend="redis"}`, which counts actual dedup *hits* (and is pre-seeded to 0 in `server.ts`) — folding errors into it would conflate "deliveries deduplicated" with "cache unavailable" and corrupt an existing dashboard series.
- `redis-token-cache.ts` and `redis-response-cache.ts` are untouched — they are the reference pattern.
- Updates the existing test the issue names (`"returns false without incrementing when Redis get throws"`) to assert the new error metric alongside its existing fail-open assertion, and adds the matching `rememberWebhookDelivery` set-throws case, which had no error-path test at all.

Closes #8363

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This diff touches only `src/selfhost/redis-cache.ts`, one meta-map entry in `src/selfhost/metrics.ts`, and `test/unit/selfhost-redis-cache.test.ts`, so `actionlint` (no workflow change), `build:mcp`/`test:mcp-pack` (no MCP change), `ui:*` (no UI/OpenAPI change), `test:workers` (no worker change), and `npm audit` (no dependency change) are not exercised by it.
- **Diff coverage verified at 100%** via the scoped simulation CI runs (`vitest run --coverage --coverage.all=false`): every executable changed line in `redis-cache.ts` (the recorder and both catch-block calls) is hit by the two error-path tests; the `metrics.ts` change is a single meta-map literal entry with no separately-instrumented executable line.
- `test/unit/selfhost-redis-cache.test.ts` (14 tests) and `test/unit/selfhost-metrics.test.ts` pass in full (52 together), `test/unit/alerts-metric-name-references.test.ts` still passes with the new metric registered, and root `tsc --noEmit` is clean.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — backend observability fix in `src/selfhost/`; no visible UI, frontend, docs, or extension change.

## Notes

- The metric name follows the siblings' `loopover_redis_<cache>_total` shape rather than extending the existing dedup counter, so the new series is additive: no existing metric, label set, or dashboard query changes.
