### PR TITLE
fix(control-panel): deduplicate the access-scope computation behind one shared helper

### DIFF
--- a/src/services/control-panel-roles.ts
+++ b/src/services/control-panel-roles.ts
@@ -71,7 +71,22 @@ export async function loadControlPanelRoleSummary(env: Env, login: string): Prom
   });
 }
 
-export function buildControlPanelAccessScope(args: RoleSummaryInputs): ControlPanelAccessScope {
+/**
+ * The access-scope facts both {@link buildControlPanelAccessScope} and {@link buildControlPanelRoleSummary}
+ * derive from the same inputs (#8373). Previously each builder carried its own byte-identical copy of this
+ * block — including the #953 suspension fix below, which had to be applied twice — so any future rule change
+ * had to be found and repeated in two places with nothing keeping them in sync.
+ *
+ * `maintainerRepoNames` is returned PRE-deduplication on purpose: the two callers finish it differently
+ * (`uniqueRepoNames` vs `uniqueRepos`, which additionally applies `sanitizeRoleText`), so deduplicating here
+ * would silently change one of their outputs. Each caller still applies its own helper.
+ */
+function resolveAccountRepoScope(args: RoleSummaryInputs): {
+  installedRepos: RoleSummaryInputs["repositories"];
+  accountInstallations: RoleSummaryInputs["installations"];
+  ownedInstalledRepos: RoleSummaryInputs["repositories"];
+  maintainerRepoNames: string[];
+} {
   const installedRepos = args.repositories.filter((repo) => repo.isInstalled);
   const accountInstallations = args.installations.filter((installation) => !installation.suspendedAt && sameLogin(installation.accountLogin, args.login));
   const accountInstallationIds = new Set(accountInstallations.map((installation) => installation.id));
@@ -85,12 +100,16 @@ export function buildControlPanelAccessScope(args: RoleSummaryInputs): ControlPa
       !(repo.installationId !== undefined && repo.installationId !== null && suspendedAccountInstallationIds.has(repo.installationId)) &&
       (sameLogin(repo.owner, args.login) || (repo.installationId !== undefined && repo.installationId !== null && accountInstallationIds.has(repo.installationId))),
   );
-  const maintainerRepos = uniqueRepoNames(
-    args.pullRequests
-      .filter((pull) => sameLogin(pull.authorLogin, args.login) && isMaintainerAssociation(pull.authorAssociation))
-      .map((pull) => pull.repoFullName)
-      .filter((repoFullName) => installedRepos.some((repo) => sameRepo(repo.fullName, repoFullName))),
-  );
+  const maintainerRepoNames = args.pullRequests
+    .filter((pull) => sameLogin(pull.authorLogin, args.login) && isMaintainerAssociation(pull.authorAssociation))
+    .map((pull) => pull.repoFullName)
+    .filter((repoFullName) => installedRepos.some((repo) => sameRepo(repo.fullName, repoFullName)));
+  return { installedRepos, accountInstallations, ownedInstalledRepos, maintainerRepoNames };
+}
+
+export function buildControlPanelAccessScope(args: RoleSummaryInputs): ControlPanelAccessScope {
+  const { installedRepos, accountInstallations, ownedInstalledRepos, maintainerRepoNames } = resolveAccountRepoScope(args);
+  const maintainerRepos = uniqueRepoNames(maintainerRepoNames);
   const scopedRepoNames = uniqueRepoNames([...ownedInstalledRepos.map((repo) => repo.fullName), ...maintainerRepos]);
   const scopedInstallationIds = new Set(accountInstallations.map((installation) => installation.id));
   for (const repo of installedRepos) {
@@ -108,25 +127,8 @@ export function buildControlPanelAccessScope(args: RoleSummaryInputs): ControlPa
 }
 
 export function buildControlPanelRoleSummary(args: RoleSummaryInputs): ControlPanelRoleSummary {
-  const installedRepos = args.repositories.filter((repo) => repo.isInstalled);
-  const accountInstallations = args.installations.filter((installation) => !installation.suspendedAt && sameLogin(installation.accountLogin, args.login));
-  const accountInstallationIds = new Set(accountInstallations.map((installation) => installation.id));
-  // A suspended installation revokes the App's access, so a repo under a suspended account installation must not grant
-  // control-panel scope — including via the owner-match branch, which previously ignored suspendedAt (#953).
-  const suspendedAccountInstallationIds = new Set(
-    args.installations.filter((installation) => installation.suspendedAt && sameLogin(installation.accountLogin, args.login)).map((installation) => installation.id),
-  );
-  const ownedInstalledRepos = installedRepos.filter(
-    (repo) =>
-      !(repo.installationId !== undefined && repo.installationId !== null && suspendedAccountInstallationIds.has(repo.installationId)) &&
-      (sameLogin(repo.owner, args.login) || (repo.installationId !== undefined && repo.installationId !== null && accountInstallationIds.has(repo.installationId))),
-  );
-  const maintainerRepos = uniqueRepos(
-    args.pullRequests
-      .filter((pull) => sameLogin(pull.authorLogin, args.login) && isMaintainerAssociation(pull.authorAssociation))
-      .map((pull) => pull.repoFullName)
-      .filter((repoFullName) => installedRepos.some((repo) => sameRepo(repo.fullName, repoFullName))),
-  );
+  const { accountInstallations, ownedInstalledRepos, maintainerRepoNames } = resolveAccountRepoScope(args);
+  const maintainerRepos = uniqueRepos(maintainerRepoNames);
   const roles: ControlPanelRoleName[] = [];
   if (args.confirmedMiner) roles.push("miner");
   if (maintainerRepos.length > 0 || ownedInstalledRepos.length > 0) roles.push("maintainer");


### PR DESCRIPTION
## Summary
`buildControlPanelAccessScope` and `buildControlPanelRoleSummary` each carried a byte-identical copy of the same access-scope computation — **including the #953 suspension fix**, which had to be applied twice. That's the exact structural precondition for the "fixed in one place, missed in its identical sibling" bug class, on logic `canLoginAccessRepo`/`canWatchRepo` rely on for private-repo access decisions.

Both now call one private `resolveAccountRepoScope(args)`, and the `#953` comment lives on that single computation instead of being duplicated.

**Behaviour-preserving, and one subtlety made it non-mechanical:** the two `maintainerRepos` lines were *not* identical — `buildControlPanelAccessScope` finishes with `uniqueRepoNames`, while `buildControlPanelRoleSummary` uses `uniqueRepos`, which additionally applies `sanitizeRoleText`. So the helper returns `maintainerRepoNames` **pre-deduplication** and each caller applies its own finisher; deduplicating inside the helper would have silently changed one builder's output. That reasoning is recorded in the helper's doc comment so it isn't "simplified" away later.

`accountInstallationIds`/`suspendedAccountInstallationIds` stay internal to the helper — neither caller uses them beyond deriving `ownedInstalledRepos`, so they're deliberately not in the returned shape.

Nothing else changed: `canLoginAccessRepo`, `canWatchRepo`, `loadControlPanelAccessScope`, `loadControlPanelRoleSummary`, `buildStaticControlPanelRoleSummary`, `buildRoleCards`, and the exported `RoleSummaryInputs`/`ControlPanelAccessScope`/`ControlPanelRoleSummary` types are all untouched.

Closes #8373

## Test plan
- [x] **89/89 green across every suite that exercises this file, unmodified** — `test/unit/control-panel-roles.test.ts`, `test/unit/agent-orchestrator.test.ts`, `test/unit/policy-sanitizer.test.ts`. Since this is a pure refactor, the existing suite passing untouched (including its #953 suspended-installation cases) *is* the correctness evidence; no new assertions were invented to describe unchanged behaviour
- [x] Local coverage on `src/services/control-panel-roles.ts`: every line and branch in this diff (lines 74-131) is covered — the file's remaining uncovered lines are its DB-loading functions (`loadControlPanelAccessScope`, `canLoginAccessRepo`), which this change does not touch
- [x] `npm run typecheck` clean
- [ ] CI validate