### PR TITLE
test(retention): cover pruneExpiredRecords's defensive ?? 0 fallback arms

### DIFF
--- a/test/unit/retention.test.ts
+++ b/test/unit/retention.test.ts
@@ -140,6 +140,34 @@ describe("pruneExpiredRecords", () => {
     const rows = await env.DB.prepare("SELECT delivery_id FROM webhook_events").all<{ delivery_id: string }>();
     expect(rows.results.map((row) => row.delivery_id)).toEqual(["wh-recent"]);
   });
+
+  it("dry-run falls back to 0 when the count query returns no row (defensive ?? 0 arm, #8370)", async () => {
+    // Mirrors dedupeSignalSnapshots's equivalent defensive-arm test: a D1 count query whose first() yields
+    // no row must degrade to deleted: 0 via `row?.n ?? 0`, never NaN.
+    const noRowEnv = {
+      DB: {
+        prepare: (_sql: string) => ({
+          bind: (..._binds: unknown[]) => ({ first: async () => undefined }),
+        }),
+      },
+    } as unknown as Env;
+    const results = await pruneExpiredRecords(noRowEnv, { dryRun: true, policy: [{ table: "audit_events", column: "created_at", days: 90 }] });
+    expect(results).toEqual([{ table: "audit_events", column: "created_at", cutoff: expect.any(String), deleted: 0 }]);
+  });
+
+  it("falls back to 0 changes when a delete run() result lacks meta (defensive ?? 0 arm, #8370)", async () => {
+    // A run() result with no meta must degrade to changes: 0 via `result.meta?.changes ?? 0`; 0 < batchSize also
+    // ends the batch loop, so the table settles at deleted: 0 instead of throwing or looping forever.
+    const noMetaEnv = {
+      DB: {
+        prepare: (_sql: string) => ({
+          bind: (..._binds: unknown[]) => ({ run: async () => ({}) }),
+        }),
+      },
+    } as unknown as Env;
+    const results = await pruneExpiredRecords(noMetaEnv, { policy: [{ table: "audit_events", column: "created_at", days: 90 }] });
+    expect(results).toEqual([{ table: "audit_events", column: "created_at", cutoff: expect.any(String), deleted: 0 }]);
+  });
 });
 
 describe("dedupeSignalSnapshots", () => {


### PR DESCRIPTION
## Summary

`pruneExpiredRecords` (src/db/retention.ts) has two defensive `?? 0` fallback arms that had **no direct test coverage**, unlike the identical pattern on its sibling `dedupeSignalSnapshots` (which has dedicated arm tests):

- the dry-run count path — `deleted: Number(row?.n ?? 0)`
- the delete-loop path — `const changes = Number(result.meta?.changes ?? 0)`

Add two tests mirroring `dedupeSignalSnapshots`'s existing equivalent tests exactly: mock `env.DB` so the count query's `first()` returns no row / the delete `run()` result lacks `meta`, and assert the function degrades to `deleted: 0` rather than throwing or producing `NaN`.

**Pure test-addition — no production logic changed** (per the issue scope).

## Tests

`test/unit/retention.test.ts` — +2 tests (now 22 pass). Each exercises one previously-uncovered nullish-coalescing branch.

## Validation

- [x] `test/unit/retention.test.ts` green (22/22).
- [x] Rebased on latest `main`; no base conflict.
- [x] Test-only change (no `src/**` diff); no secret/wallet/hotkey/trust/reward terms.

Closes #8370