### PR TITLE
fix(docs): add the 6 missing published docs pages to the DocsNav sidebar

### DIFF
--- a/apps/loopover-ui/src/components/site/docs-nav.test.tsx
+++ b/apps/loopover-ui/src/components/site/docs-nav.test.tsx
@@ -1,0 +1,53 @@
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { docsNav } from "./docs-nav";
+
+// REGRESSION (#8385): docsNav drives both the persistent /docs/* left rail and DocsPrevNext's
+// prev/next footer links, but it was maintained entirely by hand alongside docs.index.tsx's own
+// curated card list. Six published, cross-linked pages (miner-quickstart, loopover-commands,
+// ai-summaries, owner-checklist, self-hosting-docs-audit, self-hosting-unified-ams-orb) had real
+// content/docs/*.mdx files and index-page links but no sidebar entry, so a visitor landing on one
+// saw an unhighlighted rail with no route to any other group, and no page's prev/next ever reached
+// them. This is the drift guard: content/docs/ is the source of truth for what's published, so a new
+// .mdx that forgets its docsNav entry fails here instead of silently shipping unreachable.
+//
+// Filesystem-reading in a vitest test follows docs-source-server-isolation.test.ts's precedent --
+// process.cwd() is apps/loopover-ui because this file is only matched by that workspace's own
+// vitest.config.ts (`include: ["src/**/*.test.{ts,tsx}"]`); the root config takes `test/**` only.
+describe("docsNav covers every published docs page (#8385)", () => {
+  const contentDir = join(process.cwd(), "content/docs");
+  const publishedSlugs = readdirSync(contentDir)
+    .filter((name) => name.endsWith(".mdx"))
+    .map((name) => name.slice(0, -".mdx".length))
+    .sort();
+
+  const navPaths = docsNav.flatMap((group) =>
+    "items" in group
+      ? group.items.map((item) => item.to)
+      : group.subgroups.flatMap((sub) => sub.items.map((item) => item.to)),
+  );
+
+  it("reads a non-empty content/docs directory (guards against a silently-vacuous assertion)", () => {
+    expect(publishedSlugs.length).toBeGreaterThan(40);
+  });
+
+  it("has a sidebar entry for every published .mdx page", () => {
+    const missing = publishedSlugs.filter((slug) => !navPaths.includes(`/docs/${slug}`));
+    expect(missing).toEqual([]);
+  });
+
+  it("has no sidebar entry pointing at a page that isn't published", () => {
+    // "/docs" is the index route itself (docs.index.tsx), not a content/docs/*.mdx page.
+    const dangling = navPaths
+      .filter((to) => to !== "/docs")
+      .filter((to) => !publishedSlugs.includes(to.replace("/docs/", "")));
+    expect(dangling).toEqual([]);
+  });
+
+  it("lists every page exactly once, so prev/next can't revisit a page", () => {
+    const duplicates = navPaths.filter((to, index) => navPaths.indexOf(to) !== index);
+    expect(duplicates).toEqual([]);
+  });
+});

--- a/apps/loopover-ui/src/components/site/docs-nav.tsx
+++ b/apps/loopover-ui/src/components/site/docs-nav.tsx
@@ -18,6 +18,7 @@ export const docsNav: DocsGroup[] = [
       { to: "/docs", label: "Overview" },
       { to: "/docs/beta-onboarding", label: "Beta onboarding" },
       { to: "/docs/quickstart", label: "Quickstart" },
+      { to: "/docs/miner-quickstart", label: "Quickstart by lane" },
       { to: "/docs/mcp-clients", label: "MCP client setup" },
     ],
   },
