### PR TITLE
test(signals): cover the gittensor_root branch of metadataOnly (#8325)

### DIFF
--- a/test/unit/local-branch.test.ts
+++ b/test/unit/local-branch.test.ts
@@ -213,6 +213,46 @@ describe("local branch analysis", () => {
     expect(analysis.workspaceIntelligence.localScorerDiagnostics?.warnings).toHaveLength(MAX_LOCAL_SCORER_WARNING_COUNT);
   });
 
+  it("REGRESSION (#8325): mode 'gittensor_root' is NOT metadata-only (the scorer ran the real gittensor_root binary, not a metadata-only fallback)", () => {
+    const analysis = buildLocalBranchAnalysis({
+      input: {
+        login: "oktofeesh1",
+        repoFullName: repo.fullName,
+        changedFiles: [{ path: "src/scorer.ts", additions: 10, deletions: 0, status: "modified" }],
+        localScorer: { mode: "gittensor_root", sourceTokenScore: 48, totalTokenScore: 80, sourceLines: 46 },
+      },
+      repo,
+      issues: [],
+      pullRequests: [],
+      profile,
+      outcomeHistory,
+      scoringSnapshot,
+      scoringProfile,
+    });
+
+    expect(analysis.scorePreview.blockedBy).not.toEqual(expect.arrayContaining([expect.objectContaining({ code: "metadata_only" })]));
+  });
+
+  it("REGRESSION (#8325): mode 'metadata_only' IS metadata-only, contrasting the 'gittensor_root' case above (both operands of the metadataOnly && independently exercised)", () => {
+    const analysis = buildLocalBranchAnalysis({
+      input: {
+        login: "oktofeesh1",
+        repoFullName: repo.fullName,
+        changedFiles: [{ path: "src/scorer.ts", additions: 10, deletions: 0, status: "modified" }],
+        localScorer: { mode: "metadata_only", sourceTokenScore: 48, totalTokenScore: 80, sourceLines: 46 },
+      },
+      repo,
+      issues: [],
+      pullRequests: [],
+      profile,
+      outcomeHistory,
+      scoringSnapshot,
+      scoringProfile,
+    });
+
+    expect(analysis.scorePreview.blockedBy).toEqual(expect.arrayContaining([expect.objectContaining({ code: "metadata_only" })]));
+  });
+
   it("projects a blocked local branch into a useful after-pending-merge scenario", () => {
     const pressuredHistory: ContributorOutcomeHistory = {
       ...outcomeHistory,


### PR DESCRIPTION
## Summary

- `buildLocalScoreInput`'s `metadataOnly` condition (`src/signals/local-branch.ts:497`, `scorer?.mode !== "gittensor_root" && scorer?.mode !== "external_command"`) had zero test coverage for the `"gittensor_root"` comparison, despite `test/unit/local-branch.test.ts` (2600+ lines) covering every other `localScorer.mode` value.
- Adds two tests contrasting both outcomes: `mode: "gittensor_root"` (metadataOnly is `false` — no `"metadata_only"` entry in `scorePreview.blockedBy`) versus `mode: "metadata_only"` (metadataOnly is `true` — the entry is present). Pure test-addition; no production code in `local-branch.ts` was changed, per the issue's explicit scope.

**Note for a maintainer** (per the issue's own instruction to note discrepancies rather than change behavior unilaterally): the issue description frames this as *"`mode: 'gittensor_root'` combined with the other half... makes `metadataOnly` true."* The actual condition is a double `!==` (not `===`), so `mode === "gittensor_root"` always makes the first operand `false`, which always makes the whole `&&` `false` — `metadataOnly` can never be `true` when `mode` is `"gittensor_root"`. The tests here cover the real, current behavior (verified against the actual source and confirmed by running them) rather than the issue text's framing, which appears to have inverted the comparison. Flagging this in case it's worth a maintainer double-checking whether the intended behavior was actually the opposite of what's shipped.

Closes #8325

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This PR only touches `test/unit/local-branch.test.ts` (test-only, no `src/` production-code change) — no UI/MCP/workers/OpenAPI surface is affected. Verified via `npx vitest run test/unit/local-branch.test.ts`: 74/75 tests pass, including both new ones. The single pre-existing failure (`local MCP git metadata collection > classifies a type change (regular file replaced by a symlink) as unknown, not modified`) is an unrelated, local-Windows-only environment limitation (git/filesystem symlink support requires elevated privileges on Windows) — confirmed by reproducing it identically on a clean stash of this branch's base commit before any of this PR's changes existed; it exercises `collectLocalBranchMetadata`'s git symlink handling, a function this PR does not touch. Coverage on the changed condition (verified directly against `coverage/lcov.info`): line 497's branch shows both outcomes hit (`BRDA:497,35,0,2` / `BRDA:497,35,1,1`).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session/CORS changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP surface changed.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes.)
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots. (N/A — no visible UI changes.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (N/A.)

## Notes

- No production logic changed, per the issue's explicit instruction to note behavioral discrepancies for maintainer triage rather than fix them unilaterally.
