### PR TITLE
fix(miner): add orb-export to the doctor and migrate store lists (#8318)

### DIFF
--- a/packages/loopover-miner/lib/migrate-cli.ts
+++ b/packages/loopover-miner/lib/migrate-cli.ts
@@ -27,6 +27,7 @@ import { initPolicyVerdictCacheStore, resolvePolicyVerdictCacheDbPath } from "./
 import { initPolicyDocCacheStore, resolvePolicyDocCacheDbPath } from "./policy-doc-cache.js";
 import { initRankedCandidatesStore, resolveRankedCandidatesDbPath } from "./ranked-candidates.js";
 import { initDenyHookSynthesisStore, resolveDenyHookSynthesisDbPath } from "./deny-hook-synthesis.js";
+import { openOrbExportStore, resolveOrbExportDbPath } from "./orb-export.js";
 
 const MIGRATE_USAGE = "Usage: loopover-miner migrate [--json]";
 
@@ -80,6 +81,9 @@ const STORES: MigrateStoreDescriptor[] = [
   { name: "policy-doc-cache", resolveDbPath: resolvePolicyDocCacheDbPath, open: initPolicyDocCacheStore },
   { name: "ranked-candidates", resolveDbPath: resolveRankedCandidatesDbPath, open: initRankedCandidatesStore },
   { name: "deny-hook-synthesis", resolveDbPath: resolveDenyHookSynthesisDbPath, open: initDenyHookSynthesisStore },
+  // #8318: orb-export.sqlite3 (the opt-in Orb telemetry export's HMAC secret + cursor, #4277/#5681) is a
+  // durable local store like every entry above, but was never added when it shipped.
+  { name: "orb-export", resolveDbPath: resolveOrbExportDbPath, open: openOrbExportStore },
 ];
 
 /** Read a store file's stamped schema version without ever creating it -- matches checkStoreIntegrity's

--- a/packages/loopover-miner/lib/status.ts
+++ b/packages/loopover-miner/lib/status.ts
@@ -31,6 +31,7 @@ import { resolvePolicyVerdictCacheDbPath } from "./policy-verdict-cache.js";
 import { resolvePolicyDocCacheDbPath } from "./policy-doc-cache.js";
 import { resolveRankedCandidatesDbPath } from "./ranked-candidates.js";
 import { resolveDenyHookSynthesisDbPath } from "./deny-hook-synthesis.js";
+import { resolveOrbExportDbPath } from "./orb-export.js";
 
 // Slim laptop-mode CLI commands (#2288): `status` (what's installed + where local state lives) and `doctor` (is
 // this laptop set up correctly). Both are read-only and 100% local — no repo-scanning, no coding-agent invocation,
@@ -381,6 +382,9 @@ function storeIntegrityChecks(env: Record<string, string | undefined>): DoctorCh
     ["policy-doc-cache", resolvePolicyDocCacheDbPath(env)],
     ["ranked-candidates", resolveRankedCandidatesDbPath(env)],
     ["deny-hook-synthesis", resolveDenyHookSynthesisDbPath(env)],
+    // #8318: orb-export.sqlite3 (the opt-in Orb telemetry export's HMAC secret + cursor, #4277/#5681) is a
+    // durable local store like every entry above, but was never added when it shipped.
+    ["orb-export", resolveOrbExportDbPath(env)],
   ];
   return stores.map(([name, dbPath]) => checkStoreIntegrity(`store-integrity:${name}`, dbPath));
 }

--- a/test/unit/miner-migrate-cli.test.ts
+++ b/test/unit/miner-migrate-cli.test.ts
@@ -34,6 +34,7 @@ const STORE_NAMES = [
   "policy-doc-cache",
   "ranked-candidates",
   "deny-hook-synthesis",
+  "orb-export",
 ];
 
 afterEach(() => {
@@ -42,7 +43,7 @@ afterEach(() => {
 });
 
 describe("loopover-miner migrate (#4871)", () => {
-  it("covers the exact same sixteen stores doctor's store-integrity sweep covers, in the same order, and skips every one when nothing has been created yet", () => {
+  it("covers the exact same seventeen stores doctor's store-integrity sweep covers, in the same order, and skips every one when nothing has been created yet", () => {
     const env = tempEnv();
     const results = runMigrateChecks(env);
 
@@ -51,6 +52,9 @@ describe("loopover-miner migrate (#4871)", () => {
     expect(STORE_NAMES).toEqual(expect.arrayContaining(["governor-state", "attempt-log", "replay-snapshot", "worktree-allocator"]));
     // REGRESSION (#8008): ranked-candidates and deny-hook-synthesis were likewise omitted from both lists.
     expect(STORE_NAMES).toEqual(expect.arrayContaining(["ranked-candidates", "deny-hook-synthesis"]));
+    // REGRESSION (#8318): orb-export.sqlite3 (the opt-in Orb telemetry export's HMAC secret + cursor) was
+    // never added to either list when it shipped, so a corrupted store was invisible to doctor and migrate.
+    expect(STORE_NAMES).toEqual(expect.arrayContaining(["orb-export"]));
     for (const result of results) {
       expect(result.ok).toBe(true);
       expect(result.status).toBe("skipped");

--- a/test/unit/miner-status.test.ts
+++ b/test/unit/miner-status.test.ts
@@ -145,6 +145,7 @@ describe("loopover-miner status/doctor (#2288)", () => {
       "store-integrity:policy-doc-cache",
       "store-integrity:ranked-candidates",
       "store-integrity:deny-hook-synthesis",
+      "store-integrity:orb-export",
     ]);
     // REGRESSION (#6768): doctor previously omitted these four durable local stores from the integrity sweep.
     expect(checks.map((check) => check.name)).toEqual(


### PR DESCRIPTION
## Summary

Closes #8318.

`packages/loopover-miner/lib/status.ts`'s `storeIntegrityChecks` and `packages/loopover-miner/lib/migrate-cli.ts`'s `STORES` are both meant to enumerate **every** durable local SQLite store in the package -- `migrate-cli.ts`'s header says it "Mirrors status.js's storeIntegrityChecks ... store list exactly", and `status.ts`'s says to "Keep in sync with migrate-cli.js's `STORES` list". Both listed the same sixteen stores.

`orb-export.sqlite3` -- the opt-in Orb telemetry export's per-instance HMAC anonymization secret and export cursor (#4277/#5681), opened via `openOrbExportStore` / `resolveOrbExportDbPath` -- is a real durable store and was in **neither** list. So:

- a corrupted `orb-export.sqlite3` was invisible to `loopover-miner doctor`'s per-store integrity sweep, and
- `loopover-miner migrate` never brought it up to date,

unlike every other store the package ships. Same gap class already fixed for `policy-doc-cache` (#7238), `ranked-candidates` + `deny-hook-synthesis` (#8008/#8036), and four earlier omissions (#6768) -- `orb-export.ts` was simply never added when it shipped.

### Change

Adds the store to both lists using each list's **existing** entry shape, with no restructuring (as the issue requires):

- `status.ts`: `["orb-export", resolveOrbExportDbPath(env)]`
- `migrate-cli.ts`: `{ name: "orb-export", resolveDbPath: resolveOrbExportDbPath, open: openOrbExportStore }`

`resolveOrbExportDbPath(env?: Record<string, string | undefined>)` and `openOrbExportStore(dbPath?: string)` already match the sibling entries' signatures exactly, so unlike `replay-snapshot` this needs no cast. Neither file referenced a specific store **count** in its comments, so no count text needed updating.

### Tests

Both existing tests pin these lists exactly, so both are updated rather than duplicated:

- `test/unit/miner-migrate-cli.test.ts` -- `STORE_NAMES` gains `orb-export` (order preserved), the assertion's title goes sixteen -> seventeen, and a `#8318` regression assertion is added beside the existing `#6768` / `#8008` ones.
- `test/unit/miner-status.test.ts` -- the doctor check-name list gains `store-integrity:orb-export`.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #8318`).

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` - no workflow files touched.
- [x] `npm run typecheck`
- [x] `npx vitest run test/unit/miner-migrate-cli.test.ts` - 12/12 pass, including the updated seventeen-store assertion.
- [x] Changed-line coverage: the added lines are an import plus one data entry per list, which v8 tracks as part of the enclosing initializer -- no uncovered statements on the diff (verified locally with the v8 provider).
- [ ] `npm run test:coverage` (full) / `test:workers` / `build:mcp` / `ui:*` - not run: this touches two miner lib files and their two unit tests, with no worker, MCP-package, or UI surface.
- [ ] `npm audit --audit-level=moderate` - no dependency changes.
- [x] New or changed behavior has unit tests.

If any required check was skipped, explain why:

- `test/unit/miner-status.test.ts` has two failures on this Windows checkout that reproduce identically on unmodified `main` (verified by stashing the change and re-running) -- environment-specific, not caused by this diff. The store-list assertion this PR updates is not one of them.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed -- this only adds a store *name and path resolver* to two enumerations; the HMAC secret inside that store is never read, logged, or surfaced here.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests - n/a, none touched.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed - n/a.
- [x] UI changes use live API data or real empty/error/loading states - n/a, no UI change.
- [x] Visible UI changes include a `UI Evidence` section - n/a: no visible UI/frontend/docs/extension change.
- [x] Public docs/changelogs are updated where needed - n/a.

## Notes

- Both commands stay non-destructive for this store: `doctor` treats an absent file as healthy-by-absence, and `migrate` reports a not-yet-created store as a clean skip without creating it as a side effect (asserted by the existing test this PR extends).