@@ -43,6 +44,7 @@ export const docsNav: DocsGroup[] = [
         title: "Self-hosting: integrations",
         items: [
           { to: "/docs/self-hosting-github-app", label: "GitHub App & Orb" },
+          { to: "/docs/self-hosting-unified-ams-orb", label: "Unified ORB + AMS" },
           { to: "/docs/self-hosting-ai-providers", label: "AI providers" },
           { to: "/docs/self-hosting-rees", label: "REES enrichment" },
           { to: "/docs/self-hosting-rees-analyzers", label: "REES analyzers" },
@@ -63,6 +65,7 @@ export const docsNav: DocsGroup[] = [
         items: [
           { to: "/docs/self-hosting-releases", label: "Releases & images" },
           { to: "/docs/self-hosting-release-checklist", label: "Release checklist" },
+          { to: "/docs/self-hosting-docs-audit", label: "Self-host docs audit" },
           { to: "/docs/self-hosting-security", label: "Security" },
           { to: "/docs/federated-fleet-intelligence", label: "Federated fleet intelligence" },
         ],
@@ -73,6 +76,7 @@ export const docsNav: DocsGroup[] = [
           { to: "/docs/github-app", label: "GitHub App configuration" },
           { to: "/docs/maintainer-workflow", label: "Maintainer workflow" },
           { to: "/docs/maintainer-install-trust", label: "Maintainer install & trust" },
+          { to: "/docs/owner-checklist", label: "Onboarding checklist" },
         ],
       },
       {
@@ -97,6 +101,7 @@ export const docsNav: DocsGroup[] = [
     title: "Core concepts",
     items: [
       { to: "/docs/how-reviews-work", label: "How reviews work" },
+      { to: "/docs/loopover-commands", label: "@loopover commands" },
       { to: "/docs/branch-analysis", label: "Branch analysis" },
       { to: "/docs/scoreability", label: "Scoreability" },
       { to: "/docs/upstream-drift", label: "Upstream drift" },
@@ -109,6 +114,7 @@ export const docsNav: DocsGroup[] = [
     items: [
       { to: "/docs/tuning", label: "Tuning your reviews" },
       { to: "/docs/privacy-security", label: "Privacy & security" },
+      { to: "/docs/ai-summaries", label: "AI summaries policy" },
       { to: "/docs/troubleshooting", label: "Troubleshooting" },
     ],
   },


### PR DESCRIPTION
Fixes #8385

## Root cause

`docsNav` in `apps/loopover-ui/src/components/site/docs-nav.tsx` is maintained by hand alongside `docs.index.tsx`'s separately-curated landing grid. Six published pages had real `content/docs/*.mdx` content and index-page links but no `docsNav` entry:

`miner-quickstart`, `loopover-commands`, `ai-summaries`, `owner-checklist`, `self-hosting-docs-audit`, `self-hosting-unified-ams-orb`

Because `DocsPrevNext` builds its footer links from the same array via `groupItems()`, those pages were both unreachable from the persistent left rail *and* skipped in the site-wide prev/next reading flow — no other page's "next" ever landed on them.

## Fix approach

Additive only — no existing entry removed or reordered. Each page went to the group the issue specified, reusing `docs.index.tsx`'s established label so the same page isn't described two ways:

| Page | Group | Label |
| --- | --- | --- |
| `miner-quickstart` | Get started | Quickstart by lane |
| `loopover-commands` | Core concepts | @loopover commands |
| `ai-summaries` | Operating | AI summaries policy |
| `self-hosting-unified-ams-orb` | Maintainers › Self-hosting: integrations | Unified ORB + AMS |
| `self-hosting-docs-audit` | Maintainers › Self-hosting: release & security | Self-host docs audit |
| `owner-checklist` | Maintainers › GitHub App & managed beta | Onboarding checklist |

`self-hosting-docs-audit` went to *release & security* rather than *setup* because its own frontmatter describes it as a pre-release accuracy checklist, placing it next to the existing "Release checklist" entry.

`docs.index.tsx` is deliberately untouched, per the issue — the two navs are allowed to differ.

## The drift guard

New `docs-nav.test.tsx`, co-located per this repo's convention and reading real files the way `docs-source-server-isolation.test.ts` already does. `content/docs/` is treated as the source of truth for what's published:

- every `.mdx` has a sidebar entry (the actual regression)
- no entry points at a page that isn't published (reverse drift)
- no page listed twice, so prev/next can't revisit one
- a guard asserting the directory read is non-empty, so the first three can't pass vacuously if the path ever breaks

**It genuinely fails on the pre-fix state.** Stashing only the `docs-nav.tsx` change and re-running reports exactly the 6 missing slugs; restoring it passes 4/4.

## Impact / risks

- Sidebar-only; no route, no content, no docs-pipeline change. This is the same kind of edit as the ~50 entries already present, on the already-shipped `docs.$slug.tsx` dynamic route — not the frozen `docs.*.tsx` pattern.
- Main risk is a mis-grouped page, which is cosmetic and easily moved.
- The guard now fails CI if a future doc page is added without a sidebar entry. That is the intent, and the fix is a one-line addition.

## Validation

- `npm --workspace @loopover/ui run test -- src/components/site/docs-nav.test.tsx` — 4/4, re-run after rebasing onto current `main` (`9b9924b3`), since the guard asserts against the live `content/docs/` directory
- `npm --workspace @loopover/ui run typecheck` — clean
- `prettier --check` clean on both changed files
- `apps/**` is outside Codecov's `coverage.include`, so this carries no patch-coverage percentage; the drift guard is the deliverable that prevents recurrence
