### PR TITLE
test(signals): cover decidePublicSurface's oss_maintainer not_checked label fallback (#8324)

### DIFF
--- a/test/unit/settings-preview.test.ts
+++ b/test/unit/settings-preview.test.ts
@@ -134,6 +134,41 @@ describe("decidePublicSurface", () => {
     expect(decision).toMatchObject({ skipped: false, willComment: false, willLabel: false, willCheckRun: false, actions: ["none"] });
     expect(decision.summary).toMatch(/no surface action is enabled/);
   });
+
+  // #8324: the willLabel oss_maintainer + not_checked fallback disjunct. shouldApplyPrLabel returns false for
+  // an oss_maintainer repo whose miner status isn't "confirmed", so this inline condition is the only thing
+  // that can set willLabel for a not_checked PR -- it governs whether the live webhook processor labels a PR
+  // before the official Gittensor miner lookup completes.
+  describe("oss_maintainer + not_checked auto-label fallback", () => {
+    const decide = (over: Partial<RepositorySettings>) =>
+      decidePublicSurface({
+        settings: settings({ publicAudienceMode: "oss_maintainer", autoLabelEnabled: true, ...over }),
+        authorLogin: "contributor",
+        authorType: "User",
+        authorAssociation: "NONE",
+        minerStatus: "not_checked",
+      });
+
+    it("labels a comment_and_label surface (shouldApplyPrLabel is false here, so the fallback is what fires)", () => {
+      const decision = decide({ publicSurface: "comment_and_label" });
+      expect(decision.willLabel).toBe(true);
+      expect(decision.actions).toContain("label");
+    });
+
+    it("labels a label_only surface", () => {
+      expect(decide({ publicSurface: "label_only" }).willLabel).toBe(true);
+    });
+
+    it("does NOT label a comment_only surface (the disjunct's own publicSurface check excludes it)", () => {
+      const decision = decide({ publicSurface: "comment_only" });
+      expect(decision.willLabel).toBe(false);
+      expect(decision.actions).not.toContain("label");
+    });
+
+    it("does NOT label when autoLabelEnabled is false, even on a labelling surface", () => {
+      expect(decide({ publicSurface: "comment_and_label", autoLabelEnabled: false }).willLabel).toBe(false);
+    });
+  });
 });
 
 describe("buildRepoSettingsPreview", () => {


### PR DESCRIPTION
## Summary

Closes #8324.

`decidePublicSurface` in `src/signals/settings-preview.ts` is documented as the single source of truth for the GitHub App's public surface, shared by the live webhook processor and the maintainer-facing dry-run preview. Its `willLabel` computation has an inline fallback disjunct:

```ts
const willLabel =
  shouldApplyPrLabel(settings, input.minerStatus) ||
  (settings.publicAudienceMode === "oss_maintainer" && input.minerStatus === "not_checked" && settings.autoLabelEnabled && (settings.publicSurface === "comment_and_label" || settings.publicSurface === "label_only"));
```

`shouldApplyPrLabel` returns `false` for an `oss_maintainer` repo whose miner status isn't `"confirmed"`, so for a `not_checked` PR this inline condition is the **only** thing that can set `willLabel` -- it governs whether the webhook processor labels a PR before the official Gittensor miner lookup completes. It had zero coverage (`grep not_checked test/unit/settings-preview.test.ts` returned nothing).

Adds a `describe` isolating the four arms of the disjunct:
- `comment_and_label` surface -> labels (and `actions` includes `label`)
- `label_only` surface -> labels
- `comment_only` surface -> does NOT label (the disjunct's own `publicSurface` check excludes it)
- `autoLabelEnabled: false` -> does NOT label

**Test-only, no production change.**

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #8324`).

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` - no workflow files touched.
- [x] `npm run typecheck`
- [x] `npx vitest run test/unit/settings-preview.test.ts` - 36 pass (was 32); the four new assertions prove both arms of the disjunct.
- [ ] `npm run test:coverage` / `test:workers` / `build:mcp` / `ui:*` - not run: this adds four assertions to one existing unit test file and touches no other surface.
- [ ] `npm audit --audit-level=moderate` - no dependency changes.
- [x] New behavior has unit tests for new branches and fallback paths - this PR **is** that coverage.

If any required check was skipped, explain why:

- Test-only change: no `src/**` lines are modified, so `codecov/patch` has no changed lines to score. The worker/MCP/UI suites are unaffected because no such code is touched.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests - n/a, none touched.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed - n/a.
- [x] UI changes use live API data or real empty/error/loading states - n/a, no UI change.
- [x] Visible UI changes include a `UI Evidence` section - n/a: test-only, no visible change.
- [x] Public docs/changelogs are updated where needed - n/a.

## Notes

- The tests deliberately drive `minerStatus: "not_checked"` so `shouldApplyPrLabel`'s own arm is `false`, isolating the inline fallback as the sole determinant of `willLabel`.
