### PR TITLE
chore(mcp): drop three unused settings/autonomy imports from server.ts

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -172,7 +172,7 @@ import { buildTestEvidenceReport, classifyTestCoverage, hasLocalTestEvidence, is
 import { applyStepResult, buildPlanDag, nextReadySteps, planProgress, validatePlanDag, type PlanDag } from "../services/plan-dag";
 import { buildFocusManifestValidation } from "../services/focus-manifest-validation";
 import { isGlobalAgentPause, resolveAgentActionMode, resolveAgentPermissionReadiness } from "../settings/agent-execution";
-import { AGENT_ACTION_CLASSES, AUTONOMY_LEVELS, isActingAutonomyLevel, resolveAutonomy } from "../settings/autonomy";
+import { AUTONOMY_LEVELS } from "../settings/autonomy";
 import { resolveRepositorySettings } from "../settings/repository-settings";
 import { isDuplicateWinnerEnabledGlobally, resolveDuplicateWinnerEnabled } from "../settings/duplicate-winner-mode";
 import { compileFocusManifestPolicy, MAX_FOCUS_MANIFEST_BYTES } from "../signals/focus-manifest";


### PR DESCRIPTION
## Summary

- `src/mcp/server.ts:175` imported four names from `../settings/autonomy` but referenced only one. `AGENT_ACTION_CLASSES`, `isActingAutonomyLevel`, and `resolveAutonomy` appear nowhere else in the file (exact-identifier grep returns only the import line for each, and there is no re-export); `AUTONOMY_LEVELS` is genuinely used, e.g. `z.enum(AUTONOMY_LEVELS)` in the `setActionAutonomyShape` tool-input schema.
- Narrows the import to `AUTONOMY_LEVELS` only.
- This slipped past both static-analysis layers, which is why it accumulated: `src/**` has no ESLint config (only `apps/loopover-miner-ui` and `apps/loopover-ui` ship an `eslint.config.js`), and the root `tsconfig.json` sets neither `noUnusedLocals` nor `noUnusedParameters`.
- `packages/loopover-engine/src/settings/autonomy.ts` is untouched — those exports stay exported and are used elsewhere (e.g. `packages/loopover-mcp/bin/loopover-mcp.ts`).
- `MAINTAIN_AUTONOMY_ACTION_CLASSES` (`src/mcp/server.ts:623`) is deliberately **not** touched: it is the documented intentional divergence from `AGENT_ACTION_CLASSES` ("do not sync it to the engine list", `packages/loopover-mcp/bin/loopover-mcp.ts:149-152`), unrelated to this cleanup.

Closes #8339

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- One-line import narrowing in `src/mcp/server.ts` with **no behavior change**, so `actionlint` (no workflow change), `build:mcp`/`test:mcp-pack` (this is the in-repo MCP server module, not the published `packages/loopover-mcp` package or its tarball), `ui:*` (no UI/OpenAPI change), `test:workers` (no worker change), and `npm audit` (no dependency change) are not exercised by it.
- **No new behavior to test**, hence no new test: this removes references, it does not add a code path. Verified instead that nothing regressed — root `tsc --noEmit` is clean (the strongest signal here: an actually-used import would fail to compile once removed), and all three suites that import `src/mcp/server.ts` pass in full (`change-guardrail`, `issue-plan-decomposition`, `issue-watch` — 43 tests).
- **Codecov:** the single changed line is an `import` statement, which is not an instrumented (`DA`) line, so the patch contains no coverable lines and nothing can be reported uncovered. `src/mcp/server.ts` still appears in the scoped run's `coverage/lcov.info`, so the "Verify coverage report exists" step is satisfied.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — a single import-line cleanup in `src/mcp/server.ts`; no visible UI, frontend, docs, or extension change.

## Notes

- No MCP tool surface, schema, or runtime behavior changes: the removed names were never referenced, so the compiled module is behaviorally identical.
