### PR TITLE
fix(signals): guard focus-manifest's preferred linked-issue nudge on bodyObserved (#8326)

### DIFF
--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -780,7 +780,7 @@ export function buildFocusManifestGuidance(args: {
       action: "Link the relevant issue (for example `Closes #123`) before opening the PR.",
     });
     publicNextSteps.push("Link the relevant tracked issue; the maintainer requires linked issues on PRs.");
-  } else if (manifest.linkedIssuePolicy === "preferred" && linkedIssueCount === 0) {
+  } else if (manifest.linkedIssuePolicy === "preferred" && linkedIssueCount === 0 && bodyObserved) {
     findings.push({
       code: "manifest_linked_issue_preferred",
       severity: "info",

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -701,6 +701,15 @@ describe("buildFocusManifestGuidance", () => {
     expect(guidance.findings.some((finding) => finding.code === "manifest_linked_issue_preferred")).toBe(true);
   });
 
+  // #8326: the "preferred" branch was missing the bodyObserved guard its "required" sibling already has (tested
+  // just above), so a sparse webhook payload (body never observed -> linkedIssueCount === 0 only means "unknown")
+  // could surface the "prefers a linked issue" nudge as a false positive.
+  it("does NOT prefer-nudge when the PR body was never observed (bodyObserved: false)", () => {
+    const manifest = parseFocusManifest({ wantedPaths: ["src/"], linkedIssuePolicy: "preferred" });
+    const guidance = buildFocusManifestGuidance({ manifest, changedPaths: ["src/x.ts"], linkedIssueCount: 0, testFileCount: 1, bodyObserved: false });
+    expect(guidance.findings.some((finding) => finding.code === "manifest_linked_issue_preferred")).toBe(false);
+  });
+
   it("surfaces missing preferred labels and test expectations", () => {
     const guidance = buildFocusManifestGuidance({ manifest: wanted, changedPaths: ["src/x.ts"], labels: [], linkedIssueCount: 1, testFileCount: 0, passedValidationCount: 0 });
     expect(guidance.findings.some((finding) => finding.code === "manifest_missing_preferred_label")).toBe(true);


### PR DESCRIPTION
## Summary

Closes #8326.

`buildFocusManifestGuidance` in `src/signals/focus-manifest.ts` builds contributor-facing findings from a repo's maintainer focus manifest. Its `"required"` linked-issue branch already carries a `bodyObserved` guard:

```ts
if (manifest.linkedIssuePolicy === "required" && linkedIssueCount === 0 && bodyObserved && !hasNoIssueRationale) {
```

That guard exists to avoid a false positive on a sparse webhook payload where the PR body was never actually observed -- `linkedIssueCount === 0` then only means "we don't know", not "there really is no linked issue".

The `"preferred"` sibling immediately below was missing it, so a repo configured with `linkedIssuePolicy: "preferred"` could surface the "Maintainer prefers a linked issue" nudge for a PR whose body was never observed -- the exact false-positive class the `"required"` branch was already fixed to avoid.

Adds `&& bodyObserved` to the `"preferred"` condition so it matches its sibling.

Per the issue's guidance, `hasNoIssueRationale` is deliberately **not** added to the `"preferred"` branch -- only the concretely-verified `bodyObserved` gap is closed, leaving the stricter `"required"` contract's extra exemption where it is.

### Tests

Adds a regression test asserting a `preferred`-policy repo with `bodyObserved: false` and `linkedIssueCount: 0` does **not** produce the `manifest_linked_issue_preferred` finding. The existing "prefers a linked issue under the preferred policy" test directly above already covers the `bodyObserved: true` arm, so both sides of the new operand are exercised.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #8326`).

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` - no workflow files touched.
- [x] `npm run typecheck`
- [x] `npx vitest run test/unit/focus-manifest.test.ts` - 793 pass (was 792).
- [x] Changed-line coverage verified locally: the modified line executes 299x with the new `bodyObserved` operand exercised on both arms (true via the existing preferred test, false via the new one).
- [ ] `npm run test:coverage` (full) / `test:workers` / `build:mcp` / `ui:*` - not run: this is a one-line condition change plus one test, touching no worker, MCP, or UI surface.
- [ ] `npm audit --audit-level=moderate` - no dependency changes.
- [x] New or changed behavior has unit tests for new branches and fallback paths.

If any required check was skipped, explain why:

- The one changed `src/**` line is covered on both branch arms locally, so `codecov/patch` has real coverage for the diff.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests - n/a, none touched.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed - n/a; this only narrows an advisory finding's condition.
- [x] UI changes use live API data or real empty/error/loading states - n/a, no UI change.
- [x] Visible UI changes include a `UI Evidence` section - n/a: no visible UI/frontend/docs/extension change.
- [x] Public docs/changelogs are updated where needed - n/a.

## Notes

- This strictly *narrows* when an advisory `info` finding is emitted; it can never introduce a new blocker.
