### PR TITLE
fix(orb): cap gate_verdict length in orb_signals ingest (#8333)

### DIFF
--- a/src/orb/ingest.ts
+++ b/src/orb/ingest.ts
@@ -7,6 +7,7 @@ const MAX_BATCH = 500;
 const MAX_INSTANCE_ID_CHARS = 64;
 const MAX_HASH_CHARS = 128;
 const MAX_BUCKET_CHARS = 64;
+const MAX_VERDICT_CHARS = 32;
 const VALID_OUTCOMES = new Set(["merged", "closed"]);
 const VALID_REVERSALS = new Set(["none", "reopened", "reverted"]);
 const MIN_CYCLE_MS = 1_000; // <1s is implausible
@@ -166,7 +167,7 @@ export async function handleOrbIngest(body: string, db: D1Database): Promise<Orb
           instance_id,
           event.repo_hash,
           event.pr_hash,
-          typeof event.gate_verdict === "string" ? event.gate_verdict : null,
+          typeof event.gate_verdict === "string" && event.gate_verdict.length <= MAX_VERDICT_CHARS ? event.gate_verdict : null,
           event.outcome,
           reversal,
           typeof event.gate_reasoncode_bucket === "string" && event.gate_reasoncode_bucket.length <= MAX_BUCKET_CHARS ? event.gate_reasoncode_bucket : null,

--- a/test/integration/orb-ingest.test.ts
+++ b/test/integration/orb-ingest.test.ts
@@ -39,11 +39,12 @@ describe("handleOrbIngest()", () => {
     expect(await ingest(makeDb(), [ev({ outcome: "opened" })])).toEqual({ accepted: 0 });
   });
 
-  it("stores gate_verdict string vs null", async () => {
+  it("stores gate_verdict string vs null, coercing an oversized value to null", async () => {
     const db = makeDb();
-    await ingest(db, [ev({ pr_hash: "v1", gate_verdict: "merge" }), ev({ pr_hash: "v2" })]);
+    await ingest(db, [ev({ pr_hash: "v1", gate_verdict: "merge" }), ev({ pr_hash: "v2" }), ev({ pr_hash: "v3", gate_verdict: "v".repeat(33) })]);
     expect(await col(db, "v1", "gate_verdict")).toBe("merge");
     expect(await col(db, "v2", "gate_verdict")).toBeNull();
+    expect(await col(db, "v3", "gate_verdict")).toBeNull();
   });
 
   it("whitelists reversal_flag: valid kept, invalid + absent → 'none'", async () => {


### PR DESCRIPTION
## Summary

- `src/orb/ingest.ts`'s `orb_signals` insert loop capped every sibling string field (`repo_hash`/`pr_hash` at `MAX_HASH_CHARS`, `gate_reasoncode_bucket` at `MAX_BUCKET_CHARS`, `instance_id` at `MAX_INSTANCE_ID_CHARS`) except `gate_verdict`, which was only type-checked. Added a `MAX_VERDICT_CHARS` (32) constant and gated the `gate_verdict` bind the same way `gate_reasoncode_bucket` already is, so an oversized value from a malformed or hostile self-hosted instance is coerced to `null` instead of written unbounded.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

Closes #8333

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npx vitest run test/integration/orb-ingest.test.ts --coverage --coverage.include="src/orb/ingest.ts"` — 100% statements/branches/functions/lines on `src/orb/ingest.ts`
- [ ] `npm run actionlint`
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This change touches only `src/orb/ingest.ts` and its integration test (no UI/MCP/worker/OpenAPI surface touched), so the UI/MCP/workers/OpenAPI-specific checks above were not run locally; they are unaffected by this diff and are still exercised by the full CI gate.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session/CORS code touched.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (Ingest validation behavior updated and covered by the updated test; no OpenAPI schema shape changed since `gate_verdict` was already a nullable string field.)
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI touched.)
- [ ] Visible UI changes include a `UI Evidence` section below. (N/A — no visible UI change.)
- [ ] Public docs/changelogs are updated where needed. (N/A — no docs/changelog change needed.)

## UI Evidence

N/A — this is a backend validation-only change with no visible UI surface.

## Notes

- Only `gate_verdict`'s validation changed; no other field in the insert loop was touched, per the issue's own scope note.
