### PR TITLE
fix(orb): catch stream-read errors in readOrbIngestBody (#8330)

### DIFF
--- a/src/orb/ingest.ts
+++ b/src/orb/ingest.ts
@@ -24,7 +24,11 @@ function parseContentLength(header: string | null | undefined): number | null {
 }
 
 /** Read the request body with a hard byte ceiling so a hostile sender can't make us buffer unbounded
- *  input. Returns null when the body exceeds MAX_ORB_INGEST_BODY_BYTES (the caller answers 413). */
+ *  input. Returns null when the body exceeds MAX_ORB_INGEST_BODY_BYTES OR when the underlying stream
+ *  itself errors (a dropped connection / network reset mid-read, mirrors readOrbRelayRegisterBody in
+ *  ../orb/relay.ts) — both callers (/v1/orb/ingest, /v1/ams/ingest) already treat null identically to
+ *  "reject this request", so a transient read failure degrades the same way an oversized payload does,
+ *  instead of throwing UNCAUGHT out of this function as a bare framework 500. */
 export async function readOrbIngestBody(request: Request, contentLengthHeader: string | null | undefined): Promise<string | null> {
   const declared = parseContentLength(contentLengthHeader);
   if (declared !== null && declared > MAX_ORB_INGEST_BODY_BYTES) return null;
@@ -35,17 +39,21 @@ export async function readOrbIngestBody(request: Request, contentLengthHeader: s
   const decoder = new TextDecoder();
   let total = 0;
   let out = "";
-  for (;;) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    total += value.byteLength;
-    if (total > MAX_ORB_INGEST_BODY_BYTES) {
-      await reader.cancel();
-      return null;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > MAX_ORB_INGEST_BODY_BYTES) {
+        await reader.cancel();
+        return null;
+      }
+      out += decoder.decode(value, { stream: true });
     }
-    out += decoder.decode(value, { stream: true });
+    return out + decoder.decode();
+  } catch {
+    return null;
   }
-  return out + decoder.decode();
 }
 
 interface OrbIngestEvent {

--- a/test/integration/orb-ingest.test.ts
+++ b/test/integration/orb-ingest.test.ts
@@ -250,6 +250,20 @@ describe("readOrbIngestBody()", () => {
     const req = new Request("http://collector", { method: "POST", body: stream, ...({ duplex: "half" } as object) });
     expect(await readOrbIngestBody(req, null)).toBeNull();
   });
+
+  it("REGRESSION (#8330): returns null instead of throwing when the underlying stream errors mid-read", async () => {
+    // Mirrors readOrbRelayRegisterBody's identical dropped-connection regression test (orb-relay.test.ts) — a
+    // first successful chunk (some bytes already arrived) followed by a stream error is the realistic shape of
+    // a mid-read network drop, not an error on the very first read.
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.enqueue(new TextEncoder().encode('{"instance_id":'));
+        controller.error(new Error("simulated network reset"));
+      },
+    });
+    const req = new Request("http://collector", { method: "POST", body: stream, ...({ duplex: "half" } as object) });
+    await expect(readOrbIngestBody(req, null)).resolves.toBeNull();
+  });
 });
 
 describe("POST /v1/orb/ingest route", () => {
@@ -277,6 +291,22 @@ describe("POST /v1/orb/ingest route", () => {
   it("returns 413 when the body exceeds the ingest byte ceiling", async () => {
     const huge = "x".repeat(MAX_ORB_INGEST_BODY_BYTES + 16);
     const res = await app.request("/v1/orb/ingest", { method: "POST", body: huge }, createTestEnv());
+    expect(res.status).toBe(413);
+    expect(((await res.json()) as { error: string }).error).toBe("payload_too_large");
+  });
+
+  it("REGRESSION (#8330): a dropped connection mid-upload returns the same clean 413, not a framework 500", async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.enqueue(new TextEncoder().encode('{"instance_id":'));
+        controller.error(new Error("simulated network reset"));
+      },
+    });
+    const res = await app.request(
+      "/v1/orb/ingest",
+      { method: "POST", body: stream, ...({ duplex: "half" } as object) },
+      createTestEnv(),
+    );
     expect(res.status).toBe(413);
     expect(((await res.json()) as { error: string }).error).toBe("payload_too_large");
   });


### PR DESCRIPTION
## Summary

- `readOrbRelayRegisterBody` (`src/orb/relay.ts`) wraps its stream-read loop in try/catch specifically because `reader.read()` can reject on a dropped connection / network reset mid-read, and every caller already treats a `null` return identically to "reject this request" — a documented, deliberate fix for a real production 500 (GITTENSORY-J).
- `readOrbIngestBody` (`src/orb/ingest.ts`) is the same read-loop pattern, reused as-is by both `/v1/orb/ingest` and `/v1/ams/ingest`, but had no try/catch: a dropped connection mid-upload threw an uncaught rejection out of the route handler instead of the clean `413`/`400` JSON response the route otherwise returns for an oversized or malformed body.
- Wraps `readOrbIngestBody`'s read loop in the identical try/catch → `return null` pattern, with no change to the byte-cap or declared-length-check behavior.
- Adds a regression test mirroring `orb-relay.test.ts`'s dropped-connection case at both levels: the function returns `null` directly, and the `/v1/orb/ingest` route returns its normal clean `413 payload_too_large` response rather than a framework 500.

Closes #8330

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This change touches only `src/orb/ingest.ts` (pure backend logic, no UI/MCP/workers/OpenAPI surface) plus its test file. Verified via `npx vitest run test/integration/orb-ingest.test.ts test/integration/orb-relay.test.ts`: 127/128 tests pass, including both new regression tests (function-level and route-level). The single failure (`handleOrbIngest() > skips events with bad repo_hash / pr_hash / outcome`) is an unrelated, pre-existing local-environment timeout — confirmed by reproducing it identically on a clean stash of this branch's base commit before any of this PR's changes existed; it exercises `handleOrbIngest`, a function this PR does not touch. Coverage on the changed lines (verified directly against `coverage/lcov.info`): every branch inside `readOrbIngestBody`, including the new `try`/`catch`, shows both arms hit (e.g. `BRDA:45,6,0,7` / `BRDA:45,6,1,9` for the loop's `done` check; the catch body's `return null` at line 55 shows 2 hits, one per new regression test).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session/CORS changes; the affected routes' existing optional-bearer-token tests are untouched and still pass.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no new/changed API surface, only an existing error path's robustness.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes.)
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots. (N/A — no visible UI changes.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (N/A.)

## Notes

- Byte-cap and declared-length-check behavior is unchanged — only the read loop's error handling was added, per the issue's explicit requirement.
