### PR TITLE
chore(review): delegate diffFilePriority's lockfile match to the canonical isLockfile

### DIFF
--- a/packages/loopover-engine/src/review/diff-file-priority.ts
+++ b/packages/loopover-engine/src/review/diff-file-priority.ts
@@ -1,7 +1,10 @@
+import { isLockfile } from "../signals/path-matchers.js";
 import { isTestPath } from "../signals/test-evidence.js";
 
 export function diffFilePriority(path: string): number {
-  if (/(^|\/)(package-lock\.json|npm-shrinkwrap\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lock|bun\.lockb|cargo\.lock|poetry\.lock|pipfile\.lock|composer\.lock|gemfile\.lock|go\.sum|go\.work\.sum|uv\.lock|packages\.lock\.json|flake\.lock|deno\.lock|pubspec\.lock|podfile\.lock|mix\.lock|package\.resolved|gradle\.lockfile|pdm\.lock|conan\.lock|pixi\.lock|cartfile\.resolved|gopkg\.lock|shard\.lock|rebar\.lock|renv\.lock|chart\.lock)$|\.(min\.(js|css)|map|snap)$/i.test(path)) return 4;
+  // Lockfile-NAME matching delegates to the canonical isLockfile/LOCKFILE_NAMES so no copy of this
+  // function can drift from the shared set (the #4605 Finding 1 class); suffix patterns stay inline.
+  if (isLockfile(path) || /\.(min\.(js|css)|map|snap)$/i.test(path)) return 4;
   // Must stay in sync with signals/path-matchers.ts's isVendoredFileFrom -- the two already had this
   // obligation implicitly (bower_components/jspm_packages were added there in #2777 with no corresponding
   // update here, #7526) and now match the same directory-name set exactly.

--- a/scripts/check-engine-parity.ts
+++ b/scripts/check-engine-parity.ts
@@ -57,9 +57,12 @@ export const SAFE_URL_MARKERS = Object.freeze([
 
 /** `diffFilePriority` is duplicated by FUNCTION, not by file: two byte-identical host copies
  *  (review-diff.ts, review-grounding.ts) and a differently-named engine copy (diff-file-priority.ts) —
- *  none share a filename, so the directory scan never pairs them. The `cartfile\.resolved` marker directly
- *  regression-guards #4605 Finding 1: the engine copy's Carthage-lockfile regex had silently drifted to
- *  `cartfile\.lock`, which is not a real filename (Carthage's lockfile is `Cartfile.resolved`). */
+ *  none share a filename, so the directory scan never pairs them. The `isLockfile(path)` marker
+ *  regression-guards #4605 Finding 1 at its root: that bug was the engine copy's hand-rolled
+ *  Carthage-lockfile regex silently drifting to `cartfile\.lock` (not a real filename — Carthage's is
+ *  `Cartfile.resolved`). Since #8357 every copy delegates lockfile-NAME matching to the canonical
+ *  `isLockfile`/`LOCKFILE_NAMES`, so no copy owns a name list that CAN drift; asserting the delegation is
+ *  present is therefore a strictly stronger guard than asserting one literal name inside a private regex. */
 export const DIFF_FILE_PRIORITY_TWIN_PAIR: NamedTwinPair = Object.freeze({
   area: "diff-file-priority",
   hostRelative: "src/review/review-diff.ts",
@@ -70,7 +73,7 @@ export const DIFF_FILE_PRIORITY_TWIN_PAIR: NamedTwinPair = Object.freeze({
 
 export const DIFF_FILE_PRIORITY_MARKERS = Object.freeze([
   "export function diffFilePriority(path: string): number {",
-  "cartfile\\.resolved",
+  "isLockfile(path)",
 ] as const);
 
 /** `sharesMeaningfulFile` is a near-duplicate helper (the host folds its guard clause into one `if`; the

--- a/src/review/review-diff.ts
+++ b/src/review/review-diff.ts
@@ -6,6 +6,7 @@
 // which survived even with full-file grounding on). This builder orders source-first, reduces oversized
 // patches hunk-aware instead of dropping them, and always lists patch-less/over-budget files. (#accuracy-gap-1)
 
+import { isLockfile } from "../signals/path-matchers";
 import { isTestPath } from "../signals/test-evidence";
 import type { listPullRequestFiles } from "../db/repositories";
 
@@ -19,9 +20,13 @@ export const DEFAULT_DIFF_BUDGET = 80_000;
  *  Test detection delegates to the canonical `isTestPath` so this matcher can't drift from it — the
  *  previous inline regex missed real conventions (pytest `test_*.py`, Go `*_test.go`, Ruby `*_spec.rb`,
  *  Cypress/Playwright `.cy`/`.e2e`, a bare `spec/` dir), so those tests were ranked as SOURCE(0) and
- *  could displace real source under a tight budget — the exact opposite of this function's job. */
+ *  could displace real source under a tight budget — the exact opposite of this function's job.
+ *  Lockfile detection delegates to the canonical `isLockfile`/`LOCKFILE_NAMES` for the same reason: a
+ *  hand-duplicated name list silently misses every future ecosystem addition to the shared set (which has
+ *  been extended in batches before), ranking a new lockfile format as SOURCE(0) instead of GENERATED(4). */
 export function diffFilePriority(path: string): number {
-  if (/(^|\/)(package-lock\.json|npm-shrinkwrap\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lock|bun\.lockb|cargo\.lock|poetry\.lock|pipfile\.lock|composer\.lock|gemfile\.lock|go\.sum|go\.work\.sum|uv\.lock|packages\.lock\.json|flake\.lock|deno\.lock|pubspec\.lock|podfile\.lock|mix\.lock|package\.resolved|gradle\.lockfile|pdm\.lock|conan\.lock|pixi\.lock|cartfile\.resolved|gopkg\.lock|shard\.lock|rebar\.lock|renv\.lock|chart\.lock)$|\.(min\.(js|css)|map|snap)$/i.test(path)) return 4;
+  // Only the lockfile-NAME portion is delegated; the suffix-based generated-file patterns stay inline.
+  if (isLockfile(path) || /\.(min\.(js|css)|map|snap)$/i.test(path)) return 4;
   if (/(^|\/)(dist|build|out|coverage|vendor|node_modules)\//i.test(path)) return 4;
   if (/\.(md|mdx|markdown|rst|adoc|asciidoc|txt)$/i.test(path)) return 2;
   if (isTestPath(path)) return 1;

--- a/src/review/review-grounding.ts
+++ b/src/review/review-grounding.ts
@@ -22,6 +22,7 @@
 // review-grounding.ts -- if reviewbot's copy is ever resynced from this file, carry this piece forward too,
 // or reviewbot will regress to the old all-or-nothing truncation this was written to eliminate.
 
+import { isLockfile } from "../signals/path-matchers";
 import { isTestPath } from "../signals/test-evidence";
 import { neutralizePromptInjection } from "./prompt-injection";
 
@@ -189,7 +190,9 @@ export function buildGrounding(f: GroundingFlags, checks?: CheckAggregate, fileC
  *  copy missed pytest `test_*.py`, Go `*_test.go`, Ruby `*_spec.rb`, Cypress/Playwright `.cy`/`.e2e`, and a
  *  bare `spec/` dir — so those tests ranked as SOURCE(0) and were inlined ahead of real source). */
 export function diffFilePriority(path: string): number {
-  if (/(^|\/)(package-lock\.json|npm-shrinkwrap\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lock|bun\.lockb|cargo\.lock|poetry\.lock|pipfile\.lock|composer\.lock|gemfile\.lock|go\.sum|go\.work\.sum|uv\.lock|packages\.lock\.json|flake\.lock|deno\.lock|pubspec\.lock|podfile\.lock|mix\.lock|package\.resolved|gradle\.lockfile|pdm\.lock|conan\.lock|pixi\.lock|cartfile\.resolved|gopkg\.lock|shard\.lock|rebar\.lock|renv\.lock|chart\.lock)$|\.(min\.(js|css)|map|snap)$/i.test(path)) return 4;
+  // Lockfile-NAME matching delegates to the canonical isLockfile/LOCKFILE_NAMES so no copy of this
+  // function can drift from the shared set (the #4605 Finding 1 class); suffix patterns stay inline.
+  if (isLockfile(path) || /\.(min\.(js|css)|map|snap)$/i.test(path)) return 4;
   if (/(^|\/)(dist|build|out|coverage|vendor|node_modules)\//i.test(path)) return 4;
   if (/\.(md|mdx|markdown|rst|adoc|asciidoc|txt)$/i.test(path)) return 2;
   if (isTestPath(path)) return 1;

--- a/test/unit/check-engine-parity-script.test.ts
+++ b/test/unit/check-engine-parity-script.test.ts
@@ -376,10 +376,11 @@ describe("check-engine-parity script", () => {
       }
     });
 
-    it("diffFilePriority markers cover the exact Cartfile.resolved regression (#4605 Finding 1)", () => {
-      // Reproduces the actual bug: the engine copy's regex previously matched `cartfile\.lock` (not a
-      // real Carthage filename) instead of `cartfile\.resolved`. A body missing the resolved-lockfile
-      // marker fails presence — exactly what the old, un-checked engine copy would have done.
+    it("diffFilePriority markers cover the Cartfile.resolved regression class at its root (#4605 Finding 1, #8357)", () => {
+      // Reproduces the actual bug's ROOT CAUSE: a copy that hand-rolls its own lockfile-name regex can
+      // silently drift (the engine copy once matched `cartfile\.lock`, not a real Carthage filename).
+      // Since #8357 every copy delegates to the canonical isLockfile, so a body that still owns a private
+      // name list fails presence — exactly what the old, un-checked engine copy would have done.
       const buggyEngineBody =
         "export function diffFilePriority(path: string): number {\n" +
         "  if (/cartfile\\.lock$/i.test(path)) return 4;\n" +
@@ -387,7 +388,7 @@ describe("check-engine-parity script", () => {
         "}\n";
       const fixedHostBody =
         "export function diffFilePriority(path: string): number {\n" +
-        "  if (/cartfile\\.resolved$/i.test(path)) return 4;\n" +
+        "  if (isLockfile(path)) return 4;\n" +
         "  return 0;\n" +
         "}\n";
       const result = checkGateDecisionTwinPresence({


### PR DESCRIPTION
## Summary

- `diffFilePriority` (`src/review/review-diff.ts`) hand-rolled a 31-alternative lockfile-name regex duplicating the canonical `LOCKFILE_NAMES` set exported by `packages/loopover-engine/src/signals/path-matchers.ts`. Any future ecosystem addition to the canonical set (which has been extended in batches before — `cartfile.resolved`/`gopkg.lock`/`shard.lock`/`rebar.lock`/`renv.lock`/`chart.lock` landed together) would silently **not** be reflected here, ranking the new format as SOURCE(0) — highest priority, survives budget trimming — instead of GENERATED(4), dropped first.
- This is precisely the drift class this function's own header already documents fixing once for test-file detection (`isTestPath`), and a prior real instance of it in this same function is #7526.
- Delegates the lockfile-**name** portion to `isLockfile`, imported through the `src/signals/path-matchers` re-export shim — the same engine-consumption convention this file already uses for `isTestPath` via `src/signals/test-evidence`.
- The suffix-based generated-file matching (`.min.js` / `.min.css` / `.map` / `.snap`) is **preserved inline**, as required; only the name list moved.

**Behavior-change check (as the issue requires):** I diffed the two lists programmatically — the canonical `LOCKFILE_NAMES` set and the inline regex alternation are **identical, 31 entries each, zero differences in either direction**. Case-insensitivity is also preserved: the old regex used `/i`, and `isLockfile` matches the basename after `normalize()`, which lowercases. So this is a pure behavior-preserving delegation, and **no existing test relies on a lockfile name `isLockfile` does not recognize** — `test/unit/review-diff.test.ts`'s lockfile cases (`package-lock.json`, plus the `bun.lock`/`uv.lock`/`deno.lock`/`flake.lock`/`mix.lock`/`chart.lock` sweep) all pass unchanged.

Closes #8357

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This diff touches the three `diffFilePriority` copies, the engine-parity marker, and that marker's test (see the scope note above), so `actionlint` (no workflow change), `build:mcp`/`test:mcp-pack` (no MCP change), `ui:*` (no UI/OpenAPI change), `test:workers` (no worker change), and `npm audit` (no dependency change) are not exercised by it.
- **No new test**, deliberately: this is a behavior-preserving delegation with the lists proven identical, and the issue's deliverable is to confirm the existing cases still pass unchanged — they do (`test/unit/review-diff.test.ts`, 23 tests, including the dedicated "ranks every path-matchers lockfile as noise(4)" sweep, which is exactly the test that now protects the delegation).
- **Diff coverage verified at 100%**, lines and branches, via the scoped simulation CI runs (`vitest run --coverage --coverage.all=false`): the changed condition's branches are all exercised by existing tests — `isLockfile` true (short-circuit), `isLockfile` false with the suffix regex true (`.map`/`.snap`/`.min.js`), and both false (source files). Root `tsc --noEmit` is clean.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — backend refactor in `src/review/`; no visible UI, frontend, docs, or extension change.

## Scope note — why this touches more than `review-diff.ts` (CI-driven)

The issue scoped the change to `review-diff.ts` line 24. That alone **fails CI**, and finding out why changed the shape of the fix, so flagging it explicitly:

`diffFilePriority` is duplicated **by function, not by file** — three copies: `src/review/review-diff.ts`, `src/review/review-grounding.ts` (byte-identical host copy), and `packages/loopover-engine/src/review/diff-file-priority.ts`. `scripts/check-engine-parity.ts` registers the first and third as a *named twin pair* and asserts both contain the literal marker `cartfile\.resolved` — a deliberate regression guard for #4605 Finding 1, where the engine copy's Carthage regex had silently drifted to `cartfile\.lock` (not a real filename).

Delegating only `review-diff.ts` deletes that literal from one twin (`validate-code` fails: *"missing expected twin-pair marker"*) **and** leaves the other two copies still hand-rolling the very list the issue wants de-duplicated — a worse state than before. So this PR:

1. Delegates lockfile-name matching to canonical `isLockfile` in **all three** copies.
2. Retargets the twin-pair marker from `cartfile\.resolved` to `isLockfile(path)`.
3. Updates that marker test's synthetic host body to match.

**This strengthens the guard rather than weakening it.** #4605 was caused by a copy owning a private, hand-maintained name list that could drift. After this change no copy owns one, so that drift is structurally impossible instead of merely detected for one sampled filename — and the marker now asserts the delegation itself, which is what actually prevents the bug class. I deliberately did not simply delete the marker or park the literal in a comment to make the gate pass.

**Verification:** `npx tsx scripts/check-engine-parity.ts` reports **zero marker failures** (both twins carry both markers). The script's other output — 25 `"drifted apart (normalized comparison)"` lines across unrelated pairs (`slop.ts`, `test-evidence.ts`, …) — reproduces **identically on clean `origin/main`** on my Windows checkout (a CRLF artifact of the normalized compare), as does `check-engine-parity-script.test.ts` (8 failed / 33 passed on both baseline and this branch). So this PR introduces no new parity failure. `review-diff.test.ts` + `review-grounding.test.ts` pass in full (73 tests) and root `tsc --noEmit` is clean.

## Notes

- `packages/loopover-engine/src/signals/path-matchers.ts` is untouched — it is the canonical source this now defers to.
- The import goes through `src/signals/path-matchers.ts` (the thin re-export shim) rather than the engine's `dist/`, matching that shim's own documented rationale: the built output is not guaranteed to exist when `typecheck`/`test:coverage` run in CI.
