### PR TITLE
fix(db): tolerate SQLite's optional COLUMN keyword in ALTER TABLE parsing (#8368)

### DIFF
--- a/src/db/migration-column-extraction.ts
+++ b/src/db/migration-column-extraction.ts
@@ -163,7 +163,10 @@ export function extractSchemaEvents(rawStatement: string): SchemaEvent[] {
   const dropTableMatch = /^\s*DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?(\w+)/i.exec(statement);
   if (dropTableMatch) return [{ type: "drop_table", table: dropTableMatch[1]!.toLowerCase() }];
 
-  const renameColumnMatch = /\bALTER\s+TABLE\s+(\w+)\s+RENAME\s+COLUMN\s+(\w+)\s+TO\s+(\w+)/i.exec(statement);
+  // SQLite's ALTER TABLE grammar makes COLUMN optional for RENAME/DROP/ADD (#8368) -- `ALTER TABLE t ADD x
+  // INTEGER`, `DROP x`, and `RENAME x TO y` are all valid without it, so each regex tolerates the absent
+  // keyword instead of silently producing zero SchemaEvents for the terser (equally valid) form.
+  const renameColumnMatch = /\bALTER\s+TABLE\s+(\w+)\s+RENAME\s+(?:COLUMN\s+)?(\w+)\s+TO\s+(\w+)/i.exec(statement);
   if (renameColumnMatch) {
     const table = renameColumnMatch[1]!.toLowerCase();
     return [
@@ -172,10 +175,10 @@ export function extractSchemaEvents(rawStatement: string): SchemaEvent[] {
     ];
   }
 
-  const dropColumnMatch = /\bALTER\s+TABLE\s+(\w+)\s+DROP\s+COLUMN\s+(\w+)/i.exec(statement);
+  const dropColumnMatch = /\bALTER\s+TABLE\s+(\w+)\s+DROP\s+(?:COLUMN\s+)?(\w+)/i.exec(statement);
   if (dropColumnMatch) return [{ type: "remove_column", table: dropColumnMatch[1]!.toLowerCase(), column: dropColumnMatch[2]!.toLowerCase() }];
 
-  const addColumnMatch = /\bALTER\s+TABLE\s+(\w+)\s+ADD\s+COLUMN\s+(\w+)/i.exec(statement);
+  const addColumnMatch = /\bALTER\s+TABLE\s+(\w+)\s+ADD\s+(?:COLUMN\s+)?(\w+)/i.exec(statement);
   if (addColumnMatch) return [{ type: "define_column", table: addColumnMatch[1]!.toLowerCase(), column: addColumnMatch[2]!.toLowerCase() }];
 
   const createTableMatch = /\bCREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\w+)\s*\(([\s\S]*)\)[^)]*$/i.exec(statement);

--- a/test/unit/migration-column-extraction.test.ts
+++ b/test/unit/migration-column-extraction.test.ts
@@ -107,6 +107,21 @@ describe("extractSchemaEvents (#2551)", () => {
     ]);
   });
 
+  it("extracts ADD without the optional COLUMN keyword (#8368: valid terser SQLite syntax)", () => {
+    expect(extractSchemaEvents("ALTER TABLE widgets ADD color TEXT;")).toEqual([{ type: "define_column", table: "widgets", column: "color" }]);
+  });
+
+  it("extracts DROP without the optional COLUMN keyword (#8368: valid terser SQLite syntax)", () => {
+    expect(extractSchemaEvents("ALTER TABLE widgets DROP color;")).toEqual([{ type: "remove_column", table: "widgets", column: "color" }]);
+  });
+
+  it("extracts RENAME without the optional COLUMN keyword (#8368: valid terser SQLite syntax)", () => {
+    expect(extractSchemaEvents("ALTER TABLE widgets RENAME color TO hue;")).toEqual([
+      { type: "remove_column", table: "widgets", column: "color" },
+      { type: "define_column", table: "widgets", column: "hue" },
+    ]);
+  });
+
   it("returns [] for a statement with no schema-shape effect (CREATE INDEX, INSERT)", () => {
     expect(extractSchemaEvents("CREATE INDEX widgets_name_idx ON widgets (name);")).toEqual([]);
     expect(extractSchemaEvents("INSERT INTO widgets (name) VALUES ('x');")).toEqual([]);


### PR DESCRIPTION
## Summary

- `extractSchemaEvents`' three regexes (`renameColumnMatch`, `dropColumnMatch`, `addColumnMatch`) all required the literal `COLUMN` keyword, but SQLite's actual `ALTER TABLE` grammar makes it optional for all three forms — `ALTER TABLE t ADD x INTEGER`, `ALTER TABLE t DROP x`, and `ALTER TABLE t RENAME x TO y` are all valid statements that omit it (verified directly against real `sqlite3`).
- A migration written with the terser (equally valid) syntax produced **zero** `SchemaEvent`s for that statement — completely invisible to `detectColumnCollisions`, silently defeating the CI gate this parser powers (`db:migrations:check`).
- Changes `\s+COLUMN\s+` to `\s+(?:COLUMN\s+)?` in all three regexes so both forms are correctly detected. No other parsing or collision-detection logic changed.
- Adds test cases for the `COLUMN`-absent form of all three statement types, alongside the existing `COLUMN`-present tests (all of which continue to pass unmodified).

Closes #8368

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This change touches only `src/db/migration-column-extraction.ts` (pure regex/parsing logic, no UI/MCP/workers/OpenAPI surface) plus its test file. Verified via `npx vitest run test/unit/migration-column-extraction.test.ts`: all 36 tests pass, including the 3 new `COLUMN`-absent cases. Branch coverage on the changed conditions (verified directly against `coverage/lcov.info`): the `if (renameColumnMatch)` check shows both arms hit (`BRDA:170,35,0,3` / `BRDA:170,35,1,517`), `if (dropColumnMatch)` shows `BRDA:179,36,0,64` / `BRDA:179,36,1,453`, and `if (addColumnMatch)` shows `BRDA:182,37,0,189` / `BRDA:182,37,1,264` — every branch this diff touches is exercised on both sides.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session/CORS changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP surface changed.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes.)
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots. (N/A — no visible UI changes.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (N/A.)

## Notes

- Scoped exactly as the issue requires: no other `ALTER TABLE` variants (e.g. multi-column operations) were added, and no other parsing/collision-detection logic changed.
