### PR TITLE
test(ui): cover snapshot-replay privacy boundary (#8386)

### DIFF
--- a/apps/loopover-ui/src/components/site/snapshot-replay.test.tsx
+++ b/apps/loopover-ui/src/components/site/snapshot-replay.test.tsx
@@ -1,0 +1,125 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { SnapshotReplay, SnapshotReplayCard } from "@/components/site/snapshot-replay";
+import type { SnapshotReplayView } from "@/lib/snapshot-replay";
+
+// (#8386) Component coverage for the audience toggle + missing/withheld footers on snapshot replay.
+
+const PRIVATE_REASON = "AUTHENTICATED_ONLY_REASON_TEXT";
+
+function baseView(overrides: Partial<SnapshotReplayView> = {}): SnapshotReplayView {
+  return {
+    status: "populated",
+    viewer: "authenticated",
+    snapshotId: "snap-ui-1",
+    actionType: "comment",
+    target: { repoFullName: "Acme/Widget", pullNumber: 1, issueNumber: null },
+    generatedAt: "2026-06-01T12:00:00.000Z",
+    scoringModelId: "model-1",
+    confidence: "high",
+    freshness: "fresh",
+    sources: [],
+    evidenceGaps: [],
+    evidenceComplete: true,
+    staleReasons: [],
+    counterfactuals: [
+      {
+        repoFullName: "Acme/Widget",
+        recommendation: "approve",
+        alternatives: [
+          {
+            alternative: "request_changes",
+            group: "verdict",
+            publicSummary: "Public summary visible to both audiences.",
+            reason: PRIVATE_REASON,
+            facts: ["secret-fact"],
+            assumptions: ["secret-assumption"],
+          },
+        ],
+      },
+    ],
+    withheldPrivateFields: [],
+    notice: "All replayed evidence is fresh and complete.",
+    ...overrides,
+  };
+}
+
+describe("SnapshotReplayCard audience toggle (#8386)", () => {
+  it("defaults to the authenticated view and switches to publicSafe without leaking private reason text", () => {
+    const authenticated = baseView({ viewer: "authenticated" });
+    const publicSafe = baseView({
+      viewer: "public",
+      counterfactuals: [
+        {
+          repoFullName: "Acme/Widget",
+          recommendation: "approve",
+          alternatives: [
+            {
+              alternative: "request_changes",
+              group: "verdict",
+              publicSummary: "Public summary visible to both audiences.",
+              reason: null,
+              facts: [],
+              assumptions: [],
+            },
+          ],
+        },
+      ],
+      withheldPrivateFields: ["counterfactual_detail"],
+      notice: "Public-safe notice copy.",
+    });
+
+    render(<SnapshotReplayCard authenticated={authenticated} publicSafe={publicSafe} />);
+
+    expect(screen.getByRole("button", { name: "Authenticated" }).getAttribute("aria-pressed")).toBe(
+      "true",
+    );
+    expect(screen.getByText(PRIVATE_REASON)).toBeTruthy();
+    expect(screen.getByText("Public summary visible to both audiences.")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Public-safe" }));
+
+    expect(screen.getByRole("button", { name: "Public-safe" }).getAttribute("aria-pressed")).toBe(
+      "true",
+    );
+    expect(screen.queryByText(PRIVATE_REASON)).toBeNull();
+    expect(screen.getByText("Public summary visible to both audiences.")).toBeTruthy();
+    expect(screen.getByText(/Private detail withheld for this context/)).toBeTruthy();
+    expect(screen.getByText(/counterfactual_detail/)).toBeTruthy();
+  });
+});
+
+describe("SnapshotReplay rendering (#8386)", () => {
+  it("renders only the notice for missing status — no detail sections", () => {
+    render(
+      <SnapshotReplay
+        view={baseView({
+          status: "missing",
+          notice: "No decision snapshot is available to replay.",
+          counterfactuals: [],
+          withheldPrivateFields: ["counterfactual_detail"],
+        })}
+      />,
+    );
+
+    const root = screen.getByTestId("snapshot-replay");
+    expect(root.getAttribute("data-status")).toBe("missing");
+    expect(screen.getByText("No decision snapshot is available to replay.")).toBeTruthy();
+    expect(screen.queryByText("Action")).toBeNull();
+    expect(screen.queryByText("Why not the alternatives")).toBeNull();
+    expect(screen.queryByText(/Private detail withheld/)).toBeNull();
+  });
+
+  it("renders the withheldPrivateFields footer only when the array is non-empty", () => {
+    const { rerender } = render(<SnapshotReplay view={baseView({ withheldPrivateFields: [] })} />);
+    expect(screen.queryByText(/Private detail withheld for this context/)).toBeNull();
+
+    rerender(
+      <SnapshotReplay view={baseView({ withheldPrivateFields: ["counterfactual_detail"] })} />,
+    );
+    expect(
+      screen.getByText(/Private detail withheld for this context: counterfactual_detail/),
+    ).toBeTruthy();
+  });
+});

--- a/apps/loopover-ui/src/lib/snapshot-replay.test.ts
+++ b/apps/loopover-ui/src/lib/snapshot-replay.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, it } from "vitest";
+
+import { buildSnapshotReplayView, type SnapshotReplayView } from "@/lib/snapshot-replay";
+
+// (#8386) Regression coverage for the public/authenticated privacy boundary in the decision snapshot
+// replay view model — the module is intentionally standalone so these tests exercise it directly.
+
+const PRIVATE_REASON = "PRIVATE_REASON_DO_NOT_LEAK";
+const PRIVATE_FACT = "PRIVATE_FACT_DO_NOT_LEAK";
+const PRIVATE_ASSUMPTION = "PRIVATE_ASSUMPTION_DO_NOT_LEAK";
+
+function freshProvenance(overrides: Record<string, unknown> = {}) {
+  return {
+    confidence: "high",
+    freshness: "fresh",
+    scoringModelId: "model-1",
+    evidenceComplete: true,
+    evidenceGaps: [],
+    sources: [{ name: "signals", freshness: "fresh", generatedAt: "2026-01-01T00:00:00.000Z" }],
+    ...overrides,
+  };
+}
+
+function baseSnapshot(overrides: Record<string, unknown> = {}) {
+  return {
+    snapshotId: "snap-1",
+    actionType: "comment",
+    target: { repoFullName: "Acme/Widget", pullNumber: 7, issueNumber: null },
+    generatedAt: "2026-06-01T12:00:00.000Z",
+    provenance: freshProvenance(),
+    ...overrides,
+  };
+}
+
+function counterfactualFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    repoFullName: "Acme/Widget",
+    recommendation: "approve",
+    rejectedAlternatives: [
+      {
+        alternative: "request_changes",
+        group: "verdict",
+        publicSummary: "Public-safe summary only.",
+        reason: PRIVATE_REASON,
+        facts: [PRIVATE_FACT],
+        assumptions: [PRIVATE_ASSUMPTION],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function expectNoPrivateLeak(view: SnapshotReplayView) {
+  const serialized = JSON.stringify(view);
+  expect(serialized).not.toContain(PRIVATE_REASON);
+  expect(serialized).not.toContain(PRIVATE_FACT);
+  expect(serialized).not.toContain(PRIVATE_ASSUMPTION);
+  for (const cf of view.counterfactuals) {
+    for (const alt of cf.alternatives) {
+      expect(alt.reason).toBeNull();
+      expect(alt.facts).toEqual([]);
+      expect(alt.assumptions).toEqual([]);
+    }
+  }
+}
+
+describe("buildSnapshotReplayView privacy boundary (#8386)", () => {
+  it("strips reason/facts/assumptions for public viewers and records withheldPrivateFields", () => {
+    const view = buildSnapshotReplayView({
+      viewer: "public",
+      snapshot: baseSnapshot(),
+      counterfactuals: [counterfactualFixture()],
+    });
+
+    expect(view.viewer).toBe("public");
+    expect(view.withheldPrivateFields).toEqual(["counterfactual_detail"]);
+    expect(view.counterfactuals).toHaveLength(1);
+    expect(view.counterfactuals[0]!.alternatives[0]).toMatchObject({
+      publicSummary: "Public-safe summary only.",
+      reason: null,
+      facts: [],
+      assumptions: [],
+    });
+    expectNoPrivateLeak(view);
+  });
+
+  it("sets withheldPrivateFields to [] for public viewers when alternatives carry no private detail", () => {
+    const view = buildSnapshotReplayView({
+      viewer: "public",
+      snapshot: baseSnapshot(),
+      counterfactuals: [
+        {
+          repoFullName: "Acme/Widget",
+          recommendation: "approve",
+          rejectedAlternatives: [
+            {
+              alternative: "comment",
+              group: "verdict",
+              publicSummary: "Only public summary.",
+              reason: null,
+              facts: [],
+              assumptions: [],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(view.withheldPrivateFields).toEqual([]);
+    expect(view.counterfactuals[0]!.alternatives[0]!.reason).toBeNull();
+  });
+
+  it("passes counterfactuals through unchanged for authenticated viewers", () => {
+    const view = buildSnapshotReplayView({
+      viewer: "authenticated",
+      snapshot: baseSnapshot(),
+      counterfactuals: [counterfactualFixture()],
+    });
+
+    expect(view.viewer).toBe("authenticated");
+    expect(view.withheldPrivateFields).toEqual([]);
+    expect(view.counterfactuals[0]!.alternatives[0]).toMatchObject({
+      reason: PRIVATE_REASON,
+      facts: [PRIVATE_FACT],
+      assumptions: [PRIVATE_ASSUMPTION],
+    });
+  });
+});
+
+describe("buildSnapshotReplayView missing / partial snapshots (#8386)", () => {
+  it("returns missing status when snapshot is not a record", () => {
+    for (const snapshot of [null, undefined, "snap", 12, []]) {
+      const view = buildSnapshotReplayView({ viewer: "public", snapshot });
+      expect(view.status).toBe("missing");
+      expect(view.notice).toContain("No decision snapshot");
+      expect(view.snapshotId).toBeNull();
+    }
+  });
+
+  it("returns missing when provenance is absent but still carries through top-level snapshot fields", () => {
+    const view = buildSnapshotReplayView({
+      viewer: "authenticated",
+      snapshot: {
+        snapshotId: "snap-partial",
+        actionType: "approve",
+        target: { repoFullName: "Org/Repo", pullNumber: 3, issueNumber: 9 },
+        generatedAt: "2026-07-01T00:00:00.000Z",
+        provenance: null,
+      },
+    });
+
+    expect(view.status).toBe("missing");
+    expect(view.notice).toContain("no provenance");
+    expect(view.snapshotId).toBe("snap-partial");
+    expect(view.actionType).toBe("approve");
+    expect(view.generatedAt).toBe("2026-07-01T00:00:00.000Z");
+    expect(view.target).toEqual({ repoFullName: "Org/Repo", pullNumber: 3, issueNumber: 9 });
+  });
+});
+
+describe("buildSnapshotReplayView status / freshness (#8386)", () => {
+  it("is populated when freshness is fresh, evidence is complete, and gaps are empty", () => {
+    const view = buildSnapshotReplayView({
+      viewer: "public",
+      snapshot: baseSnapshot(),
+    });
+    expect(view.status).toBe("populated");
+    expect(view.staleReasons).toEqual([]);
+    expect(view.notice).toContain("fresh and complete");
+  });
+
+  it("is stale when freshness is not fresh", () => {
+    const view = buildSnapshotReplayView({
+      viewer: "public",
+      snapshot: baseSnapshot({ provenance: freshProvenance({ freshness: "stale" }) }),
+    });
+    expect(view.status).toBe("stale");
+    expect(view.staleReasons).toContain("Snapshot freshness is stale.");
+  });
+
+  it("is stale when evidenceComplete is false", () => {
+    const view = buildSnapshotReplayView({
+      viewer: "public",
+      snapshot: baseSnapshot({ provenance: freshProvenance({ evidenceComplete: false }) }),
+    });
+    expect(view.status).toBe("stale");
+    expect(view.staleReasons).toContain("Evidence is incomplete.");
+  });
+
+  it("is stale when evidenceGaps is non-empty", () => {
+    const view = buildSnapshotReplayView({
+      viewer: "public",
+      snapshot: baseSnapshot({
+        provenance: freshProvenance({ evidenceGaps: ["missing_diff"] }),
+      }),
+    });
+    expect(view.status).toBe("stale");
+    expect(view.staleReasons).toContain("Evidence gap — missing_diff.");
+    expect(view.notice).toMatch(/1 evidence caveat[^s]/);
+  });
+
+  it("pluralizes the stale notice when multiple caveats apply", () => {
+    const view = buildSnapshotReplayView({
+      viewer: "public",
+      snapshot: baseSnapshot({
+        provenance: freshProvenance({
+          freshness: "degraded",
+          evidenceComplete: false,
+          evidenceGaps: ["a", "b"],
+        }),
+      }),
+    });
+    expect(view.status).toBe("stale");
+    expect(view.staleReasons.length).toBeGreaterThan(1);
+    expect(view.notice).toMatch(/evidence caveats/);
+  });
+});
+
+describe("buildSnapshotReplayView counterfactual filtering + narrowing (#8386)", () => {
+  it("filters counterfactuals to the matching target repo case-insensitively", () => {
+    const view = buildSnapshotReplayView({
+      viewer: "authenticated",
+      snapshot: baseSnapshot({
+        target: { repoFullName: "acme/widget", pullNumber: null, issueNumber: null },
+      }),
+      counterfactuals: [
+        counterfactualFixture({ repoFullName: "ACME/WIDGET" }),
+        counterfactualFixture({
+          repoFullName: "Other/Repo",
+          rejectedAlternatives: [
+            {
+              alternative: "other",
+              group: "verdict",
+              publicSummary: "Other repo alternative",
+              reason: "x",
+              facts: [],
+              assumptions: [],
+            },
+          ],
+        }),
+      ],
+    });
+
+    expect(view.counterfactuals).toHaveLength(1);
+    expect(view.counterfactuals[0]!.repoFullName).toBe("ACME/WIDGET");
+  });
+
+  it("keeps all counterfactual entries when target repoFullName is null", () => {
+    const view = buildSnapshotReplayView({
+      viewer: "authenticated",
+      snapshot: baseSnapshot({
+        target: { repoFullName: null, pullNumber: null, issueNumber: null },
+      }),
+      counterfactuals: [
+        counterfactualFixture({ repoFullName: "One/Repo" }),
+        counterfactualFixture({
+          repoFullName: "Two/Repo",
+          rejectedAlternatives: [
+            {
+              alternative: "other",
+              group: "verdict",
+              publicSummary: "Second",
+              reason: "y",
+              facts: [],
+              assumptions: [],
+            },
+          ],
+        }),
+      ],
+    });
+
+    expect(view.counterfactuals.map((cf) => cf.repoFullName).sort()).toEqual([
+      "One/Repo",
+      "Two/Repo",
+    ]);
+  });
+
+  it("narrows unknown confidence and freshness strings to unknown", () => {
+    const view = buildSnapshotReplayView({
+      viewer: "public",
+      snapshot: baseSnapshot({
+        provenance: freshProvenance({
+          confidence: "super-high",
+          freshness: "brand-new",
+          // Keep status populated/stale deterministic: unknown freshness is not "fresh", so stale.
+          evidenceComplete: true,
+          evidenceGaps: [],
+        }),
+      }),
+    });
+
+    expect(view.confidence).toBe("unknown");
+    expect(view.freshness).toBe("unknown");
+    expect(view.status).toBe("stale");
+  });
+
+  it("accepts known confidence/freshness values without rewriting them", () => {
+    const view = buildSnapshotReplayView({
+      viewer: "public",
+      snapshot: baseSnapshot({
+        provenance: freshProvenance({ confidence: "medium", freshness: "fresh" }),
+      }),
+    });
+    expect(view.confidence).toBe("medium");
+    expect(view.freshness).toBe("fresh");
+    expect(view.status).toBe("populated");
+  });
+});


### PR DESCRIPTION
## Summary

- Closes #8386: adds `apps/loopover-ui/src/lib/snapshot-replay.test.ts` covering `buildSnapshotReplayView` public stripping of `reason`/`facts`/`assumptions`, authenticated pass-through, missing/partial snapshots, stale triggers, repo filtering, and confidence/freshness narrowing.
- Adds `apps/loopover-ui/src/components/site/snapshot-replay.test.tsx` covering the audience toggle leak-guard, missing-status notice-only render, and `withheldPrivateFields` footer.
- Resubmission of #8426 (approve/merge-recommended, CI green) which was closed only for incomplete screenshot-evidence rows.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [x] `npm run ui:test` (via `npm --workspace @loopover/ui run test -- src/lib/snapshot-replay.test.ts src/components/site/snapshot-replay.test.tsx` — 17 passing)
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Test-only UI change under `apps/**` (Codecov ignore). No `src/**` backend changes. Focused vitest suite green (17 tests).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

No rendered UI source changed — only `*.test.ts` / `*.test.tsx` were added. Before and after are identical captures of production `/` (dark-mode-only UI) so every required viewport × theme row is present. Light rows use the same dark rendering under `prefers-color-scheme: light`, matching the house convention that loopover-ui has no separate light theme.

| State / title | Before (main) | After (this PR) |
| --- | --- | --- |
| Homepage — no visual delta (test-only) — Desktop · Light | <a href="https://raw.githubusercontent.com/jsdevninja/gittensory/screenshots/8386-desktop-before-light.png"><img src="https://raw.githubusercontent.com/jsdevninja/gittensory/screenshots/8386-desktop-before-light.png" alt="before Desktop Light" width="240"></a> | <a href="https://raw.githubusercontent.com/jsdevninja/gittensory/screenshots/8386-desktop-after-light.png"><img src="https://raw.githubusercontent.com/jsdevninja/gittensory/screenshots/8386-desktop-after-light.png" alt="after Desktop Light" width="240"></a> |
| Homepage — no visual delta (test-only) — Desktop · Dark | <a href="https://raw.githubusercontent.com/jsdevninja/gittensory/screenshots/8386-desktop-before-dark.png"><img src="https://raw.githubusercontent.com/jsdevninja/gittensory/screenshots/8386-desktop-before-dark.png" alt="before Desktop Dark" width="240"></a> | <a href="https://raw.githubusercontent.com/jsdevninja/gittensory/screenshots/8386-desktop-after-dark.png"><img src="https://raw.githubusercontent.com/jsdevninja/gittensory/screenshots/8386-desktop-after-dark.png" alt="after Desktop Dark" width="240"></a> |
| Homepage — no visual delta (test-only) — Tablet · Light | <a href="https://raw.githubusercontent.com/jsdevninja/gittensory/screenshots/8386-tablet-before-light.png"><img src="https://raw.githubusercontent.com/jsdevninja/gittensory/screenshots/8386-tablet-before-light.png" alt="before Tablet Light" width="240"></a> | <a href="https://raw.githubusercontent.com/jsdevninja/gittensory/screenshots/8386-tablet-after-light.png"><img src="https://raw.githubusercontent.com/jsdevninja/gittensory/screenshots/8386-tablet-after-light.png" alt="after Tablet Light" width="240"></a> |
| Homepage — no visual delta (test-only) — Tablet · Dark | <a href="https://raw.githubusercontent.com/jsdevninja/gittensory/screenshots/8386-tablet-before-dark.png"><img src="https://raw.githubusercontent.com/jsdevninja/gittensory/screenshots/8386-tablet-before-dark.png" alt="before Tablet Dark" width="240"></a> | <a href="https://raw.githubusercontent.com/jsdevninja/gittensory/screenshots/8386-tablet-after-dark.png"><img src="https://raw.githubusercontent.com/jsdevninja/gittensory/screenshots/8386-tablet-after-dark.png" alt="after Tablet Dark" width="240"></a> |
| Homepage — no visual delta (test-only) — Mobile · Light | <a href="https://raw.githubusercontent.com/jsdevninja/gittensory/screenshots/8386-mobile-before-light.png"><img src="https://raw.githubusercontent.com/jsdevninja/gittensory/screenshots/8386-mobile-before-light.png" alt="before Mobile Light" width="240"></a> | <a href="https://raw.githubusercontent.com/jsdevninja/gittensory/screenshots/8386-mobile-after-light.png"><img src="https://raw.githubusercontent.com/jsdevninja/gittensory/screenshots/8386-mobile-after-light.png" alt="after Mobile Light" width="240"></a> |
| Homepage — no visual delta (test-only) — Mobile · Dark | <a href="https://raw.githubusercontent.com/jsdevninja/gittensory/screenshots/8386-mobile-before-dark.png"><img src="https://raw.githubusercontent.com/jsdevninja/gittensory/screenshots/8386-mobile-before-dark.png" alt="before Mobile Dark" width="240"></a> | <a href="https://raw.githubusercontent.com/jsdevninja/gittensory/screenshots/8386-mobile-after-dark.png"><img src="https://raw.githubusercontent.com/jsdevninja/gittensory/screenshots/8386-mobile-after-dark.png" alt="after Mobile Dark" width="240"></a> |

## Notes

- Same diff as #8426; only the PR body/UI Evidence grid differs.
