### PR TITLE
test(scoring): cover the unpinned-SHA and languages-fetch-failed warnings (#8327)

### DIFF
--- a/test/unit/scoring.test.ts
+++ b/test/unit/scoring.test.ts
@@ -502,6 +502,46 @@ NOVELTY_BONUS_SCALAR = 3
     expect(refreshed.sourceKind).toBe("raw-github");
   });
 
+  // #8327: the fail-open SHA test above proves scoring still refreshes unpinned, but never asserted the sole
+  // operator-facing signal that it IS unpinned. Pin the warning string so a future refactor can't silently
+  // drop it.
+  it("surfaces the unpinned-fallback warning when the upstream SHA can't be resolved", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "token" });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("constants.py")) return new Response(VALID_CONSTANTS_PY + "MERGED_PR_BASE_SCORE = 25\n");
+      if (url.includes("programming_languages.json")) return Response.json({});
+      if (url.includes("api.github.com") && url.includes("/commits/")) throw new Error("network error");
+      return new Response("not found", { status: 404 });
+    });
+
+    const refreshed = await refreshScoringModelSnapshot(env);
+
+    expect(refreshed.payload.upstreamSourceSha).toBeUndefined();
+    expect(refreshed.warnings.some((w) => /immutable commit SHA/.test(w) && /unpinned/.test(w))).toBe(true);
+  });
+
+  // #8327: the languages-fetch-failed warning was unreachable by existing tests -- every constants-succeed test
+  // stubbed programming_languages.json to succeed, and every languages-fail test also failed constants first
+  // (short-circuiting into the earlier fallback). This combines constants-succeed with languages-fail.
+  it("warns when the programming-language weights fetch fails while constants still succeed", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "token" });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("constants.py")) return new Response(VALID_CONSTANTS_PY + "MERGED_PR_BASE_SCORE = 25\n");
+      if (url.includes("programming_languages.json")) return new Response("upstream down", { status: 500 });
+      if (url.includes("api.github.com") && url.includes("/commits/")) return Response.json({ sha: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2" });
+      return new Response("not found", { status: 404 });
+    });
+
+    const refreshed = await refreshScoringModelSnapshot(env);
+
+    // Constants still applied (not the fallback path), and the languages failure is surfaced as its own warning.
+    expect(refreshed.constants.MERGED_PR_BASE_SCORE).toBe(25);
+    expect(refreshed.sourceKind).toBe("raw-github");
+    expect(refreshed.warnings.some((w) => /Programming language weights fetch failed/.test(w))).toBe(true);
+  });
+
   it("pins the constants fetch to the resolved upstream SHA (immutable) when it can be resolved", async () => {
     const env = createTestEnv({ GITTENSOR_UPSTREAM_REPO: "custom/upstream", GITTENSOR_UPSTREAM_REF: "test" });
     const SHA = "0123456789abcdef0123456789abcdef01234567";


### PR DESCRIPTION
## Summary

Closes #8327.

`refreshScoringModelSnapshot` in `src/scoring/model.ts` pushes operator-facing warnings when a degraded upstream fetch is tolerated. Two of those warning branches had test-coverage gaps:

1. **Unpinned-fallback warning** (line ~59) -- the sole operator signal that scoring is running against a *mutable* ref because the immutable commit SHA couldn't be resolved. The existing "is fail-open when the upstream SHA fetch fails" test already triggers this branch but only asserts `payload.upstreamSourceSha` is undefined, never `refreshed.warnings`. A refactor could silently drop the string.

2. **Programming-language-weights-fetch-failed warning** (line ~116) -- had zero coverage. Every constants-succeed test stubbed `programming_languages.json` to succeed, and every languages-fail test also failed `constants.py` first (short-circuiting into the earlier `!constantsUsable` fallback before reaching this line). No existing test combined "constants succeed" with "languages fail".

Adds two tests:
- One asserting the unpinned warning is surfaced when the SHA lookup throws (same setup as the existing fail-open test, plus the missing `warnings` assertion).
- One combining a successful `constants.py` with a failing `programming_languages.json` (HTTP 500) so the language-weights warning branch is finally exercised, while `sourceKind` stays `raw-github` (the constants path, not the fallback).

**Test-only, no production change.**

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #8327`).

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` - no workflow files touched.
- [x] `npm run typecheck`
- [x] `npx vitest run test/unit/scoring.test.ts` - 90 pass (was 88); both new warning branches asserted.
- [ ] `npm run test:coverage` / `test:workers` / `build:mcp` / `ui:*` - not run: this adds two tests to one existing unit file and touches no other surface.
- [ ] `npm audit --audit-level=moderate` - no dependency changes.
- [x] New behavior has unit tests for new branches and fallback paths - this PR **is** that coverage.

If any required check was skipped, explain why:

- Test-only change: no `src/**` lines are modified, so `codecov/patch` has no changed lines to score.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests - n/a, none touched.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed - n/a.
- [x] UI changes use live API data or real empty/error/loading states - n/a, no UI change.
- [x] Visible UI changes include a `UI Evidence` section - n/a: test-only, no visible change.
- [x] Public docs/changelogs are updated where needed - n/a.

## Notes

- The languages-fail test asserts `sourceKind === "raw-github"` to prove the constants path was taken (not the `!constantsUsable` fallback), which is exactly what makes line ~116 reachable.
