### PR TITLE
refactor(scripts): use the canonical latestStableOrbTag in check-orb-stable-release-due

### DIFF
--- a/scripts/check-orb-stable-release-due.ts
+++ b/scripts/check-orb-stable-release-due.ts
@@ -5,14 +5,14 @@
 // scripts/orb-release-core.ts's buildOrbStableReleaseReport for the underlying logic and rationale.
 import { execFileSync } from "node:child_process";
 import { writeFileSync } from "node:fs";
-import { buildOrbStableReleaseReport, type OrbReleaseCommit } from "./orb-release-core.js";
+import { buildOrbStableReleaseReport, latestStableOrbTag, type OrbReleaseCommit } from "./orb-release-core.js";
 
 function main() {
   const args = parseArgs(process.argv.slice(2));
   const tags = git(["tag", "--list", "orb-v*"])
     .split("\n")
     .filter(Boolean);
-  const stableTagName = latestStableTagName(tags);
+  const stableTagName = latestStableOrbTag(tags)?.tag ?? null;
 
   const report = buildOrbStableReleaseReport({
     tags,
@@ -24,17 +24,6 @@ function main() {
   if (!args.json && !args.output) {
     process.stdout.write(report.due ? `ORB stable release due: orb-v${report.nextVersion}\n` : "No ORB stable release due.\n");
   }
-}
-
-// Same tag-selection concern as check-orb-release-due.ts's latestStableTagName -- kept here (not exported
-// from the core module) since it's a git-log concern, not a pure-logic one.
-function latestStableTagName(tags: readonly string[]): string | null {
-  const stable = tags.filter((tag) => /^orb-v\d+\.\d+\.\d+$/.test(tag));
-  return stable.sort(compareTagsDesc)[0] ?? null;
-}
-
-function compareTagsDesc(left: string, right: string): number {
-  return right.localeCompare(left, undefined, { numeric: true });
 }
 
 type ParsedArgs = { json: boolean; output: string | null };


### PR DESCRIPTION
## Summary
`scripts/check-orb-stable-release-due.ts` hand-rolled `latestStableTagName`/`compareTagsDesc` to answer the same "find the latest stable `orb-v` tag" question that `scripts/orb-release-core.ts` already answers canonically — and the comment excusing the duplication was stale: `check-orb-release-due.ts` no longer has a local `latestStableTagName`, it imports `latestStableOrbTag` from the core module.

- Import `latestStableOrbTag` from `./orb-release-core.js` (the same import the sibling script already uses) and call it exactly as the sibling does: `latestStableOrbTag(tags)?.tag ?? null`.
- Delete both now-dead local functions (`compareTagsDesc` had no other caller) and the inaccurate cross-reference comment.
- Nothing else changes: `orb-release-core.ts`, `check-orb-release-due.ts`, and this script's behaviour are untouched.

This also removes a real latent divergence, not just duplication: the deleted local version filtered by regex and sorted with `String.localeCompare(..., { numeric: true })`, whereas `latestStableOrbTag` parses through `parseSemver` and sorts with `compareSemver` on the numeric tuple, filtering `prerelease === null`. The two agree on every tag currently in this repo, so this is a pure consolidation — but only the canonical one picks up future semver-handling changes.

Closes #8394

## Test plan
- [x] `npm run typecheck` clean (confirms the two deleted functions had no remaining references)
- [x] `test/unit/orb-release.test.ts` green (40/40) — the suite covering `orb-release-core.ts`'s `latestStableOrbTag`/`compareSemver`, i.e. the implementation this now routes through
- [x] Smoke-ran the real script against this repo's actual git tags (`npx tsx scripts/check-orb-stable-release-due.ts --json`): resolves `stableVersion: 3.3.0` → `nextVersion: 3.4.0`, identical to the pre-change behaviour
- [x] No new test owed: `scripts/**` is excluded from Codecov's `coverage.include` per `codecov.yml`, and this adds no logic — it deletes a duplicate and calls an already-tested helper
- [ ] CI validate