### PR TITLE
fix(review): re-sync the two public-surface redaction term lists

### DIFF
--- a/src/review/unified-comment-bridge.ts
+++ b/src/review/unified-comment-bridge.ts
@@ -71,8 +71,8 @@ export { splitAiReviewNits } from "./ai-notes";
 // src/signals/engine.ts containsPrivatePublicTerm (drop if still present). Kept inline so this module
 // stays a pure, dependency-light renderer-mapping seam.
 const PRIVATE_FORBIDDEN_TERMS =
-  /\b(?:rewards?|payouts?|farming|estimated\s+scores?|raw\s+trust\s+scores?|trust\s+scores?|score\s+estimates?|reward\s+estimates?|wallets?|hotkeys?|coldkeys?|reviewability|scoreability|private\s+signals?|likely_duplicate|reviewability\s*\d)\b/gi;
-const PRIVATE_DROP_TERMS = /\b(?:reward|payout|farming|wallet|hotkey|trust score|raw trust|estimated score|scoreability|likely_duplicate|reviewability\s*\d)\b/i;
+  /\b(?:rewards?|payouts?|farming|estimated\s+scores?|raw\s+trust\s+scores?|raw\s+trust|trust\s+scores?|score\s+estimates?|reward\s+estimates?|wallets?|hotkeys?|coldkeys?|mnemonics?|seed\s?phrases?|cohorts?|miner[-_\s]?originated|human[-_\s]?originated|rankings?|reviewability|scoreability|private\s+signals?|likely_duplicate|reviewability\s*\d)\b/gi;
+const PRIVATE_DROP_TERMS = /\b(?:reward|payout|farming|wallet|hotkey|trust score|raw trust|estimated score|scoreability|cohort|mnemonic|likely_duplicate|reviewability\s*\d)\b/i;
 
 /** Scrub forbidden terms from a contributor-facing Nit; return null to DROP it if it still leaks after
  *  scrubbing (fail-safe: never publish a line that names private rubric/scoring/reward internals). */

