### PR TITLE
test(ui): cover analytics-proxy's allowlist, cookie/IP, and set-cookie stripping (#8387)

### DIFF
--- a/apps/loopover-ui/src/lib/analytics-proxy.test.ts
+++ b/apps/loopover-ui/src/lib/analytics-proxy.test.ts
@@ -12,10 +12,16 @@ type ForwardedCall = { url: string; method: string; headers: Headers };
 /** Stub global fetch to return `response`, recording each forwarded request in a typed, inspectable list. */
 function stubUpstream(response: Response) {
   const calls: ForwardedCall[] = [];
-  const fetchMock = vi.fn(async (url: string | URL, init?: { method?: string; headers?: HeadersInit }) => {
-    calls.push({ url: String(url), method: init?.method ?? "GET", headers: new Headers(init?.headers) });
-    return response;
-  });
+  const fetchMock = vi.fn(
+    async (url: string | URL, init?: { method?: string; headers?: HeadersInit }) => {
+      calls.push({
+        url: String(url),
+        method: init?.method ?? "GET",
+        headers: new Headers(init?.headers),
+      });
+      return response;
+    },
+  );
   vi.stubGlobal("fetch", fetchMock);
   return { fetchMock, calls };
 }
@@ -31,9 +37,13 @@ afterEach(() => {
 
 describe("handleAnalyticsProxy", () => {
   it("forwards an allowed POST to the upstream collect endpoint, preserving the query and relaying the response", async () => {
-    const { fetchMock, calls } = stubUpstream(new Response("ok-body", { status: 202, statusText: "Accepted" }));
+    const { fetchMock, calls } = stubUpstream(
+      new Response("ok-body", { status: 202, statusText: "Accepted" }),
+    );
 
-    const response = await handleAnalyticsProxy(send({ query: "?v=2&cache=abc", body: "beacon-payload" }));
+    const response = await handleAnalyticsProxy(
+      send({ query: "?v=2&cache=abc", body: "beacon-payload" }),
+    );
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     // /stats prefix stripped, path + query preserved onto the real upstream host.
@@ -68,7 +78,9 @@ describe("handleAnalyticsProxy", () => {
   it("strips the visitor's first-party cookie before forwarding (cookieless guarantee, #597)", async () => {
     const { calls } = stubUpstream(new Response(null, { status: 200 }));
 
-    await handleAnalyticsProxy(send({ headers: { cookie: "session=secret; theme=dark", "x-keep": "yes" } }));
+    await handleAnalyticsProxy(
+      send({ headers: { cookie: "session=secret; theme=dark", "x-keep": "yes" } }),
+    );
 
     expect(calls[0]!.headers.get("cookie")).toBeNull();
     // Non-stripped headers still pass through, so this isn't just dropping everything.
@@ -96,7 +108,12 @@ describe("handleAnalyticsProxy", () => {
   });
 
   it("strips set-cookie from the upstream response before relaying it to the browser", async () => {
-    stubUpstream(new Response("ok", { status: 200, headers: { "set-cookie": "umami=1; Path=/", "x-app": "v1" } }));
+    stubUpstream(
+      new Response("ok", {
+        status: 200,
+        headers: { "set-cookie": "umami=1; Path=/", "x-app": "v1" },
+      }),
+    );
 
     const response = await handleAnalyticsProxy(send());
 

--- a/apps/loopover-ui/src/lib/analytics-proxy.test.ts
+++ b/apps/loopover-ui/src/lib/analytics-proxy.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { handleAnalyticsProxy } from "./analytics-proxy";
+
+// #8387: the analytics proxy is the cookieless-beacon relay to the Umami-compatible upstream. Its four
+// security behaviors (strict allowlist, cookie strip, cf-connecting-ip-only x-forwarded-for, set-cookie
+// strip) had zero coverage. These pin each one against a stubbed upstream fetch.
+
+const UPSTREAM = "https://tasty.aethereal.dev";
+
+type ForwardedCall = { url: string; method: string; headers: Headers };
+
+/** Stub global fetch to return `response`, recording each forwarded request in a typed, inspectable list. */
+function stubUpstream(response: Response) {
+  const calls: ForwardedCall[] = [];
+  const fetchMock = vi.fn(async (url: string | URL, init?: { method?: string; headers?: HeadersInit }) => {
+    calls.push({ url: String(url), method: init?.method ?? "GET", headers: new Headers(init?.headers) });
+    return response;
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return { fetchMock, calls };
+}
+
+function send(init: RequestInit & { path?: string; query?: string } = {}) {
+  const { path = "/stats/api/send", query = "", ...rest } = init;
+  return new Request(`https://loopover.ai${path}${query}`, { method: "POST", ...rest });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("handleAnalyticsProxy", () => {
+  it("forwards an allowed POST to the upstream collect endpoint, preserving the query and relaying the response", async () => {
+    const { fetchMock, calls } = stubUpstream(new Response("ok-body", { status: 202, statusText: "Accepted" }));
+
+    const response = await handleAnalyticsProxy(send({ query: "?v=2&cache=abc", body: "beacon-payload" }));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // /stats prefix stripped, path + query preserved onto the real upstream host.
+    expect(calls[0]!.url).toBe(`${UPSTREAM}/api/send?v=2&cache=abc`);
+    expect(calls[0]!.method).toBe("POST");
+    // Upstream status/statusText/body are relayed back untouched.
+    expect(response).toBeInstanceOf(Response);
+    expect(response!.status).toBe(202);
+    expect(response!.statusText).toBe("Accepted");
+    expect(await response!.text()).toBe("ok-body");
+  });
+
+  it("rejects a disallowed method with 405 + an allow header, without ever calling fetch (method gate)", async () => {
+    const { fetchMock } = stubUpstream(new Response("should not be used"));
+
+    const response = await handleAnalyticsProxy(send({ method: "GET" }));
+
+    expect(response!.status).toBe(405);
+    expect(response!.headers.get("allow")).toBe("POST");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined (falls through to SSR) and never fetches for a path outside the allowlist", async () => {
+    const { fetchMock } = stubUpstream(new Response("should not be used"));
+
+    // The admin/auth API lives on the same upstream origin as the collect endpoint -- must NOT be proxied.
+    expect(await handleAnalyticsProxy(send({ path: "/stats/admin" }))).toBeUndefined();
+    expect(await handleAnalyticsProxy(send({ path: "/stats/api/collect" }))).toBeUndefined();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("strips the visitor's first-party cookie before forwarding (cookieless guarantee, #597)", async () => {
+    const { calls } = stubUpstream(new Response(null, { status: 200 }));
+
+    await handleAnalyticsProxy(send({ headers: { cookie: "session=secret; theme=dark", "x-keep": "yes" } }));
+
+    expect(calls[0]!.headers.get("cookie")).toBeNull();
+    // Non-stripped headers still pass through, so this isn't just dropping everything.
+    expect(calls[0]!.headers.get("x-keep")).toBe("yes");
+  });
+
+  it("re-derives x-forwarded-for from the trusted cf-connecting-ip and drops any client-supplied value (no geo spoofing)", async () => {
+    const { calls } = stubUpstream(new Response(null, { status: 200 }));
+
+    await handleAnalyticsProxy(
+      send({ headers: { "cf-connecting-ip": "203.0.113.7", "x-forwarded-for": "66.66.66.66" } }),
+    );
+
+    expect(calls[0]!.headers.get("x-forwarded-for")).toBe("203.0.113.7");
+    // The trusted-IP header itself is not leaked upstream.
+    expect(calls[0]!.headers.get("cf-connecting-ip")).toBeNull();
+  });
+
+  it("does not set x-forwarded-for when there is no cf-connecting-ip", async () => {
+    const { calls } = stubUpstream(new Response(null, { status: 200 }));
+
+    await handleAnalyticsProxy(send({ headers: { "x-forwarded-for": "66.66.66.66" } }));
+
+    expect(calls[0]!.headers.get("x-forwarded-for")).toBeNull();
+  });
+
+  it("strips set-cookie from the upstream response before relaying it to the browser", async () => {
+    stubUpstream(new Response("ok", { status: 200, headers: { "set-cookie": "umami=1; Path=/", "x-app": "v1" } }));
+
+    const response = await handleAnalyticsProxy(send());
+
+    expect(response!.headers.get("set-cookie")).toBeNull();
+    expect(response!.headers.get("x-app")).toBe("v1"); // unrelated response headers are still relayed
+  });
+
+  it("fails quietly with 502 when the upstream fetch throws (analytics must never take the page down)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("network down");
+      }),
+    );
+
+    const response = await handleAnalyticsProxy(send({ body: "beacon" }));
+
+    expect(response!.status).toBe(502);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #8387.

`apps/loopover-ui/src/lib/analytics-proxy.ts`'s `handleAnalyticsProxy` relays the app's cookieless analytics beacon (`POST /stats/api/send`) to the Umami-compatible upstream without ever exposing that host to the browser. The module's own comments spell out four security-sensitive behaviors, and it had **zero test coverage** -- no test file referenced `handleAnalyticsProxy` or `analytics-proxy` at all, so a regression in any of them would ship with no signal.

Adds `apps/loopover-ui/src/lib/analytics-proxy.test.ts` (`vi.stubGlobal("fetch", ...)` with `afterEach(() => vi.unstubAllGlobals())`, the established pattern in this directory), covering all four plus the fail-safe:

1. **Forwarding** -- an allowed `POST /stats/api/send` reaches `https://tasty.aethereal.dev/api/send` with the query string preserved, and the upstream's status / statusText / body are relayed back.
2. **Method gate** -- a disallowed method returns `405` with an `allow` header and never calls `fetch`.
3. **Allowlist** -- a path outside `ROUTES` (`/stats/admin`, `/stats/api/collect`) returns `undefined` (SSR fallthrough) and never calls `fetch`. This is the load-bearing "must NOT become an open proxy onto the Umami host, whose admin/auth API lives on the same origin" guarantee.
4. **Cookie stripping** -- the visitor's first-party `cookie` is not forwarded (the fix for closed issue #597's cookieless-guarantee bug), while a non-stripped header still passes through, so the assertion isn't just "drops everything".
5. **IP trust** -- `x-forwarded-for` is re-derived from the trusted `cf-connecting-ip` and a client-supplied `x-forwarded-for` is dropped (no geolocation spoofing); with no `cf-connecting-ip`, no `x-forwarded-for` is set.
6. **`set-cookie` stripping** -- the upstream's `set-cookie` is not relayed to the browser, while unrelated response headers still are.
7. **Fail-safe** -- an upstream `fetch` throw yields `502` rather than taking the page down.

**Test-only, no production change.**

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #8387`).

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` - no workflow files touched.
- [x] `npm run ui:typecheck`
- [x] `npm --workspace @loopover/ui run test -- --run src/lib/analytics-proxy.test.ts` - 8/8 pass.
- [ ] `npm run test:coverage` / `test:workers` / `build:mcp` - not run: this adds one test file under `apps/loopover-ui/` and touches no backend, worker, or MCP surface.
- [ ] `npm audit --audit-level=moderate` - no dependency changes.
- [x] New behavior has unit tests for new branches and fallback paths - this PR **is** that coverage.

If any required check was skipped, explain why:

- Test-only change under `apps/**`, which `codecov.yml` ignores, so `codecov/patch` has no changed lines to score.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests - yes: the cookie-strip, allowlist-rejection, method-rejection, IP-spoof-rejection, and `set-cookie`-strip cases are all negative-path assertions.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed - n/a.
- [x] UI changes use live API data or real empty/error/loading states - n/a, no component or rendering change.
- [x] Visible UI changes include a `UI Evidence` section - n/a: test-only, no visible UI difference.
- [x] Public docs/changelogs are updated where needed - n/a.

## Notes

- The upstream `fetch` is stubbed via a small typed recorder rather than reading `mock.calls`, so the forwarded URL/method/headers are inspected without casting through the Workers `RequestInit<CfProperties>` type.
