### PR TITLE
fix(selfhost): bound s3-blob-store fetch calls with a per-attempt timeout (#8362)

### DIFF
--- a/src/selfhost/s3-blob-store.ts
+++ b/src/selfhost/s3-blob-store.ts
@@ -37,6 +37,12 @@ export type S3BlobStoreConfig = {
 // review pipeline over a persistently misconfigured or down bucket.
 const S3_CLIENT_RETRIES = 3;
 
+// Per-request ceiling for every S3 REST call (matches the bounded-fetch convention already used by the
+// other self-host adapters, e.g. qdrant-vectorize.ts's QDRANT_FETCH_TIMEOUT_MS). aws4fetch's `retries`
+// option above only bounds retry COUNT, not per-attempt hang time -- a misconfigured or unreachable
+// S3-compatible endpoint could otherwise hang get/put/delete indefinitely.
+const S3_FETCH_TIMEOUT_MS = 15_000;
+
 /** Build an S3-compatible-bucket-backed REVIEW_AUDIT store. Keys are app-generated
  *  (`loopover/shots/<hash>.png`, already validated by the /loopover/shot serve route's own prefix +
  *  traversal check) and passed straight through as the S3 object key -- no additional encoding beyond the
@@ -56,7 +62,7 @@ export function createS3BlobStore(config: S3BlobStoreConfig): R2Bucket {
     /** Stream a stored object's bytes, or null on a miss (404) or any request failure. */
     async get(key: string): Promise<R2ObjectBody | null> {
       try {
-        const response = await client.fetch(urlFor(key), { method: "GET" });
+        const response = await client.fetch(urlFor(key), { method: "GET", signal: AbortSignal.timeout(S3_FETCH_TIMEOUT_MS) });
         if (!response.ok) return null;
         return { body: response.body } as unknown as R2ObjectBody;
       } catch {
@@ -74,14 +80,14 @@ export function createS3BlobStore(config: S3BlobStoreConfig): R2Bucket {
       const body = await new Response(value ?? "").arrayBuffer();
       const headers: Record<string, string> = {};
       if (options?.httpMetadata?.contentType) headers["content-type"] = options.httpMetadata.contentType;
-      const response = await client.fetch(urlFor(key), { method: "PUT", headers, body });
+      const response = await client.fetch(urlFor(key), { method: "PUT", headers, body, signal: AbortSignal.timeout(S3_FETCH_TIMEOUT_MS) });
       if (!response.ok) throw new Error(`S3 put failed: ${response.status} ${await response.text().catch(() => "")}`);
       return { key } as unknown as R2Object;
     },
     /** Delete a stored object. Best-effort semantics live with the caller (see actions-fallback.ts's dispatch
      *  marker cleanup) -- this itself just reports whether the DELETE request succeeded. */
     async delete(key: string): Promise<void> {
-      const response = await client.fetch(urlFor(key), { method: "DELETE" });
+      const response = await client.fetch(urlFor(key), { method: "DELETE", signal: AbortSignal.timeout(S3_FETCH_TIMEOUT_MS) });
       if (!response.ok && response.status !== 404) {
         throw new Error(`S3 delete failed: ${response.status} ${await response.text().catch(() => "")}`);
       }

--- a/test/unit/selfhost-s3-blob-store.test.ts
+++ b/test/unit/selfhost-s3-blob-store.test.ts
@@ -120,3 +120,40 @@ describe("createS3BlobStore (self-host visual screenshot persistence, S3-compati
     expect(request.headers.get("authorization")).toContain("/us-east-1/s3/aws4_request");
   });
 });
+
+describe("S3 REST calls are bounded by an AbortSignal timeout (#8362)", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("get, put, and delete all pass an AbortSignal to the underlying fetch", async () => {
+    fetchMock.mockResolvedValue(new Response(new Uint8Array([1]), { status: 200 }));
+    const store = createS3BlobStore(CONFIG);
+    await store.get("loopover/shots/x.png");
+    await store.put("loopover/shots/x.png", new Uint8Array([1]));
+    await store.delete("loopover/shots/x.png");
+
+    expect(fetchMock.mock.calls.length).toBe(3);
+    for (const call of fetchMock.mock.calls) {
+      const [request] = call as [Request];
+      expect(request.signal).toBeInstanceOf(AbortSignal);
+    }
+  });
+
+  it("a get() request that aborts (simulating a timed-out fetch) degrades to null (never throws), matching the network-failure fail-safe", async () => {
+    fetchMock.mockRejectedValueOnce(new DOMException("The operation was aborted.", "TimeoutError"));
+    await expect(createS3BlobStore(CONFIG).get("loopover/shots/x.png")).resolves.toBeNull();
+  });
+
+  it("a put() request that aborts (simulating a timed-out fetch) rejects, matching the network-failure fail-safe contract of put/delete", async () => {
+    fetchMock.mockRejectedValueOnce(new DOMException("The operation was aborted.", "TimeoutError"));
+    await expect(createS3BlobStore(CONFIG).put("loopover/shots/x.png", new Uint8Array([1]))).rejects.toThrow(/aborted/);
+  });
+});


### PR DESCRIPTION
## Summary

- This repo's self-host backend adapters follow a bounded-fetch convention: every external network call carries an explicit timeout (see `src/selfhost/qdrant-vectorize.ts`'s `QDRANT_FETCH_TIMEOUT_MS` / `signal: AbortSignal.timeout(...)`, and `src/selfhost/ai.ts`). `src/selfhost/s3-blob-store.ts`'s three `client.fetch()` calls (`get`, `put`, `delete`) carried no timeout at all — a misconfigured or unreachable S3-compatible endpoint could hang each call indefinitely, which in turn hangs the screenshot/visual-review pipeline that depends on this store. Added a `S3_FETCH_TIMEOUT_MS` constant and passed `signal: AbortSignal.timeout(S3_FETCH_TIMEOUT_MS)` to all three calls, mirroring the qdrant-vectorize pattern exactly.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

Closes #8362

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npx vitest run test/unit/selfhost-s3-blob-store.test.ts --coverage --coverage.include="src/selfhost/s3-blob-store.ts"` — all 17 tests pass (14 pre-existing + 3 new), 100% branch coverage on the changed file
- [ ] `npm run actionlint`
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This change touches only `src/selfhost/s3-blob-store.ts` and its unit test (no UI/MCP/worker/OpenAPI surface touched), so the UI/MCP/workers/OpenAPI-specific checks above were not run locally; they are unaffected by this diff and are still exercised by the full CI gate.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session/CORS code touched.)
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — internal self-host blob-store adapter only, no external API/OpenAPI/MCP surface.)
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI touched.)
- [ ] Visible UI changes include a `UI Evidence` section below. (N/A — no visible UI change.)
- [ ] Public docs/changelogs are updated where needed. (N/A — no docs/changelog change needed.)

## UI Evidence

N/A — this is a backend adapter change with no visible UI surface.

## Notes

- Only the timeout/signal wiring changed; `aws4fetch`'s `retries: 3` option and all other client configuration are untouched, per the issue's own scope note.