--- a/src/rules/advisory.ts
+++ b/src/rules/advisory.ts
@@ -379,7 +379,7 @@ export function buildIssueAdvisory(repo: RepositoryRecord | null, issue: IssueRe
 // for the same leak class (#7074) -- `raw\s+trust\s+scores?` stays ahead of bare `raw\s+trust` so the compound
 // still matches first.
 const CHECK_RUN_FORBIDDEN_TERMS =
-  /\b(?:rewards?|payouts?|farming|estimated\s+scores?|raw\s+trust\s+scores?|raw\s+trust|trust\s+scores?|score\s+estimates?|reward\s+estimates?|wallets?|hotkeys?|coldkeys?|mnemonics?|seed\s?phrases?|cohorts?|miner[-_\s]?originated|human[-_\s]?originated|rankings?|reviewability|scoreability|private\s+signals?)\b/gi;
+  /\b(?:rewards?|payouts?|farming|estimated\s+scores?|raw\s+trust\s+scores?|raw\s+trust|trust\s+scores?|score\s+estimates?|reward\s+estimates?|wallets?|hotkeys?|coldkeys?|mnemonics?|seed\s?phrases?|cohorts?|miner[-_\s]?originated|human[-_\s]?originated|rankings?|reviewability|scoreability|private\s+signals?|likely_duplicate|reviewability\s*\d)\b/gi;
 
 function sanitizeForCheckRun(text: string): string {
   return text.replace(CHECK_RUN_FORBIDDEN_TERMS, "[context]").replace(/\s+/g, " ").trim();

--- a/test/unit/unified-comment-bridge.test.ts
+++ b/test/unit/unified-comment-bridge.test.ts
@@ -13,6 +13,7 @@ import {
   verdictToRecommendation,
   visualFindingsFromFindings,
 } from "../../src/review/unified-comment-bridge";
+import { buildCheckRunAnnotations } from "../../src/rules/advisory";
 import { VISUAL_REGRESSION_FINDING_CODE, VISUAL_UNRELATED_ISSUE_FINDING_CODE } from "../../src/review/visual/visual-findings";
 import { PR_PANEL_COMMENT_MARKER as MARKER_FROM_COMMENTS } from "../../src/github/comments";
 import { deriveUnifiedStatus, type MergeReadiness, type UnifiedCollapsible, type UnifiedCommentStatus } from "../../src/review/unified-comment";
@@ -1418,6 +1419,71 @@ describe("buildDualReviewNotes — public-safe Nit scrub (privacy-critical, gate
       });
       const nit = reviews[0]?.notes?.nits?.[0] ?? "";
       expect(nit, `"${term}" must not leak`).not.toContain(term);
+    }
+  });
+
+  it("REGRESSION (#8322): every forbidden term is redacted by BOTH public-surface sanitizers (check-run text and PR-comment Nits)", () => {
+    // The two lists had drifted: advisory.ts scrubbed mnemonic/seed phrase/cohort/miner-originated/
+    // human-originated/rankings/bare "raw trust" while the Nit path did not (so those leaked into public
+    // PR comments), and the Nit path scrubbed likely_duplicate/reviewability<digit> while the check-run
+    // path did not. This drives one representative string per term through BOTH sanitizers via their real
+    // public entry points, so a future one-sided edit to either regex fails here. It is deliberately a
+    // behavioral test, not a string comparison of the two regex sources.
+    const forbiddenTerms = [
+      "reward", "rewards", "payout", "payouts", "farming", "estimated score", "raw trust scores",
+      "raw trust", "trust score", "score estimates", "reward estimates", "wallet", "hotkey", "coldkey",
+      "mnemonic", "seed phrase", "cohort", "miner-originated", "human_originated", "rankings",
+      "reviewability", "scoreability", "private signals", "likely_duplicate", "reviewability3",
+    ];
+
+    for (const term of forbiddenTerms) {
+      // (1) PR-comment Nit path — publicSafeNit scrubs to "[context]" or drops the Nit entirely.
+      const reviews = buildDualReviewNotes({
+        aiReview: { notes: "Reviewer assessment." },
+        warnings: [{ code: "w", severity: "warning", title: `Concern about ${term} here`, detail: "...", action: "n/a" }],
+        recommendation: "manual_review",
+        verdict: "manual",
+      });
+      const nit = reviews[0]?.notes?.nits?.[0] ?? "";
+      expect(nit.toLowerCase(), `Nit path must not leak "${term}"`).not.toContain(term.toLowerCase());
+
+      // (2) Check-run annotation path — sanitizeForCheckRun scrubs title and message.
+      const advisory = {
+        id: "a1",
+        targetType: "pull_request" as const,
+        targetKey: "o/r#1",
+        repoFullName: "o/r",
+        pullNumber: 1,
+        headSha: "sha",
+        conclusion: "neutral" as const,
+        severity: "warning" as const,
+        title: "LoopOver advisory",
+        summary: "s",
+        findings: [
+          {
+            code: "missing_test_evidence",
+            title: `Concern about ${term} here`,
+            severity: "warning" as const,
+            detail: `Detail naming ${term} explicitly.`,
+            // publicText is what actually reaches an annotation (advisory.ts skips findings without it),
+            // so the term must live here or the check-run leg would assert against an EMPTY list.
+            publicText: `Detail naming ${term} explicitly.`,
+          },
+        ],
+        generatedAt: "2026-07-24T00:00:00.000Z",
+      };
+      const { annotations } = buildCheckRunAnnotations(
+        advisory,
+        {
+          files: [{ repoFullName: "o/r", pullNumber: 1, path: "src/a.ts", additions: 1, deletions: 0, changes: 1, payload: {} }],
+          collisions: { repoFullName: "o/r", generatedAt: "2026-07-24T00:00:00.000Z", summary: { clusterCount: 0, highRiskCount: 0, itemsReviewed: 0 }, clusters: [] },
+          pullNumber: 1,
+        },
+        "standard",
+      );
+      // Non-vacuity guard: an empty annotation list would make the assertion below trivially true.
+      expect(annotations.length, `check-run leg must actually produce an annotation for "${term}"`).toBeGreaterThan(0);
+      expect(JSON.stringify(annotations).toLowerCase(), `check-run path must not leak "${term}"`).not.toContain(term.toLowerCase());
     }
   });
 


