### PR TITLE
fix(queue): isolate per-repo failures in backfill-registered-repos fan-out (#8355)

### DIFF
--- a/src/queue/job-dispatch.ts
+++ b/src/queue/job-dispatch.ts
@@ -107,7 +107,7 @@ export async function processJob(env: Env, message: JobMessage): Promise<void> {
         if (repositories.length > 0) {
           const delayStepSeconds =
             message.mode === "full" || message.mode === "resume" ? 45 : 15;
-          await Promise.all(
+          const settled = await Promise.allSettled(
             repositories.map((repo, index) => {
               const repoMessage: JobMessage = {
                 type: "backfill-registered-repos",
@@ -124,6 +124,23 @@ export async function processJob(env: Env, message: JobMessage): Promise<void> {
                 : env.JOBS.send(repoMessage);
             }),
           );
+          // #8355: Promise.allSettled (not Promise.all) so one repo's send failure never blocks or duplicates
+          // a sibling repo's send -- a bare Promise.all rejecting mid-fan-out previously caused the queue's own
+          // retry to re-run this ENTIRE repositories.map from scratch, duplicate-dispatching every repo whose
+          // send had already succeeded before the failure. Every repo's send is attempted exactly once
+          // regardless of an earlier one's outcome; a genuine failure still surfaces below (after every send
+          // has been attempted) so the cron invocation itself is marked failed for observability.
+          const failedRepoFullNames: string[] = [];
+          settled.forEach((result, index) => {
+            if (result.status === "rejected") {
+              const repoFullName = repositories[index]!.fullName;
+              failedRepoFullNames.push(repoFullName);
+              console.error(JSON.stringify({ level: "error", event: "backfill_registered_repos_fanout_send_failed", repoFullName, reason: String(result.reason) }));
+            }
+          });
+          if (failedRepoFullNames.length > 0) {
+            throw new Error(`backfill-registered-repos fan-out: ${failedRepoFullNames.length}/${repositories.length} repo send(s) failed: ${failedRepoFullNames.join(", ")}`);
+          }
           return;
         }
       }

--- a/test/unit/job-dispatch.test.ts
+++ b/test/unit/job-dispatch.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { processJob } from "../../src/queue/job-dispatch";
 import { createTestEnv } from "../helpers/d1";
+import { upsertInstallation, upsertRepositoryFromGitHub } from "../../src/db/repositories";
 import type { JobMessage } from "../../src/types";
 
 describe("processJob unknown job type (#5836)", () => {
@@ -37,5 +38,69 @@ describe("processJob unknown job type (#5836)", () => {
     await processJob(env, { type: "retry-orb-relay" } as JobMessage);
 
     expect(warnLogs.some((line) => line.includes("unknown_job_type_ignored"))).toBe(false);
+  });
+});
+
+describe("processJob backfill-registered-repos fan-out isolation (#8355)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("attempts every OTHER repo's send even when one repo's send rejects, and throws after the settle", async () => {
+    const sentTo: string[] = [];
+    const env = createTestEnv({
+      JOBS: {
+        async send(message: unknown) {
+          const repoFullName = (message as { repoFullName?: string }).repoFullName;
+          if (repoFullName) sentTo.push(repoFullName);
+          if (repoFullName === "owner/fails") throw new Error("simulated transient queue-send failure");
+          return undefined;
+        },
+      } as unknown as Queue,
+    });
+    await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
+    await upsertRepositoryFromGitHub(env, { name: "ok-1", full_name: "owner/ok-1", private: false, owner: { login: "owner" } }, 9001);
+    await upsertRepositoryFromGitHub(env, { name: "fails", full_name: "owner/fails", private: false, owner: { login: "owner" } }, 9001);
+    await upsertRepositoryFromGitHub(env, { name: "ok-2", full_name: "owner/ok-2", private: false, owner: { login: "owner" } }, 9001);
+
+    const errorLogs: string[] = [];
+    vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+      errorLogs.push(String(args[0]));
+    });
+
+    await expect(processJob(env, { type: "backfill-registered-repos", requestedBy: "schedule" } as JobMessage)).rejects.toThrow(
+      /backfill-registered-repos fan-out: 1\/3 repo send\(s\) failed: owner\/fails/,
+    );
+
+    // Every repo was attempted exactly once, regardless of the middle one's rejection.
+    expect(sentTo.sort()).toEqual(["owner/fails", "owner/ok-1", "owner/ok-2"]);
+
+    const failureLog = errorLogs.map((line) => JSON.parse(line) as Record<string, unknown>).find((log) => log.event === "backfill_registered_repos_fanout_send_failed");
+    expect(failureLog).toMatchObject({ level: "error", event: "backfill_registered_repos_fanout_send_failed", repoFullName: "owner/fails" });
+  });
+
+  it("does not throw or log a failure when every repo's send succeeds", async () => {
+    const sentTo: string[] = [];
+    const env = createTestEnv({
+      JOBS: {
+        async send(message: unknown) {
+          const repoFullName = (message as { repoFullName?: string }).repoFullName;
+          if (repoFullName) sentTo.push(repoFullName);
+          return undefined;
+        },
+      } as unknown as Queue,
+    });
+    await upsertInstallation(env, { action: "created", installation: { id: 9002, account: { login: "owner2", id: 2, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
+    await upsertRepositoryFromGitHub(env, { name: "ok-1", full_name: "owner2/ok-1", private: false, owner: { login: "owner2" } }, 9002);
+    await upsertRepositoryFromGitHub(env, { name: "ok-2", full_name: "owner2/ok-2", private: false, owner: { login: "owner2" } }, 9002);
+
+    const errorLogs: string[] = [];
+    vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+      errorLogs.push(String(args[0]));
+    });
+
+    await expect(processJob(env, { type: "backfill-registered-repos", requestedBy: "schedule" } as JobMessage)).resolves.toBeUndefined();
+    expect(sentTo.sort()).toEqual(["owner2/ok-1", "owner2/ok-2"]);
+    expect(errorLogs.some((line) => line.includes("backfill_registered_repos_fanout_send_failed"))).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- `processJob`'s `"backfill-registered-repos"` case fans out one per-repo job via a bare `Promise.all` when the cron-scheduled full-fleet sweep runs with no `repoFullName`. `Promise.all` rejects as soon as any single `env.JOBS.send` call rejects, throwing out of the whole `processJob` invocation.
- The queue's own retry mechanism then re-invokes the entire handler from scratch, re-running the full `repositories.map` fan-out again — including for every repo whose `env.JOBS.send` had already succeeded, causing duplicate per-repo backfill dispatch across the whole fleet from a single transient send failure.
- Switches to `Promise.allSettled` so every repo's send is attempted exactly once regardless of an earlier one's outcome. Each individual failure is logged (`repoFullName` + reason) matching this file's existing structured-logging convention (the `"sync-brokered-installed-repos"` case a few lines above). A genuine failure still surfaces via a thrown error after the settle, so the cron invocation itself is marked failed for observability — but only once every repo's send has been attempted.

Closes #8355

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This change touches only `src/queue/job-dispatch.ts` (pure backend logic, no UI/MCP/workers/OpenAPI surface) plus its test file. Verified via `npx vitest run test/unit/job-dispatch.test.ts`: all 4 tests pass, including the 2 new ones — one asserting every OTHER repo's send is still attempted when one repo's send rejects (and that the job throws with the exact failed repo named, after every send was attempted), and one asserting no throw/log when every send succeeds. Coverage on the changed lines (verified directly against `coverage/lcov.info`): the rejection-detection branch inside the `settled.forEach` shows both arms hit (`BRDA:135,10,0,1` / `BRDA:135,10,1,4`), and the final `failedRepoFullNames.length > 0` throw-condition shows both arms hit (`BRDA:141,11,0,1` / `BRDA:141,11,1,1`).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session/CORS changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP surface changed.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes.)
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots. (N/A — no visible UI changes.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (N/A.)

## Notes

- Used `Promise.allSettled` directly at the call site rather than `mapWithConcurrency` (also acceptable per the issue): `mapWithConcurrency`'s own worker pool is itself built on `Promise.all` internally, so it would not provide per-item isolation without the mapper also catching its own errors — `Promise.allSettled` gives that isolation directly with no extra wrapping.
