### PR TITLE
test(db): cover pruneExpiredRecords defensive ?? 0 arms (#8370)

### DIFF
--- a/test/unit/retention.test.ts
+++ b/test/unit/retention.test.ts
@@ -121,6 +121,37 @@ describe("pruneExpiredRecords", () => {
     expect(rows.results.map((row) => row.id)).toEqual(["ctx-recent"]);
   });
 
+  it("dry-run falls back to 0 when the count query returns no row (defensive ?? 0 arm)", async () => {
+    const noRowEnv = {
+      DB: {
+        prepare: (_sql: string) => ({
+          bind: (..._binds: unknown[]) => ({ first: async () => undefined }), // count query returns no row → `row?.n ?? 0` fallback fires
+        }),
+      },
+    } as unknown as Env;
+    const results = await pruneExpiredRecords(noRowEnv, {
+      dryRun: true,
+      nowMs: NOW,
+      policy: [{ table: "ai_usage_events", column: "created_at", days: 90 }],
+    });
+    expect(results).toEqual([{ table: "ai_usage_events", column: "created_at", cutoff: daysAgo(90), deleted: 0 }]);
+  });
+
+  it("falls back to 0 changes when a delete run() result lacks meta (defensive ?? 0 arm)", async () => {
+    const noMetaEnv = {
+      DB: {
+        prepare: (_sql: string) => ({
+          bind: (..._binds: unknown[]) => ({ run: async () => ({}) }), // no meta → `result.meta?.changes ?? 0` fallback fires, so changes = 0 < batchSize
+        }),
+      },
+    } as unknown as Env;
+    const results = await pruneExpiredRecords(noMetaEnv, {
+      nowMs: NOW,
+      policy: [{ table: "ai_usage_events", column: "created_at", days: 90 }],
+    });
+    expect(results).toEqual([{ table: "ai_usage_events", column: "created_at", cutoff: daysAgo(90), deleted: 0 }]);
+  });
+
   it("the policy only targets append-only/log/snapshot tables (no current-state tables)", () => {
     const tables = RETENTION_POLICY.map((r) => r.table);
     for (const protectedTable of ["webhook_events", "repositories", "repository_settings", "pull_requests", "issues", "repository_ai_keys", "contributors"]) {


### PR DESCRIPTION
## Summary

- Adds direct test coverage for `pruneExpiredRecords`'s two defensive `?? 0` fallback arms in `src/db/retention.ts` (the dry-run `row?.n ?? 0` count path at line 75, and the delete-loop `result.meta?.changes ?? 0` path at line 85), mirroring the existing tests already written for the sibling function `dedupeSignalSnapshots`'s identical pattern (`test/unit/retention.test.ts` lines 236-264). No production code changed — this closes a Codecov branch-coverage gap that already existed for the untested arms.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

Closes #8370

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npx vitest run test/unit/retention.test.ts --coverage --coverage.include="src/db/retention.ts"` — 100% statements/branches/functions/lines on `src/db/retention.ts`
- [ ] `npm run actionlint`
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This change touches only `test/unit/retention.test.ts` (a single backend unit test file, no UI/MCP/worker/OpenAPI surface touched), so the UI/MCP/workers/OpenAPI-specific checks above were not run locally; they are unaffected by this diff and are still exercised by the full CI gate.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session/CORS code touched.)
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP surface touched.)
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI touched.)
- [ ] Visible UI changes include a `UI Evidence` section below. (N/A — no visible UI change.)
- [ ] Public docs/changelogs are updated where needed. (N/A — no docs/changelog change needed.)

## UI Evidence

N/A — this is a backend test-only change with no visible UI surface.

## Notes

- Pure test-addition per the issue's own scope note: "Do not modify `pruneExpiredRecords`'s actual logic — this issue is scoped to adding missing test coverage for existing, already-correct defensive code."
