### PR TITLE
fix(db): tolerate SQLite optional COLUMN keyword in migration parsing (#8368)

### DIFF
--- a/src/db/migration-column-extraction.ts
+++ b/src/db/migration-column-extraction.ts
@@ -163,7 +163,7 @@ export function extractSchemaEvents(rawStatement: string): SchemaEvent[] {
   const dropTableMatch = /^\s*DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?(\w+)/i.exec(statement);
   if (dropTableMatch) return [{ type: "drop_table", table: dropTableMatch[1]!.toLowerCase() }];
 
-  const renameColumnMatch = /\bALTER\s+TABLE\s+(\w+)\s+RENAME\s+COLUMN\s+(\w+)\s+TO\s+(\w+)/i.exec(statement);
+  const renameColumnMatch = /\bALTER\s+TABLE\s+(\w+)\s+RENAME\s+(?:COLUMN\s+)?(\w+)\s+TO\s+(\w+)/i.exec(statement);
   if (renameColumnMatch) {
     const table = renameColumnMatch[1]!.toLowerCase();
     return [
@@ -172,10 +172,10 @@ export function extractSchemaEvents(rawStatement: string): SchemaEvent[] {
     ];
   }
 
-  const dropColumnMatch = /\bALTER\s+TABLE\s+(\w+)\s+DROP\s+COLUMN\s+(\w+)/i.exec(statement);
+  const dropColumnMatch = /\bALTER\s+TABLE\s+(\w+)\s+DROP\s+(?:COLUMN\s+)?(\w+)/i.exec(statement);
   if (dropColumnMatch) return [{ type: "remove_column", table: dropColumnMatch[1]!.toLowerCase(), column: dropColumnMatch[2]!.toLowerCase() }];
 
-  const addColumnMatch = /\bALTER\s+TABLE\s+(\w+)\s+ADD\s+COLUMN\s+(\w+)/i.exec(statement);
+  const addColumnMatch = /\bALTER\s+TABLE\s+(\w+)\s+ADD\s+(?:COLUMN\s+)?(\w+)/i.exec(statement);
   if (addColumnMatch) return [{ type: "define_column", table: addColumnMatch[1]!.toLowerCase(), column: addColumnMatch[2]!.toLowerCase() }];
 
   const createTableMatch = /\bCREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\w+)\s*\(([\s\S]*)\)[^)]*$/i.exec(statement);

--- a/test/unit/migration-column-extraction.test.ts
+++ b/test/unit/migration-column-extraction.test.ts
@@ -107,6 +107,21 @@ describe("extractSchemaEvents (#2551)", () => {
     ]);
   });
 
+  it("extracts ADD COLUMN's terser SQLite form that omits the COLUMN keyword (#8368)", () => {
+    expect(extractSchemaEvents("ALTER TABLE widgets ADD color TEXT;")).toEqual([{ type: "define_column", table: "widgets", column: "color" }]);
+  });
+
+  it("extracts DROP COLUMN's terser SQLite form that omits the COLUMN keyword (#8368)", () => {
+    expect(extractSchemaEvents("ALTER TABLE widgets DROP color;")).toEqual([{ type: "remove_column", table: "widgets", column: "color" }]);
+  });
+
+  it("extracts RENAME COLUMN's terser SQLite form that omits the COLUMN keyword (#8368)", () => {
+    expect(extractSchemaEvents("ALTER TABLE widgets RENAME color TO hue;")).toEqual([
+      { type: "remove_column", table: "widgets", column: "color" },
+      { type: "define_column", table: "widgets", column: "hue" },
+    ]);
+  });
+
   it("returns [] for a statement with no schema-shape effect (CREATE INDEX, INSERT)", () => {
     expect(extractSchemaEvents("CREATE INDEX widgets_name_idx ON widgets (name);")).toEqual([]);
     expect(extractSchemaEvents("INSERT INTO widgets (name) VALUES ('x');")).toEqual([]);


### PR DESCRIPTION
## Summary

- `src/db/migration-column-extraction.ts`'s `extractSchemaEvents` powers the CI-gating column-collision check (`scripts/check-migrations.ts` / `db:migrations:check`). Its three `ALTER TABLE ... COLUMN ...` regexes (RENAME/DROP/ADD) all required the literal `COLUMN` keyword, but SQLite's actual grammar makes it optional for all three forms (`ALTER TABLE t ADD x INTEGER`, `DROP x`, `RENAME x TO y` are all valid, verified directly against real `sqlite3`). A migration using the terser syntax produced zero `SchemaEvent`s and was silently invisible to collision detection. Made `COLUMN` optional (`\s+(?:COLUMN\s+)?`) in all three regexes.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

Closes #8368

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npx vitest run test/unit/migration-column-extraction.test.ts --coverage --coverage.include="src/db/migration-column-extraction.ts"` — all 36 tests pass (33 pre-existing + 3 new), 100% statements/branches/functions/lines on the changed file
- [x] `npx tsx scripts/check-migrations.ts` — ran directly against the real 178-file migration corpus: `178 migrations OK — contiguous 0001..0174 ..., no new duplicates`, confirming the widened regexes don't misparse any existing migration
- [ ] `npm run actionlint`
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This change touches only `src/db/migration-column-extraction.ts` and its unit test (no UI/MCP/worker/OpenAPI surface touched), so the UI/MCP/workers/OpenAPI-specific checks above were not run locally; they are unaffected by this diff and are still exercised by the full CI gate.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session/CORS code touched.)
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — internal CI-gating parser only, no external API/OpenAPI/MCP surface.)
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI touched.)
- [ ] Visible UI changes include a `UI Evidence` section below. (N/A — no visible UI change.)
- [ ] Public docs/changelogs are updated where needed. (N/A — no docs/changelog change needed.)

## UI Evidence

N/A — this is a backend/tooling parser change with no visible UI surface.

## Notes

- Only the three regexes' `COLUMN` handling changed; no other parsing or collision-detection logic touched, per the issue's own scope note. No multi-column `ALTER TABLE` variant support was added (explicitly out of scope).
