### PR TITLE
fix(github): reuse an existing repo-docs branch ref instead of failing (#8310)

### DIFF
--- a/src/github/repo-doc-pr.ts
+++ b/src/github/repo-doc-pr.ts
@@ -25,6 +25,7 @@
 // module's own design intent), so a skill-only content change can still open a PR even when AGENTS.md itself
 // is unchanged, and a skill-file conflict (manual-review-required without the overwrite opt-in) only excludes
 // the skill from this run rather than blocking the AGENTS.md refresh it rode in with.
+import { errorMessage } from "../utils/json";
 import { githubErrorStatus, withInstallationTokenRetry } from "./app";
 import { githubRateLimitAdmissionKeyForInstallation, makeInstallationOctokit } from "./client";
 import { LOOPOVER_SITE_URL } from "./footer";
@@ -58,6 +59,13 @@ function splitRepo(repoFullName: string): { owner: string; repo: string } {
 
 type DocTreeEntry = { path: string; mode: "100644" | "120000"; type: "blob"; content: string };
 type Octokit = ReturnType<typeof makeInstallationOctokit>;
+
+/** #8310: GitHub answers a create-ref for an existing branch with 422 "Reference already exists". Matched on
+ *  BOTH the status and the message so an unrelated 422 (e.g. a bad sha) still fails loudly instead of being
+ *  silently force-updated. */
+function isRefAlreadyExistsError(error: unknown): boolean {
+  return githubErrorStatus(error) === 422 && /reference already exists/i.test(errorMessage(error));
+}
 
 // GitHub's Contents API base64-encodes the file's raw bytes (with line-wrapped whitespace); decoding through
 // atob + TextDecoder (rather than a naive charCodeAt reassembly) is what makes this correct for non-ASCII
@@ -224,7 +232,18 @@ export async function openRepoDocPullRequest(env: Env, repoFullName: string, mod
       const commit = await octokit.request("POST /repos/{owner}/{repo}/git/commits", { owner, repo, message: PR_TITLE, tree: treeSha, parents: [baseCommitSha] });
       const commitSha = (commit.data as { sha: string }).sha;
 
-      await octokit.request("POST /repos/{owner}/{repo}/git/refs", { owner, repo, ref: `refs/heads/${REPO_DOC_BRANCH_NAME}`, sha: commitSha });
+      // #8310: the ref can already exist with NO open PR on it -- a maintainer closed the previous repo-doc PR
+      // without deleting its branch (GitHub never forces that, and an API/bot close deletes nothing). The
+      // open-only PR lookup above then finds nothing, so we reach here and POST /git/refs 422s "Reference
+      // already exists", failing the whole refresh forever. This branch is exclusively owned by this feature
+      // (see the header comment), never shared with contributor work, so force-updating it to the freshly
+      // built commit is safe. Any OTHER failure still propagates to the outer catch's fail-safe.
+      try {
+        await octokit.request("POST /repos/{owner}/{repo}/git/refs", { owner, repo, ref: `refs/heads/${REPO_DOC_BRANCH_NAME}`, sha: commitSha });
+      } catch (refError) {
+        if (!isRefAlreadyExistsError(refError)) throw refError;
+        await octokit.request("PATCH /repos/{owner}/{repo}/git/refs/{ref}", { owner, repo, ref: `heads/${REPO_DOC_BRANCH_NAME}`, sha: commitSha, force: true });
+      }
 
       const pr = await octokit.request("POST /repos/{owner}/{repo}/pulls", {
         owner,

--- a/test/unit/repo-doc-pr.test.ts
+++ b/test/unit/repo-doc-pr.test.ts
@@ -212,6 +212,74 @@ describe("openRepoDocPullRequest (#3000)", () => {
     expect(prCall?.body.body as string).toContain("LoopOver opened this pull request");
   });
 
+  // #8310: a maintainer closing the repo-doc PR WITHOUT deleting its branch left the ref behind. The open-only
+  // PR lookup then finds nothing, create-ref 422s "Reference already exists", and every later refresh failed
+  // permanently. The branch is owned solely by this feature, so force-updating it is safe.
+  it("force-updates the existing branch ref and still opens a fresh PR when the branch survived a closed PR", async () => {
+    const env = envWithKey();
+    await seedInstalledRepo(env, { defaultBranch: "main" });
+    await seedProfileData(env);
+    await seedRepoDocGenerationConfig(env, REPO);
+    const calls: Array<{ method: string; url: string; body: Record<string, unknown> }> = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      if (TOKEN_URL.test(url)) return Response.json({ token: "t" });
+      const method = init?.method ?? "GET";
+      calls.push({ method, url, body: init?.body ? JSON.parse(String(init.body)) : {} });
+      if (url.includes("/pulls?") && method === "GET") return Response.json([]); // the closed PR is not returned
+      if (url.includes("/contents/AGENTS.md") && method === "GET") return new Response("not found", { status: 404 });
+      if (url.includes("/contents/CLAUDE.md") && method === "GET") return new Response("not found", { status: 404 });
+      if (url.endsWith("/branches/main")) return Response.json({ commit: { sha: "base-commit-sha", commit: { tree: { sha: "base-tree-sha" } } } });
+      if (url.endsWith("/git/trees") && method === "POST") return Response.json({ sha: "new-tree-sha" });
+      if (url.endsWith("/git/commits") && method === "POST") return Response.json({ sha: "new-commit-sha" });
+      if (url.endsWith("/git/refs") && method === "POST") {
+        return Response.json({ message: "Reference already exists" }, { status: 422 });
+      }
+      if (method === "PATCH" && url.includes("/git/refs/")) return Response.json({ ref: "refs/heads/loopover/repo-docs" });
+      if (url.endsWith("/repos/owner/widgets/pulls") && method === "POST") return Response.json({ number: 43, html_url: "https://github.com/owner/widgets/pull/43" });
+      return new Response("unexpected", { status: 500 });
+    });
+
+    const result = await openRepoDocPullRequest(env, REPO, "live");
+
+    // A brand-new PR is opened (reused: false) -- a CLOSED PR is never silently revived.
+    expect(result).toMatchObject({ opened: true, reused: false, pullNumber: 43 });
+    const patchCall = calls.find((c) => c.method === "PATCH" && c.url.includes("/git/refs/"));
+    expect(patchCall, "expected a force ref-update after the create 422'd").toBeTruthy();
+    expect(patchCall?.body).toMatchObject({ sha: "new-commit-sha", force: true });
+  });
+
+  // #8310 (other arm): only "Reference already exists" is recovered. Any other create-ref failure must still
+  // degrade through the existing fail-safe rather than being force-pushed over.
+  it("does NOT force-update the ref for an unrelated create-ref failure, degrading to opened:false", async () => {
+    const env = envWithKey();
+    await seedInstalledRepo(env, { defaultBranch: "main" });
+    await seedProfileData(env);
+    await seedRepoDocGenerationConfig(env, REPO);
+    const calls: Array<{ method: string; url: string; body: Record<string, unknown> }> = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      if (TOKEN_URL.test(url)) return Response.json({ token: "t" });
+      const method = init?.method ?? "GET";
+      calls.push({ method, url, body: init?.body ? JSON.parse(String(init.body)) : {} });
+      if (url.includes("/pulls?") && method === "GET") return Response.json([]);
+      if (url.includes("/contents/AGENTS.md") && method === "GET") return new Response("not found", { status: 404 });
+      if (url.includes("/contents/CLAUDE.md") && method === "GET") return new Response("not found", { status: 404 });
+      if (url.endsWith("/branches/main")) return Response.json({ commit: { sha: "base-commit-sha", commit: { tree: { sha: "base-tree-sha" } } } });
+      if (url.endsWith("/git/trees") && method === "POST") return Response.json({ sha: "new-tree-sha" });
+      if (url.endsWith("/git/commits") && method === "POST") return Response.json({ sha: "new-commit-sha" });
+      if (url.endsWith("/git/refs") && method === "POST") {
+        return Response.json({ message: "Invalid request. sha is not a valid commit" }, { status: 422 });
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+
+    const result = await openRepoDocPullRequest(env, REPO, "live");
+
+    expect(result.opened).toBe(false);
+    expect(calls.some((c) => c.method === "PATCH")).toBe(false);
+  });
+
   // #4613: a self-hoster's PUBLIC_SITE_ORIGIN reaches the generated AGENTS.md's attribution link instead
   // of LOOPOVER_SITE_URL. NOTE: createTestEnv() defaults PUBLIC_SITE_ORIGIN to a truthy value (matching
   // LOOPOVER_SITE_URL's own string), so envWithKey() alone does NOT exercise the `??` fallback's nullish


### PR DESCRIPTION
## Summary

Closes #8310.

`openRepoDocPullRequest` always targets the fixed `loopover/repo-docs` branch (deliberately stable, per the file's header comment, so repeat runs update one PR instead of piling up duplicates). But it only checks for an **open** PR on that branch before deciding to create the ref:

```ts
// src/github/repo-doc-pr.ts:167
const existingOpenPrs = await octokit.request("GET /repos/{owner}/{repo}/pulls", { ..., state: "open", ... });
```

When a maintainer **closes** the repo-doc PR *without deleting its branch* -- GitHub offers a "Delete branch" button but never forces it, and a PR closed via the API or a bot deletes nothing -- the ref survives. The open-only lookup then finds nothing, the function proceeds, and `POST /git/refs` 422s **"Reference already exists"**. The outer `try/catch` turns that into `{ opened: false, reason }`, so **every subsequent refresh for that repo fails permanently** -- both the scheduled sweep and the on-demand `loopover_refresh_repo_docs` tool.

### Change

When the create reports that specific failure, fall back to `PATCH /repos/{owner}/{repo}/git/refs/{ref}` with `{ sha: commitSha, force: true }`, then continue into the existing PR-open path unchanged. This branch is exclusively owned by this feature and never shared with contributor work, so force-updating it to the freshly built commit is safe.

Deliberately narrow, matching the issue's constraints:

- **Only** a 422 whose message matches `Reference already exists` recovers. Any other create-ref failure (e.g. an invalid sha) still propagates to the outer catch's fail-safe, so nothing is silently force-pushed over.
- The **"reuse only an OPEN PR"** behaviour at line 167 is untouched -- a closed PR still results in a **new** pull request (`reused: false`); only the underlying ref is reused.
- Reuses the module's existing `githubErrorStatus` helper and the shared `errorMessage` helper rather than hand-rolling status/message extraction.

### Tests

- the 422 path force-updates the ref (asserting the `PATCH` body carries `{ sha, force: true }`) and still opens a **fresh** PR with `reused: false`
- an unrelated create-ref 422 issues **no** `PATCH` and degrades to `opened: false`, pinning the fail-safe

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #8310`).

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` - no workflow files touched.
- [x] `npm run typecheck`
- [x] `npx vitest run test/unit/repo-doc-pr.test.ts` - 33 pass (was 31).
- [x] Changed-line coverage verified locally with the v8 provider: **no uncovered statements and no partial branches** on the diff (both arms of the new `isRefAlreadyExistsError` guard are exercised by the two tests above).
- [ ] `npm run test:coverage` (full) / `test:workers` / `build:mcp` / `ui:*` - not run: this is a scoped change to one backend module plus its unit test, touching no worker, MCP, or UI surface.
- [ ] `npm audit --audit-level=moderate` - no dependency changes.
- [x] New or changed behavior has unit tests for new branches and fallback paths.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests - no auth logic changes; the write still goes through the same `makeInstallationOctokit` / `withInstallationTokenRetry` chokepoint, and the unrelated-failure test is the negative path.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed - no contract change; `loopover_refresh_repo_docs` simply stops failing on this case.
- [x] UI changes use live API data or real empty/error/loading states - n/a, no UI change.
- [x] Visible UI changes include a `UI Evidence` section - n/a: no visible UI/frontend/docs/extension change.
- [x] Public docs/changelogs are updated where needed - n/a.

## Notes

- The force-update is confined to `loopover/repo-docs`. Because the recovery is gated on both the 422 status **and** the "Reference already exists" message, an unrelated 422 can never reach the `force: true` call.


<sub>Reopened from #8474, which was auto-closed because its branch received an additional commit (a rebase onto latest `main`) after opening - this repo reviews one-shot and treats that as a restart. No code changed: same diff, rebased and re-verified (33/33 tests; 0 uncovered statements and 0 partial branches on the diff).</sub>
