### PR TITLE
test(db): cover pruneExpiredRecords' two defensive ?? 0 arms (#8370)

### DIFF
--- a/test/unit/retention.test.ts
+++ b/test/unit/retention.test.ts
@@ -140,6 +140,30 @@ describe("pruneExpiredRecords", () => {
     const rows = await env.DB.prepare("SELECT delivery_id FROM webhook_events").all<{ delivery_id: string }>();
     expect(rows.results.map((row) => row.delivery_id)).toEqual(["wh-recent"]);
   });
+
+  it("dry-run falls back to 0 when the count query returns no row (defensive ?? 0 arm, #8370)", async () => {
+    const noRowEnv = {
+      DB: {
+        prepare: (_sql: string) => ({
+          bind: (..._binds: unknown[]) => ({ first: async () => undefined }), // count query returns no row → `row?.n ?? 0` fallback fires
+        }),
+      },
+    } as unknown as Env;
+    const results = await pruneExpiredRecords(noRowEnv, { dryRun: true, policy: [{ table: "webhook_events", column: "received_at", days: 1 }] });
+    expect(results).toEqual([{ table: "webhook_events", column: "received_at", cutoff: expect.any(String), deleted: 0 }]);
+  });
+
+  it("falls back to 0 changes when a delete run() result lacks meta (defensive ?? 0 arm, #8370)", async () => {
+    const noMetaEnv = {
+      DB: {
+        prepare: (_sql: string) => ({
+          bind: (..._binds: unknown[]) => ({ run: async () => ({}) }), // no meta → `result.meta?.changes ?? 0` fallback fires, so changes = 0 < batchSize
+        }),
+      },
+    } as unknown as Env;
+    const results = await pruneExpiredRecords(noMetaEnv, { policy: [{ table: "webhook_events", column: "received_at", days: 1 }] });
+    expect(results).toEqual([{ table: "webhook_events", column: "received_at", cutoff: expect.any(String), deleted: 0 }]);
+  });
 });
 
 describe("dedupeSignalSnapshots", () => {


### PR DESCRIPTION
## Summary

- `pruneExpiredRecords`'s two defensive `?? 0` fallback arms (`src/db/retention.ts:75` dry-run `row?.n ?? 0`, and `:85` delete-loop `result.meta?.changes ?? 0`) had zero direct test coverage, unlike the identical pattern on this file's sibling function `dedupeSignalSnapshots`, which already has dedicated tests for both equivalent arms.
- Adds two new tests mirroring `dedupeSignalSnapshots`'s existing tests exactly: mock `env.DB.prepare` to return a row/`meta` shape missing the relevant field, and assert the function falls back to `0` rather than throwing or producing `NaN`.
- Pure test-addition — no production code in `src/db/retention.ts` was changed, per the issue's explicit scope.

Closes #8370

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This PR only touches `test/unit/retention.test.ts` (test-only, no `src/` production-code change) — no UI/MCP/workers/OpenAPI surface is affected. Verified via `npx vitest run test/unit/retention.test.ts`: all 21 tests pass, including the 2 new ones. Coverage on the target lines (verified directly against `coverage/lcov.info`): line 75's branch now shows `BRDA:75,10,0,25` / `BRDA:75,10,1,1` and line 85's shows `BRDA:85,11,0,21` / `BRDA:85,11,1,1` — both the truthy and nullish-fallback sides of both `?? 0` arms are hit, closing the previously-uncovered branch the issue identified.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session/CORS changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP surface changed.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes.)
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots. (N/A — no visible UI changes.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (N/A.)

## Notes

- Zero production-code risk: `src/db/retention.ts` itself is unchanged, exactly as the issue scoped it.
