### PR TITLE
feat(miner): fetch AGENTS.md/CLAUDE.md for the contribution-profile agent_docs signal

### DIFF
--- a/packages/loopover-miner/lib/contribution-profile-extract.ts
+++ b/packages/loopover-miner/lib/contribution-profile-extract.ts
@@ -254,6 +254,45 @@ async function fetchContributing(
   return null;
 }
 
+/** #8316: mirror of `fetchContributing` for AI-agent-facing contributor docs. Probes `AGENTS.md` then `CLAUDE.md`
+ *  at the repo ROOT only (unlike CONTRIBUTING.md, neither follows the `.github/` convention in real repos),
+ *  reusing the same `getJson`/`decodeContents` helpers, returning the first hit or `null`. #6794's own signal
+ *  inventory found some repos state their contribution rules only in an agent doc — the `agent_docs` source the
+ *  schema (`contribution-profile.ts`) already defines but nothing populated until now. */
+async function fetchAgentDocs(
+  base: string,
+  target: { owner: string; repo: string },
+  headers: Record<string, string>,
+  fetchImpl: typeof fetch,
+  sleepFn: ((ms: number) => Promise<unknown>) | undefined,
+): Promise<string | null> {
+  for (const path of ["AGENTS.md", "CLAUDE.md"]) {
+    const payload = await getJson(
+      `${base}/repos/${target.owner}/${target.repo}/contents/${path}`,
+      headers,
+      fetchImpl,
+      sleepFn,
+    );
+    const text = decodeContents(payload);
+    if (text !== null) return text;
+  }
+  return null;
+}
+
+/** #8316: an agent-doc-derived prBody rule flowed through the same `extractPrBody` logic CONTRIBUTING.md uses,
+ *  which hardcodes the `contributing_md` provenance source — re-tag it to the schema's `agent_docs` source so a
+ *  repo that states its PR-body rule only in AGENTS.md/CLAUDE.md is attributed correctly. An `absent`/`unknown`
+ *  result carries empty provenance, so it maps to itself unchanged. */
+function tagAgentDocsSource(
+  rule: ContributionSignalRule<ContributionPrBodyRequirements>,
+): ContributionSignalRule<ContributionPrBodyRequirements> {
+  if (rule.provenance.length === 0) return rule;
+  return {
+    ...rule,
+    provenance: rule.provenance.map((entry) => ({ ...entry, source: "agent_docs" })),
+  };
+}
+
 /** Extract the PR-body linked-issue requirement from CONTRIBUTING.md. A very small file is a signpost, not the
  *  rules, so it yields `absent` rather than a false negative dressed as a real one. */
 function extractPrBody(
@@ -321,7 +360,15 @@ export async function extractContributionProfile(
     "explicit",
   );
   const exclusionLabels = classifyLabels(labels, EXCLUSION_TERMS, "inferred");
-  const prBody = extractPrBody(contributing);
+  // #8316: CONTRIBUTING.md stays authoritative. Only when it yields no rule at all (`absent`, i.e. no
+  // CONTRIBUTING.md exists) do we fall back to an AI-agent doc (AGENTS.md/CLAUDE.md) through the SAME
+  // extractPrBody logic, tagging its provenance `agent_docs`. A signpost-sized CONTRIBUTING.md (`unknown`) is
+  // deliberately NOT overridden — zero regression for any repo that already has a real CONTRIBUTING.md.
+  let prBody = extractPrBody(contributing);
+  if (prBody.confidence === "absent") {
+    const agentDocs = await fetchAgentDocs(base, target, headers, fetchImpl, sleepFn);
+    prBody = tagAgentDocsSource(extractPrBody(agentDocs));
+  }
 
   return {
     repoFullName: `${target.owner}/${target.repo}`,

--- a/test/unit/contribution-profile-extract.test.ts
+++ b/test/unit/contribution-profile-extract.test.ts
@@ -16,9 +16,24 @@ function stubFetch(
     labels?: Label[] | number;
     contributing?: string | null;
     contributingGithubDir?: string | null;
+    agentsMd?: string | null;
+    claudeMd?: string | null;
   } = {},
 ) {
   const emptyHeaders = { get: (_name: string) => null };
+  // #8316: a base64 contents response (present) or 404 (absent), matching the CONTRIBUTING.md branches above.
+  const contentsResponse = (text: string | null | undefined) =>
+    (text == null
+      ? { ok: false, status: 404, headers: emptyHeaders, json: async () => ({}) }
+      : {
+          ok: true,
+          status: 200,
+          headers: emptyHeaders,
+          json: async () => ({
+            encoding: "base64",
+            content: Buffer.from(String(text)).toString("base64"),
+          }),
+        }) as unknown as Response;
   return asFetch(
     vi.fn(async (url: string) => {
       const u = String(url);
@@ -75,6 +90,8 @@ function stubFetch(
           }),
         } as unknown as Response;
       }
+      if (u.includes("/contents/AGENTS.md")) return contentsResponse(opts.agentsMd);
+      if (u.includes("/contents/CLAUDE.md")) return contentsResponse(opts.claudeMd);
       return {
         ok: false,
         status: 404,
@@ -612,8 +629,10 @@ describe("extractContributionProfile (#6796)", () => {
       generatedAt: AT,
       sleepFn: async () => {},
     });
-    // Both the root and `.github/` probes are each retried to exhaustion (3 attempts × 2 paths).
-    expect(docCalls).toBe(6);
+    // CONTRIBUTING.md's root and `.github/` probes are each retried to exhaustion (3 attempts × 2 paths = 6);
+    // then, because that leaves prBody `absent`, the #8316 agent-doc fallback probes AGENTS.md and CLAUDE.md,
+    // each likewise retried to exhaustion (3 × 2 = 6) — 12 doc calls total, all still degrading fail-open.
+    expect(docCalls).toBe(12);
     expect(profile.prBody.confidence).toBe("absent");
   });
 
@@ -762,5 +781,75 @@ describe("extractContributionProfile (#6796)", () => {
     expect(profile.exclusionLabels.confidence).toBe("absent");
     expect(profile.prBody.confidence).toBe("explicit");
     expect(profile.completeness).toBe("absent");
+  });
+});
+
+describe("extractContributionProfile — agent-doc PR-body fallback (#8316)", () => {
+  it("keeps CONTRIBUTING.md authoritative and ignores agent docs when it yields a non-absent rule", async () => {
+    // CONTRIBUTING.md states the rule; an AGENTS.md that WOULD flip the result if consulted must be ignored.
+    const fetchImpl = stubFetch({
+      contributing: bigContributing("Every PR must include closes #<issue>."),
+      agentsMd: bigContributing("This repo has no linked-issue requirement whatsoever."),
+    });
+    const profile = await extractContributionProfile("acme/has-contributing", {
+      fetchImpl: asFetch(fetchImpl),
+      generatedAt: AT,
+    });
+    expect(profile.prBody).toEqual({
+      value: { requiresLinkedIssue: true },
+      confidence: "explicit",
+      provenance: [{ source: "contributing_md", detail: "CONTRIBUTING.md" }],
+    });
+  });
+
+  it("falls back to AGENTS.md (tagged agent_docs) when there is no CONTRIBUTING.md", async () => {
+    const fetchImpl = stubFetch({
+      contributing: null,
+      agentsMd: bigContributing("Contributors must link the issue: closes #<n>."),
+    });
+    const profile = await extractContributionProfile("acme/agents-only", {
+      fetchImpl: asFetch(fetchImpl),
+      generatedAt: AT,
+    });
+    expect(profile.prBody).toEqual({
+      value: { requiresLinkedIssue: true },
+      confidence: "explicit",
+      provenance: [{ source: "agent_docs", detail: "CONTRIBUTING.md" }],
+    });
+  });
+
+  it("falls back to CLAUDE.md when AGENTS.md is missing but CLAUDE.md is present", async () => {
+    const fetchImpl = stubFetch({
+      contributing: null,
+      agentsMd: null,
+      claudeMd: bigContributing("Please reference an issue in the PR body."),
+    });
+    const profile = await extractContributionProfile("acme/claude-only", {
+      fetchImpl: asFetch(fetchImpl),
+      generatedAt: AT,
+    });
+    expect(profile.prBody).toEqual({
+      value: { requiresLinkedIssue: true },
+      confidence: "explicit",
+      provenance: [{ source: "agent_docs", detail: "CONTRIBUTING.md" }],
+    });
+  });
+
+  it("stays absent when neither CONTRIBUTING.md nor any agent doc exists", async () => {
+    const fetchImpl = stubFetch({ contributing: null, agentsMd: null, claudeMd: null });
+    const profile = await extractContributionProfile("acme/nothing", {
+      fetchImpl: asFetch(fetchImpl),
+      generatedAt: AT,
+    });
+    expect(profile.prBody).toEqual({ value: null, confidence: "absent", provenance: [] });
+  });
+
+  it("treats a signpost-sized agent doc as unknown, not a false rule (no provenance to tag)", async () => {
+    const fetchImpl = stubFetch({ contributing: null, agentsMd: "See our wiki." });
+    const profile = await extractContributionProfile("acme/tiny-agents", {
+      fetchImpl: asFetch(fetchImpl),
+      generatedAt: AT,
+    });
+    expect(profile.prBody).toEqual({ value: null, confidence: "unknown", provenance: [] });
   });
 });


