### PR TITLE
fix(rules): honor alreadyPublicSafe in check-run annotations (#8321)

### DIFF
--- a/src/rules/advisory.ts
+++ b/src/rules/advisory.ts
@@ -476,9 +476,14 @@ export function buildCheckRunAnnotations(
     level: CheckRunAnnotation["annotation_level"],
     title: string,
     message: string,
+    // `alreadyPublicSafe` (#7981, extended to annotations by #8321): same contract formatCheckRunOutput's
+    // `text` already honors -- a fixed, engineer-authored message with no interpolated contributor/AI content
+    // must not be scrubbed, or a deliberately-worded string gets mangled. The title keeps its sanitizer:
+    // there is no per-title safety flag on a finding, so nothing licenses skipping it.
+    alreadyPublicSafe = false,
   ) => {
     const safeTitle = sanitizeForCheckRun(title).slice(0, 255);
-    const safeMessage = sanitizeForCheckRun(message).slice(0, 65535);
+    const safeMessage = (alreadyPublicSafe ? message : sanitizeForCheckRun(message)).slice(0, 65535);
     if (!path || !safeTitle || !safeMessage) return;
     const key = `${path}:${safeTitle}:${safeMessage}`;
     if (seen.has(key)) return;
@@ -532,6 +537,7 @@ export function buildCheckRunAnnotations(
         severityToAnnotationLevel(finding.severity),
         finding.title,
         finding.publicText,
+        finding.alreadyPublicSafe ?? false,
       );
     }
   }

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -936,6 +936,54 @@ describe("advisory rules", () => {
     expect(out.text).not.toContain("[context]");
   });
 
+  // #8321: the SAME finding is also rendered as an inline annotation, and buildCheckRunAnnotations used to
+  // scrub it unconditionally -- so one PR showed the message verbatim in the check-run text but mangled in the
+  // annotation. These two pin both arms of the flag on the annotation path.
+  describe("buildCheckRunAnnotations honors alreadyPublicSafe (#8321)", () => {
+    const SAFE_TEXT = "Subnet document appears to include secret, wallet, PAT, or private-key material.";
+    const annotationsFor = (alreadyPublicSafe: boolean) => {
+      const advisory = buildPullRequestAdvisory(repo, {
+        repoFullName: repo.fullName, number: 31, title: "Add lane doc", state: "open",
+        authorLogin: "contributor", authorAssociation: "NONE", labels: [], linkedIssues: [],
+      });
+      const files: PullRequestFileRecord[] = [
+        { repoFullName: repo.fullName, pullNumber: 31, path: "src/lane/doc.ts", additions: 5, deletions: 0, changes: 5, payload: {} },
+      ];
+      const collisions: CollisionReport = {
+        repoFullName: repo.fullName, generatedAt: "2026-06-10T00:00:00.000Z",
+        summary: { clusterCount: 0, highRiskCount: 0, itemsReviewed: 0 }, clusters: [],
+      };
+      const withFinding = {
+        ...advisory,
+        findings: [
+          {
+            code: "surface_lane_reject",
+            title: "Registry surface review",
+            severity: "critical" as const,
+            detail: SAFE_TEXT,
+            publicText: SAFE_TEXT,
+            ...(alreadyPublicSafe ? { alreadyPublicSafe: true } : {}),
+          },
+        ],
+      };
+      return buildCheckRunAnnotations(withFinding, { files, collisions, pullNumber: 31 }, "standard").annotations;
+    };
+
+    it("renders an alreadyPublicSafe message verbatim, matching formatCheckRunOutput", () => {
+      const entry = annotationsFor(true).find((a) => a.title === "Registry surface review");
+      expect(entry, "expected an annotation for the finding").toBeTruthy();
+      expect(entry!.message).toBe(SAFE_TEXT);
+      expect(entry!.message).not.toContain("[context]");
+    });
+
+    it("still sanitizes the message when alreadyPublicSafe is absent (unchanged behavior)", () => {
+      const entry = annotationsFor(false).find((a) => a.title === "Registry surface review");
+      expect(entry, "expected an annotation for the finding").toBeTruthy();
+      expect(entry!.message).toContain("[context]");
+      expect(entry!.message).not.toBe(SAFE_TEXT);
+    });
+  });
+
   it("formatCheckRunOutput publishes only explicit public finding text", () => {
     const advisory = buildPullRequestAdvisory(repo, null);
     const output = formatCheckRunOutput(


### PR DESCRIPTION
## Summary

Closes #8321.

`formatCheckRunOutput` in `src/rules/advisory.ts` already honors a finding's `alreadyPublicSafe` flag when building the check-run `text`:

```ts
return [`${label} ${f.alreadyPublicSafe ? f.publicText : sanitizeForCheckRun(f.publicText)}`];
```

Per #7981, that flag marks a fixed, engineer-authored message with no interpolated contributor/AI content, so scrubbing it would mangle a deliberately-worded string -- e.g. turning `"...secret, wallet, PAT..."` into `"...secret, [context], PAT..."`.

`buildCheckRunAnnotations` renders those **same** findings as inline annotations, but its `addCandidate` helper sanitized the message unconditionally and never received the flag. The result: one finding, on one PR, rendered verbatim in the check-run `text` but scrubbed in the annotation for that same finding -- reintroducing the exact bug class #7981 fixed, in a sibling path #7981 didn't touch.

### Change

`addCandidate` now takes an `alreadyPublicSafe` parameter (defaulting to `false`) and skips the message sanitizer when it is set, mirroring `formatCheckRunOutput`'s conditional exactly.

- The **title** deliberately keeps its sanitizer: there is no per-title safety flag on a finding, so nothing licenses skipping it (as the issue requires -- no new flag invented).
- Findings **without** the flag are byte-for-byte unchanged, and the parameter's default keeps the other two `addCandidate` call sites (missing-test evidence, duplicate overlap) untouched.

### Tests

Two tests pinning both arms on the annotation path, placed beside the existing #7981 `formatCheckRunOutput` test so the pair reads together:

- an `alreadyPublicSafe` finding's annotation message renders verbatim (no `[context]` placeholder)
- a finding **without** the flag is still sanitized (unchanged behavior)

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #8321`).

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` - no workflow files touched.
- [x] `npm run typecheck`
- [x] `npx vitest run test/unit/rules.test.ts` - 101 pass (was 99).
- [x] Changed-line coverage verified locally with the v8 provider: the ternary at the sanitizer takes **both** arms (`[1, 164]`), the `?? false` at the call site takes **both** (`[31, 30]`), and the new default-arg is exercised (`[165]`) by the two untouched call sites.
- [ ] `npm run test:coverage` (full) / `test:workers` / `build:mcp` / `ui:*` - not run: this is a scoped change to one backend module plus its unit test, touching no worker, MCP, or UI surface.
- [ ] `npm audit --audit-level=moderate` - no dependency changes.
- [x] New or changed behavior has unit tests for new branches and fallback paths.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics -- this only stops double-scrubbing a message the codebase already classifies as public-safe; every unflagged finding still goes through `sanitizeForCheckRun`.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests - n/a, none touched.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed - n/a.
- [x] UI changes use live API data or real empty/error/loading states - n/a, no UI change.
- [x] Visible UI changes include a `UI Evidence` section - n/a: no visible UI/frontend/docs/extension change.
- [x] Public docs/changelogs are updated where needed - n/a.

## Notes

- The flag is opt-in and set only by engineer-authored findings, so this cannot widen what contributor- or AI-derived text can put into a check run.
