### PR TITLE
fix(orb): guard finalizeRelayFailureRetryRow DB writes against duplicate redelivery (#8332)

### DIFF
--- a/src/orb/relay.ts
+++ b/src/orb/relay.ts
@@ -106,14 +106,30 @@ async function finalizeRelayFailureRetryRow(
   row: { delivery_id: string; event_name: string; installation_id: number },
   outcome: RelayForwardOutcome,
 ): Promise<void> {
-  if (isRelayFailureRetryTerminal(outcome, row.event_name)) {
-    await env.DB.prepare("DELETE FROM orb_relay_failures WHERE delivery_id = ?").bind(row.delivery_id).run();
+  try {
+    if (isRelayFailureRetryTerminal(outcome, row.event_name)) {
+      await env.DB.prepare("DELETE FROM orb_relay_failures WHERE delivery_id = ?").bind(row.delivery_id).run();
+      return;
+    }
+    await env.DB
+      .prepare("UPDATE orb_relay_failures SET attempts = attempts + 1, last_attempt_at = datetime('now') WHERE delivery_id = ?")
+      .bind(row.delivery_id)
+      .run();
+  } catch (error) {
+    // The forward already succeeded (outcome is known) before this write failed -- the row stays pending retry, so
+    // the SAME event risks redelivery to the container on the next retry tick. Never throw (retryFailedRelays's
+    // "Never throws" contract): log with enough context to spot the duplicate-forward risk from the log alone.
+    console.error(JSON.stringify({
+      level: "error",
+      event: "orb_relay_failure_finalize_write_failed",
+      message: `finalizeRelayFailureRetryRow DB write failed after a successful forward -- duplicate redelivery risk for ${row.delivery_id}`,
+      deliveryId: row.delivery_id,
+      eventName: row.event_name,
+      outcome,
+      error: error instanceof Error ? error.message : String(error),
+    }));
     return;
   }
-  await env.DB
-    .prepare("UPDATE orb_relay_failures SET attempts = attempts + 1, last_attempt_at = datetime('now') WHERE delivery_id = ?")
-    .bind(row.delivery_id)
-    .run();
   if (outcome === "skipped") {
     logRelayTransientSkip({
       deliveryId: row.delivery_id,

--- a/test/integration/orb-relay.test.ts
+++ b/test/integration/orb-relay.test.ts
@@ -402,6 +402,56 @@ describe("retryFailedRelays", () => {
     expect(row ?? null).toBeNull(); // row removed on success
   });
 
+  it("does not throw when the finalize DELETE fails right after a successful forward (#8332 duplicate-redelivery guard)", async () => {
+    const e = brokeredEnv();
+    const secret = await enroll(e, 9700);
+    await registerOrbRelay(e, secret, "https://c.example/v1/orb/relay");
+    await storeRelayFailure(e, { deliveryId: "finalize-delete-fail", eventName: "pull_request", installationId: 9700, rawBody: "{}" });
+    const realPrepare = db(e).prepare.bind(db(e));
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    e.DB = {
+      prepare: (sql: string) =>
+        sql === "DELETE FROM orb_relay_failures WHERE delivery_id = ?"
+          ? { bind: () => ({ run: async () => { throw new Error("simulated D1 write failure"); } }) }
+          : realPrepare(sql),
+    } as unknown as Env["DB"];
+    const fetchOk = (() => Promise.resolve(new Response("ok", { status: 200 }))) as typeof fetch;
+    await expect(retryFailedRelays(e, { fetchImpl: fetchOk })).resolves.toBeUndefined(); // "Never throws" contract holds
+    expect(
+      errorLog.mock.calls.some(
+        ([line]) =>
+          String(line).includes("orb_relay_failure_finalize_write_failed") &&
+          String(line).includes("finalize-delete-fail") &&
+          String(line).includes("forwarded"),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not throw when the finalize UPDATE fails right after a non-terminal forward (#8332 duplicate-redelivery guard)", async () => {
+    const e = brokeredEnv();
+    const secret = await enroll(e, 9701);
+    await registerOrbRelay(e, secret, "https://c.example/v1/orb/relay");
+    await storeRelayFailure(e, { deliveryId: "finalize-update-fail", eventName: "pull_request", installationId: 9701, rawBody: "{}" });
+    const realPrepare = db(e).prepare.bind(db(e));
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    e.DB = {
+      prepare: (sql: string) =>
+        sql === "UPDATE orb_relay_failures SET attempts = attempts + 1, last_attempt_at = datetime('now') WHERE delivery_id = ?"
+          ? { bind: () => ({ run: async () => { throw new Error("simulated D1 write failure"); } }) }
+          : realPrepare(sql),
+    } as unknown as Env["DB"];
+    const fetchFail = (() => Promise.resolve(new Response("bad", { status: 503 }))) as typeof fetch;
+    await expect(retryFailedRelays(e, { fetchImpl: fetchFail })).resolves.toBeUndefined(); // "Never throws" contract holds
+    expect(
+      errorLog.mock.calls.some(
+        ([line]) =>
+          String(line).includes("orb_relay_failure_finalize_write_failed") &&
+          String(line).includes("finalize-update-fail") &&
+          String(line).includes("failed"),
+      ),
+    ).toBe(true);
+  });
+
   it("INCREMENTS attempts when forwardOrbEvent still fails", async () => {
     const e = brokeredEnv();
     const secret = await enroll(e, 9101);


### PR DESCRIPTION
## Summary

- `src/orb/relay.ts`'s `retryFailedRelays` doc comment promises "Never throws." Its per-row finalize step, `finalizeRelayFailureRetryRow`, issued its `DELETE`/`UPDATE` on `orb_relay_failures` with no try/catch — a transient D1 write failure right after a successful forward would reject out of the `Promise.all` batch, breaking that contract, and would leave the failure row un-deleted despite the event already having been forwarded (risking duplicate redelivery on the next retry tick). Wrapped both writes in a try/catch that logs an alertable structured error (`delivery_id`, `event_name`, `outcome`) and swallows, matching this file's existing `console.error(JSON.stringify({...}))` logging convention used elsewhere in the same file.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

Closes #8332

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npx vitest run test/integration/orb-relay.test.ts --coverage --coverage.include="src/orb/relay.ts"` — all 85 tests pass; the two new/changed lines in `finalizeRelayFailureRetryRow` are fully exercised by two new regression tests (DELETE-path and UPDATE-path DB-write failure)
- [ ] `npm run actionlint`
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This change touches only `src/orb/relay.ts` and its integration test (no UI/MCP/worker/OpenAPI surface touched), so the UI/MCP/workers/OpenAPI-specific checks above were not run locally; they are unaffected by this diff and are still exercised by the full CI gate.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session/CORS code touched.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (Internal retry-cron behavior only; no external API/OpenAPI/MCP surface changed.)
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI touched.)
- [ ] Visible UI changes include a `UI Evidence` section below. (N/A — no visible UI change.)
- [ ] Public docs/changelogs are updated where needed. (N/A — no docs/changelog change needed.)

## UI Evidence

N/A — this is a backend cron/retry-path change with no visible UI surface.

## Notes

- Only `finalizeRelayFailureRetryRow`'s two DB writes are guarded; no other logic in `retryFailedRelays` or elsewhere in the file was touched, per the issue's own scope note.
