### PR TITLE
fix(ui): sync useLocalStorage across tabs via storage events (#8384)

### DIFF
--- a/apps/loopover-ui/src/lib/use-local-storage.test.ts
+++ b/apps/loopover-ui/src/lib/use-local-storage.test.ts
@@ -1,7 +1,11 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useLocalStorage } from "@/lib/use-local-storage";
+
+function dispatchStorage(init: StorageEventInit) {
+  window.dispatchEvent(new StorageEvent("storage", init));
+}
 
 describe("useLocalStorage legacyKey migration (rebrand key rename)", () => {
   beforeEach(() => {
@@ -54,5 +58,84 @@ describe("useLocalStorage legacyKey migration (rebrand key rename)", () => {
     await waitFor(() => expect(result.current[2]).toBe(true));
     act(() => result.current[1]("new-value"));
     expect(window.localStorage.getItem("new.key")).toBe(JSON.stringify("new-value"));
+  });
+});
+
+describe("useLocalStorage cross-tab storage sync", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("updates value when another tab writes a valid JSON value for the hook's own key", async () => {
+    const { result } = renderHook(() => useLocalStorage<string>("solo.key", "initial"));
+    await waitFor(() => expect(result.current[2]).toBe(true));
+    expect(result.current[0]).toBe("initial");
+
+    act(() => {
+      dispatchStorage({ key: "solo.key", newValue: JSON.stringify("from-other-tab") });
+    });
+    expect(result.current[0]).toBe("from-other-tab");
+  });
+
+  it("ignores a storage event for a different key", async () => {
+    const { result } = renderHook(() => useLocalStorage<string>("solo.key", "initial"));
+    await waitFor(() => expect(result.current[2]).toBe(true));
+
+    act(() => {
+      dispatchStorage({ key: "other.key", newValue: JSON.stringify("nope") });
+    });
+    expect(result.current[0]).toBe("initial");
+  });
+
+  it("resets to initial when another tab removes the key (newValue null)", async () => {
+    window.localStorage.setItem("solo.key", JSON.stringify("present"));
+    const { result } = renderHook(() => useLocalStorage<string>("solo.key", "initial"));
+    await waitFor(() => expect(result.current[2]).toBe(true));
+    expect(result.current[0]).toBe("present");
+
+    act(() => {
+      dispatchStorage({ key: "solo.key", newValue: null });
+    });
+    expect(result.current[0]).toBe("initial");
+  });
+
+  it("ignores a malformed newValue without throwing", async () => {
+    const { result } = renderHook(() => useLocalStorage<string>("solo.key", "initial"));
+    await waitFor(() => expect(result.current[2]).toBe(true));
+
+    act(() => {
+      dispatchStorage({ key: "solo.key", newValue: "{not-json" });
+    });
+    expect(result.current[0]).toBe("initial");
+  });
+
+  it("honors a storage event for the configured legacyKey", async () => {
+    const { result } = renderHook(() =>
+      useLocalStorage<string>("new.key", "initial", "legacy.key"),
+    );
+    await waitFor(() => expect(result.current[2]).toBe(true));
+
+    act(() => {
+      dispatchStorage({ key: "legacy.key", newValue: JSON.stringify("from-legacy-tab") });
+    });
+    expect(result.current[0]).toBe("from-legacy-tab");
+  });
+
+  it("removes the storage listener on unmount", async () => {
+    const removeSpy = vi.spyOn(window, "removeEventListener");
+    const { result, unmount } = renderHook(() => useLocalStorage<string>("solo.key", "initial"));
+    await waitFor(() => expect(result.current[2]).toBe(true));
+
+    unmount();
+    expect(removeSpy).toHaveBeenCalledWith("storage", expect.any(Function));
+
+    // Firing after unmount must not throw (listener is gone).
+    expect(() => {
+      dispatchStorage({ key: "solo.key", newValue: JSON.stringify("after-unmount") });
+    }).not.toThrow();
   });
 });

--- a/apps/loopover-ui/src/lib/use-local-storage.ts
+++ b/apps/loopover-ui/src/lib/use-local-storage.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 /**
  * Tiny SSR-safe localStorage hook. Reads once on mount; writes are persisted
@@ -12,6 +12,10 @@ import { useCallback, useEffect, useState } from "react";
 export function useLocalStorage<T>(key: string, initial: T, legacyKey?: string) {
   const [value, setValue] = useState<T>(initial);
   const [hydrated, setHydrated] = useState(false);
+  // Call sites often pass a fresh `[]` / `{...}` literal each render; keep the
+  // listener keyed only on `key`/`legacyKey` and read the latest initial via ref.
+  const initialRef = useRef(initial);
+  initialRef.current = initial;
 
   useEffect(() => {
     try {
@@ -29,6 +33,23 @@ export function useLocalStorage<T>(key: string, initial: T, legacyKey?: string) 
       /* ignore */
     }
     setHydrated(true);
+
+    // Cross-tab sync: the browser fires `storage` only in *other* same-origin tabs
+    // (never the tab that wrote). Same-tab writes already update state via `update()`.
+    const onStorage = (event: StorageEvent) => {
+      if (event.key !== key && (!legacyKey || event.key !== legacyKey)) return;
+      if (event.newValue === null) {
+        setValue(initialRef.current);
+        return;
+      }
+      try {
+        setValue(JSON.parse(event.newValue) as T);
+      } catch {
+        /* ignore */
+      }
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
   }, [key, legacyKey]);
 
   const update = useCallback(


### PR DESCRIPTION
## Summary

- Make `useLocalStorage` listen for the native `storage` event so already-mounted hooks in other same-origin tabs re-render when the same key (or configured `legacyKey`) changes elsewhere.
- Reset to `initial` when another tab removes the key (`newValue: null`); ignore malformed JSON the same way mount-time reads already do.
- Extend `use-local-storage.test.ts` with cross-tab sync, ignore-other-key, null-reset, malformed, legacyKey, and unmount cleanup coverage.

Closes #8384

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- UI-only change under `apps/loopover-ui` (Codecov ignores `apps/**`). Validated with `npm run ui:test`, `npm run ui:typecheck`, `npm run ui:lint`, `git diff --check`, and `npm audit --audit-level=moderate` as required by the issue.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

No visual/layout change — data-correctness fix only (cross-tab state sync). Per the issue Expected Outcome: no UI Evidence screenshots required.

| State / title                         | JPG/PNG evidence                                                                     |
| ------------------------------------- | ------------------------------------------------------------------------------------ |
| N/A — no visible UI change            |                                                                                      |

## Notes

- Listener follows the same add/remove cleanup pattern as `startHealthPolling()` in `apps/loopover-ui/src/lib/api/status.ts`.
- `initial` is read via a ref so inline `[]` / object-literal call sites do not re-subscribe every render.