### PR DESCRIPTION
## Summary

`src/review/unified-comment-bridge.ts` documents `PRIVATE_FORBIDDEN_TERMS` as mirroring `src/rules/advisory.ts`'s `CHECK_RUN_FORBIDDEN_TERMS`. It did not — the two had drifted **in both directions**, so a term redacted on one public surface leaked on the other:

- **Missing from the PR-comment Nit path** (present in `advisory.ts`): bare `raw\s+trust`, `mnemonics?`, `seed\s?phrases?`, `cohorts?`, `miner[-_\s]?originated`, `human[-_\s]?originated`, `rankings?`. A Nit naming e.g. "cohort" or "mnemonic" reached a **public GitHub comment unredacted**, while the identical term was correctly scrubbed on the check-run path.
- **Missing from the check-run path** (present in the bridge): `likely_duplicate`, `reviewability\s*\d` (the digit variant exists because `reviewability3` has no word boundary before the digit).

Both regexes are now the **identical union** of the two vocabularies, and `PRIVATE_DROP_TERMS` (the Nit fail-safe) gains `cohort` and `mnemonic` — the two most likely to appear in free-text Nits.

Closes #8322

## The parity test

The issue asked for a real behavioral test that fails if **either** list regresses, explicitly *not* a string comparison of the two regex sources (their syntax legitimately differs). The new test drives one representative string per term — 25 of them, the union — through **both** sanitizers via their real public entry points (`buildDualReviewNotes` → `publicSafeNit`, and `buildCheckRunAnnotations` → `sanitizeForCheckRun`), asserting the term never survives.

I verified it actually bites, rather than assuming it does:

| Reverted list | Parity test |
| --- | --- |
| Bridge back to its drifted form | **fails** ✅ |
| `advisory.ts` back to its drifted form | **fails** ✅ |
| Both current | passes ✅ |

That second case matters: my first draft of the check-run leg **passed** against a drifted `advisory.ts` — a false negative. `buildCheckRunAnnotations` skips findings without `publicText` and only annotates files shaped as `PullRequestFileRecord` (`path`, not `filename`), so it was asserting against an **empty** annotation list. Fixed by putting the term in `publicText` and adding an explicit non-vacuity assertion (`annotations.length > 0`) so the check-run leg can never silently assert nothing again.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This diff touches two regex constants in `src/**` plus one test file, so `actionlint` (no workflow change), `build:mcp`/`test:mcp-pack` (no MCP change), `ui:*` (no UI/OpenAPI change), `test:workers` (no worker change), and `npm audit` (no dependency change) are not exercised by it.
- **Diff coverage verified at 100%** via the scoped simulation CI runs (`vitest run --coverage --coverage.all=false`): all three changed source lines (`advisory.ts:382`, `unified-comment-bridge.ts:74-75`) are executed, with every newly-added term individually exercised by the parity test as the coverage requirement demands. `unified-comment-bridge.test.ts` + `rules.test.ts` pass in full (195 tests) and root `tsc --noEmit` is clean.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — two backend redaction regexes and a test; no visible UI, frontend, docs, or extension change.

## Notes

- This only ever **widens** redaction on both surfaces: no term was removed from either list, so nothing that was previously scrubbed now leaks. The existing "scrub list is a superset of the drop guard" invariant still holds — the scrub union covers every drop term including the two new ones.
- Ordering is preserved so longest-match-first still wins (`raw\s+trust\s+scores?` stays ahead of bare `raw\s+trust`).
