### PR TITLE
fix(scenarios): reject non-array changedFiles that bypasses the source-upload scan

### DIFF
--- a/src/scenarios/input-model.ts
+++ b/src/scenarios/input-model.ts
@@ -196,6 +196,13 @@ export function assertScenarioLocalBranchInputSafe(payload: Record<string, unkno
     }
   }
   const changedFiles = payload.changedFiles;
+  // #8328: a present-but-non-array changedFiles (a plain object like { diff: "…source…" }, a string, a number)
+  // is not the documented array-of-entries shape, and the Array.isArray guard below would silently skip the
+  // entire forbidden-key/oversize scan for it — letting exactly the source content this validator exists to
+  // refuse slip through unchecked. Reject it outright; an omitted / undefined changedFiles stays allowed.
+  if (changedFiles !== undefined && !Array.isArray(changedFiles)) {
+    throw new Error("Refusing non-array changedFiles; an array of file entries is required.");
+  }
   if (Array.isArray(changedFiles)) {
     for (const entry of changedFiles) {
       if (!entry || typeof entry !== "object") continue;

--- a/test/unit/scenario-input-model.test.ts
+++ b/test/unit/scenario-input-model.test.ts
@@ -257,6 +257,17 @@ describe("source-upload safety", () => {
     ).not.toThrow();
   });
 
+  it("rejects a present-but-non-array changedFiles that would otherwise bypass the source scan (#8328)", () => {
+    // A plain object like { diff: "…source…" } or a bare string is not the documented array-of-entries shape;
+    // before #8328 the Array.isArray guard silently skipped the forbidden-key/oversize scan for these values,
+    // letting exactly the source content this validator refuses slip through unchecked.
+    expect(() => assertScenarioLocalBranchInputSafe({ changedFiles: { diff: "x".repeat(5000) } })).toThrow(/non-array changedFiles/i);
+    expect(() => assertScenarioLocalBranchInputSafe({ changedFiles: "not-an-array" })).toThrow(/non-array changedFiles/i);
+    // The existing valid shapes (a real array, an omitted changedFiles) must still be accepted unchanged.
+    expect(() => assertScenarioLocalBranchInputSafe({ changedFiles: [{ path: "ok.ts" }] })).not.toThrow();
+    expect(() => assertScenarioLocalBranchInputSafe({ login: "miner", repoFullName: "octo/demo" })).not.toThrow();
+  });
+
   it("rejects source-upload env flag and forbidden local branch keys", () => {
     const previous = process.env.LOOPOVER_UPLOAD_SOURCE;
     process.env.LOOPOVER_UPLOAD_SOURCE = "true";


### PR DESCRIPTION
## What

`assertScenarioLocalBranchInputSafe` is a safety-boundary validator — it exists to refuse
source content (`"source contents are never uploaded"`) and oversized payloads
(`"metadata-only paths are required"`) in scenario local-branch inputs. But its `changedFiles`
handling was gated on `Array.isArray(changedFiles)`: a **present-but-non-array** value (a
plain object like `{ diff: "…5000 chars of source…" }`, or a bare string) fell through the
`Array.isArray` guard entirely, so the nested forbidden-key/oversize scan never ran and the
function returned normally — silently accepting exactly the kind of payload it exists to
reject. The outer top-level-key loop only inspects `payload`'s own keys; it does not recurse
into a non-array `changedFiles` value, so nothing else caught it either.

## Change

Reject a present, non-array `changedFiles` outright, before the `Array.isArray` block:

```ts
if (changedFiles !== undefined && !Array.isArray(changedFiles)) {
  throw new Error("Refusing non-array changedFiles; an array of file entries is required.");
}
```

Behavior for every already-correct case is unchanged: a valid array of entries (with or
without forbidden keys / oversized values) still runs the full scan, and an omitted /
`undefined` `changedFiles` is still allowed.

## Validation

- New regression test in `test/unit/scenario-input-model.test.ts`: both
  `assertScenarioLocalBranchInputSafe({ changedFiles: { diff: "x".repeat(5000) } })` and
  `assertScenarioLocalBranchInputSafe({ changedFiles: "not-an-array" })` now throw, while a
  valid array and an omitted `changedFiles` still do not.
- `npx vitest run test/unit/scenario-input-model.test.ts` → all pass; 100% branch coverage on
  the new guard (both operands, both sides, verified via lcov).
- Full `npm run test:changed` net green (modulo the pre-existing Windows-only
  subprocess/symlink baseline failures that pass on Linux CI).

Closes #8328