### PR DESCRIPTION
Closes #8316.

`ContributionSignalSource` has defined `agent_docs` since #6795, but `contribution-profile-extract.ts` only ever fetched labels + `CONTRIBUTING.md`, so the source sat permanently unused.

## Change (2 files, `packages/loopover-miner/lib/**`)
- **`fetchAgentDocs`** mirrors `fetchContributing` (`Promise<string | null>`, same `getJson`/`decodeContents`), probing `AGENTS.md` then `CLAUDE.md` at the repo root only.
- **`extractContributionProfile`** calls it, but per the exact precedence: CONTRIBUTING.md stays authoritative; the agent doc is evaluated **only when `extractPrBody(contributing)` is `absent`** (no CONTRIBUTING.md). A real or signpost-sized (`unknown`) CONTRIBUTING.md is never overridden — zero regression.
- **`tagAgentDocsSource`** re-tags the agent-doc result's provenance `source` to `agent_docs`; empty provenance maps to itself.
- No new `ContributionProfile` field — result lands in the existing `prBody` slot.

## Tests
The 5 cases the issue enumerates, in the existing root-suite `test/unit/contribution-profile-extract.test.ts` (100% branch coverage on the new logic): CONTRIBUTING.md authoritative; AGENTS.md fallback → `agent_docs`; CLAUDE.md fallback; neither → `absent`; signpost-sized agent doc → `unknown`. The existing #7090 5xx-exhaustion test now expects the agent-doc probes too (12 doc calls; fail-open contract unchanged, `prBody` still degrades to `absent`).