### PR TITLE
fix(miner): cover worktree-allocator worktree_slots in purge-cli right-to-be-forgotten sweep (#8320)

### DIFF
--- a/packages/loopover-miner/lib/purge-cli.ts
+++ b/packages/loopover-miner/lib/purge-cli.ts
@@ -37,6 +37,8 @@ import { openReplaySnapshotStore, resolveReplaySnapshotDbPath } from "./replay-s
 import type { ReplaySnapshotStore } from "./replay-snapshot.js";
 import { initDenyHookSynthesisStore, resolveDenyHookSynthesisDbPath } from "./deny-hook-synthesis.js";
 import type { DenyHookSynthesisStore } from "./deny-hook-synthesis.js";
+import { countWorktreeAllocatorFreeSlotsByRepo, openWorktreeAllocator, resolveWorktreeAllocatorDbPath } from "./worktree-allocator.js";
+import type { WorktreeAllocator } from "./worktree-allocator.js";
 import { resolveAttemptLogDbPath } from "./attempt-log.js";
 import {
   CLAIM_LEDGER_PURGE_SPEC,
@@ -79,7 +81,8 @@ type PurgeOpenerKey =
   | "initPolicyVerdictCacheStore"
   | "initRankedCandidatesStore"
   | "openReplaySnapshotStore"
-  | "initDenyHookSynthesisStore";
+  | "initDenyHookSynthesisStore"
+  | "openWorktreeAllocator";
 
 export type PurgeCliOptions = {
   openClaimLedger?: () => ClaimLedger;
@@ -94,6 +97,7 @@ export type PurgeCliOptions = {
   initRankedCandidatesStore?: () => RankedCandidatesStore;
   openReplaySnapshotStore?: () => ReplaySnapshotStore;
   initDenyHookSynthesisStore?: () => DenyHookSynthesisStore;
+  openWorktreeAllocator?: () => WorktreeAllocator;
   resolveDbPaths?: Record<string, () => string>;
 };
 
@@ -104,6 +108,11 @@ type PurgeTarget = {
   resolveDbPath: () => string;
   spec?: LedgerPurgeSpec;
   specs?: LedgerPurgeSpec[];
+  // worktree-allocator's dry-run count can't be expressed as a generic LedgerPurgeSpec (spec/specs) -- its
+  // match condition is `status = 'free' AND repo_full_name = ?`, not a bare `repoColumn = ?`, since an
+  // 'active' slot must never be counted as purgeable (see worktree-allocator.js's own purgeFreeByRepo
+  // comment). A target declares exactly one of spec/specs/dryRunCount.
+  dryRunCount?: (db: DatabaseSync, repoFullName: string) => number;
 };
 
 const REAL_PURGE_TARGETS: PurgeTarget[] = [
@@ -124,6 +133,10 @@ const REAL_PURGE_TARGETS: PurgeTarget[] = [
   { name: "ranked-candidates", optionKey: "initRankedCandidatesStore", opener: initRankedCandidatesStore, resolveDbPath: resolveRankedCandidatesDbPath, spec: RANKED_CANDIDATES_PURGE_SPEC },
   { name: "replay-snapshot", optionKey: "openReplaySnapshotStore", opener: openReplaySnapshotStore, resolveDbPath: resolveReplaySnapshotDbPath, spec: REPLAY_SNAPSHOT_PURGE_SPEC },
   { name: "deny-hook-synthesis", optionKey: "initDenyHookSynthesisStore", opener: initDenyHookSynthesisStore, resolveDbPath: resolveDenyHookSynthesisDbPath, spec: DENY_HOOK_SYNTHESIS_PURGE_SPEC },
+  // worktree_slots is a FIXED pool (#8320), not an append-only ledger -- its own purgeByRepo/dry-run count
+  // never DELETE a row and never touch an 'active' slot (see worktree-allocator.js). No spec/specs: its
+  // match condition can't be expressed as the generic LedgerPurgeSpec's bare `repoColumn = ?`.
+  { name: "worktree-allocator", optionKey: "openWorktreeAllocator", opener: openWorktreeAllocator, resolveDbPath: resolveWorktreeAllocatorDbPath, dryRunCount: countWorktreeAllocatorFreeSlotsByRepo },
 ];
 
 export type ParsedPurgeArgs = { json: boolean; dryRun: boolean; repoFullName: string } | { error: string };
@@ -216,14 +229,15 @@ export function runPurgeDryRun(
   const resolveDbPaths = options.resolveDbPaths ?? {};
   const stores: PurgeDryRunStoreResult[] = REAL_PURGE_TARGETS.map((target) => {
     const dbPath = (resolveDbPaths[target.name] ?? target.resolveDbPath)();
-    // A target scopes one table (`spec`) or -- for governor-state -- several in one file (`specs`); sum the
-    // per-table counts against the single read-only handle so the preview matches what a real purge removes.
-    // Every REAL_PURGE_TARGETS entry declares exactly one of the two, so `target.spec` is always set here.
-    const specs = target.specs ?? [target.spec!];
     try {
-      const wouldPurge = countExistingRows(dbPath, (db) =>
-        specs.reduce((sum, spec) => sum + countStoreByRepo(db, spec, parsed.repoFullName), 0),
-      );
+      // A target scopes one table (`spec`), several in one file (`specs`, governor-state), or -- when its
+      // match condition can't be expressed as a generic LedgerPurgeSpec (worktree-allocator, #8320) -- a
+      // custom `dryRunCount`. Every REAL_PURGE_TARGETS entry declares exactly one of the three.
+      const wouldPurge = target.dryRunCount
+        ? countExistingRows(dbPath, (db) => target.dryRunCount!(db, parsed.repoFullName))
+        : countExistingRows(dbPath, (db) =>
+            (target.specs ?? [target.spec!]).reduce((sum, spec) => sum + countStoreByRepo(db, spec, parsed.repoFullName), 0),
+          );
       return { store: target.name, wouldPurge };
     } catch (error) {
       return { store: target.name, wouldPurge: null, error: describeError(error) };

--- a/packages/loopover-miner/lib/worktree-allocator.ts
+++ b/packages/loopover-miner/lib/worktree-allocator.ts
@@ -37,6 +37,7 @@ export type WorktreeAllocator = {
   hostId: string;
   acquire(attemptId: string, repoFullName: string): WorktreeAllocation;
   release(attemptId: string): WorktreeAllocation | null;
+  purgeByRepo(repoFullName: string): number;
   listSlots(): WorktreeAllocation[];
   close(): void;
 };
@@ -304,6 +305,20 @@ export function openWorktreeAllocator(options: {
   const listSlots = db.prepare(
     "SELECT slot_index, worktree_path, attempt_id, repo_full_name, status, owner_pid, owner_host, allocated_at FROM worktree_slots ORDER BY slot_index",
   );
+  // #8320: worktree_slots is a FIXED pool (slot_index is the primary key; every slot 0..maxConcurrency-1
+  // always exists), so purging by repo must never DELETE a row the way the generic purgeStoreByRepo helper
+  // does elsewhere -- that would shrink the pool below maxConcurrency and break ensureSlots/selectFreeSlot's
+  // invariant. It must also never touch an 'active' row: that reflects a live, currently-running attempt's
+  // real worktree checkout on disk, and force-clearing it would desync the allocator from that checkout. Only
+  // 'free' rows are eligible -- release()/reclaimOrphanedAllocations() already blank repo_full_name (and the
+  // other owner fields) to NULL on every path that frees a slot, so in the overwhelming majority of real
+  // calls this matches (and clears) 0 rows; it exists purely as a defensive backstop for a row that predates
+  // this fix or was left stale by an unexpected crash path.
+  const purgeFreeByRepo = db.prepare(`
+    UPDATE worktree_slots
+    SET repo_full_name = NULL, attempt_id = NULL, owner_pid = NULL, owner_host = NULL, allocated_at = NULL
+    WHERE status = 'free' AND repo_full_name = ?
+  `);
 
   const allocator: WorktreeAllocator = {
     dbPath: resolvedPath,
@@ -355,6 +370,11 @@ export function openWorktreeAllocator(options: {
       const row = releaseByAttempt.get(normalizedAttempt) as WorktreeSlotRow | undefined;
       return row ? rowToAllocation(row) : null;
     },
+    purgeByRepo(repoFullName) {
+      const normalized = normalizeRepoFullName(repoFullName);
+      const info = purgeFreeByRepo.run(normalized);
+      return Number(info.changes);
+    },
     listSlots() {
       return (listSlots.all() as WorktreeSlotRow[]).map(rowToAllocation);
     },
@@ -364,6 +384,17 @@ export function openWorktreeAllocator(options: {
   };
 
   return allocator;
+}
+
+/** Read-only row count for `purge-cli.js`'s `--dry-run`, matching {@link WorktreeAllocator.purgeByRepo}'s own
+ *  match condition exactly (`status = 'free' AND repo_full_name = ?`) -- an 'active' slot is never counted,
+ *  same reasoning as the real purge itself (see purgeFreeByRepo's comment in {@link openWorktreeAllocator}). */
+export function countWorktreeAllocatorFreeSlotsByRepo(db: DatabaseSync, repoFullName: string): number {
+  const normalized = normalizeRepoFullName(repoFullName);
+  const row = db
+    .prepare("SELECT COUNT(*) AS count FROM worktree_slots WHERE status = 'free' AND repo_full_name = ?")
+    .get(normalized) as { count: number };
+  return Number(row.count);
 }
 
 function getDefaultWorktreeAllocator(): WorktreeAllocator {

--- a/test/unit/miner-attempt-cli.test.ts
+++ b/test/unit/miner-attempt-cli.test.ts
@@ -1371,6 +1371,7 @@ describe("runAttempt (#5132)", () => {
           throw new Error("no_free_worktree_slots");
         },
         release: vi.fn(),
+        purgeByRepo: vi.fn(),
         listSlots: () => [],
         close: vi.fn(),
       }),

--- a/test/unit/miner-purge-cli.test.ts
+++ b/test/unit/miner-purge-cli.test.ts
@@ -222,6 +222,7 @@ describe("runPurge --dry-run (#5564, #6599)", () => {
       "ranked-candidates": () => rankedCandidatesDbPath,
       "replay-snapshot": () => replaySnapshotDbPath,
       "deny-hook-synthesis": () => denyHookSynthesisDbPath,
+      "worktree-allocator": () => join(root, "worktree-allocator.sqlite3"),
       "attempt-log": () => attemptLogDbPath,
     };
 
@@ -245,6 +246,7 @@ describe("runPurge --dry-run (#5564, #6599)", () => {
         { store: "ranked-candidates", wouldPurge: 1 },
         { store: "replay-snapshot", wouldPurge: 1 },
         { store: "deny-hook-synthesis", wouldPurge: 1 },
+        { store: "worktree-allocator", wouldPurge: 0 },
       ],
       attemptLogNote: ATTEMPT_LOG_NOT_PURGEABLE_NOTE,
       attemptLogTotalRows: 0,
@@ -280,12 +282,13 @@ describe("runPurge --dry-run (#5564, #6599)", () => {
       "ranked-candidates": () => join(root, "ranked-candidates.sqlite3"),
       "replay-snapshot": () => join(root, "replay-snapshot.sqlite3"),
       "deny-hook-synthesis": () => join(root, "deny-hook-synthesis.sqlite3"),
+      "worktree-allocator": () => join(root, "worktree-allocator.sqlite3"),
       "attempt-log": () => join(root, "attempt-log.sqlite3"),
     };
     const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
     expect(runPurge(["--repo", "acme/widgets", "--dry-run", "--json"], { resolveDbPaths })).toBe(0);
     const result = JSON.parse(String(log.mock.calls[0]?.[0]));
-    expect(result.stores).toHaveLength(12);
+    expect(result.stores).toHaveLength(13);
     expect(result.stores.every((entry: { wouldPurge: number }) => entry.wouldPurge === 0)).toBe(true);
     expect(result.attemptLogTotalRows).toBe(0);
     for (const resolve of Object.values(resolveDbPaths)) {
@@ -401,6 +404,7 @@ describe("runPurge --dry-run (#5564, #6599)", () => {
       LOOPOVER_MINER_RANKED_CANDIDATES_DB: process.env.LOOPOVER_MINER_RANKED_CANDIDATES_DB,
       LOOPOVER_MINER_REPLAY_SNAPSHOT_DB: process.env.LOOPOVER_MINER_REPLAY_SNAPSHOT_DB,
       LOOPOVER_MINER_DENY_HOOK_SYNTHESIS_DB: process.env.LOOPOVER_MINER_DENY_HOOK_SYNTHESIS_DB,
+      LOOPOVER_MINER_WORKTREE_ALLOCATOR_DB: process.env.LOOPOVER_MINER_WORKTREE_ALLOCATOR_DB,
       LOOPOVER_MINER_ATTEMPT_LOG_DB: process.env.LOOPOVER_MINER_ATTEMPT_LOG_DB,
     };
     process.env.LOOPOVER_MINER_CLAIM_LEDGER_DB = join(root, "claim-ledger.sqlite3");
@@ -415,12 +419,13 @@ describe("runPurge --dry-run (#5564, #6599)", () => {
     process.env.LOOPOVER_MINER_RANKED_CANDIDATES_DB = join(root, "ranked-candidates.sqlite3");
     process.env.LOOPOVER_MINER_REPLAY_SNAPSHOT_DB = join(root, "replay-snapshot.sqlite3");
     process.env.LOOPOVER_MINER_DENY_HOOK_SYNTHESIS_DB = join(root, "deny-hook-synthesis.sqlite3");
+    process.env.LOOPOVER_MINER_WORKTREE_ALLOCATOR_DB = join(root, "worktree-allocator.sqlite3");
     process.env.LOOPOVER_MINER_ATTEMPT_LOG_DB = join(root, "attempt-log.sqlite3");
     try {
       const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
       expect(runPurge(["--repo", "acme/widgets", "--dry-run", "--json"])).toBe(0);
       const result = JSON.parse(String(log.mock.calls[0]?.[0]));
-      expect(result.stores).toHaveLength(12);
+      expect(result.stores).toHaveLength(13);
       expect(result.stores.every((entry: { wouldPurge: number }) => entry.wouldPurge === 0)).toBe(true);
       // Nothing was created — dry run against nonexistent default-path stores makes zero writes.
       expect(existsSync(process.env.LOOPOVER_MINER_CLAIM_LEDGER_DB)).toBe(false);
@@ -462,6 +467,7 @@ describe("runPurge (real, #5564, #6599)", () => {
       initRankedCandidatesStore: () => fakeStore(0),
       openReplaySnapshotStore: () => fakeStore(0),
       initDenyHookSynthesisStore: () => fakeStore(0),
+      openWorktreeAllocator: () => fakeStore(0),
     };
 
     const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
@@ -484,6 +490,7 @@ describe("runPurge (real, #5564, #6599)", () => {
         { store: "ranked-candidates", purged: 0 },
         { store: "replay-snapshot", purged: 0 },
         { store: "deny-hook-synthesis", purged: 0 },
+        { store: "worktree-allocator", purged: 0 },
         { store: "attempt-log", purged: null, note: ATTEMPT_LOG_NOT_PURGEABLE_NOTE },
       ],
     });

--- a/test/unit/miner-worktree-allocator.test.ts
+++ b/test/unit/miner-worktree-allocator.test.ts
@@ -6,6 +6,7 @@ import { DatabaseSync } from "node:sqlite";
 import {
   acquireWorktree,
   closeDefaultWorktreeAllocator,
+  countWorktreeAllocatorFreeSlotsByRepo,
   isProcessAlive,
   openWorktreeAllocator,
   releaseWorktree,
@@ -94,6 +95,78 @@ describe("loopover-miner worktree allocator scaffolding (#4298)", () => {
       expect(() => allocator.acquire("attempt-c", bad)).toThrow("invalid_repo_full_name");
     }
     expect(allocator.release("missing")).toBeNull();
+  });
+
+  describe("purgeByRepo (#8320)", () => {
+    it("clears a FREE slot directly seeded with a stale repo_full_name, and counts it", () => {
+      const allocator = tempAllocator({ maxConcurrency: 1 });
+      const db = new DatabaseSync(allocator.dbPath);
+      // Normal acquire/release always blanks repo_full_name back to NULL on free -- this seeds the stale
+      // shape purgeByRepo exists to backstop (a row that predates the fix, or was left by a crash path).
+      db.exec("UPDATE worktree_slots SET repo_full_name = 'acme/widgets' WHERE slot_index = 0");
+      db.close();
+
+      expect(allocator.purgeByRepo("acme/widgets")).toBe(1);
+      const row = allocator.listSlots()[0]!;
+      expect(row.status).toBe("free");
+      expect(row.repoFullName).toBeNull();
+    });
+
+    it("never touches an ACTIVE slot for the target repo, and does not count it", () => {
+      const allocator = tempAllocator({ maxConcurrency: 1 });
+      const allocation = allocator.acquire("attempt-active", "acme/widgets");
+
+      expect(allocator.purgeByRepo("acme/widgets")).toBe(0);
+      const row = allocator.listSlots()[0]!;
+      expect(row.status).toBe("active");
+      expect(row.repoFullName).toBe("acme/widgets");
+      expect(row.attemptId).toBe(allocation.attemptId);
+    });
+
+    it("returns 0 when no row matches the repo", () => {
+      const allocator = tempAllocator({ maxConcurrency: 1 });
+      expect(allocator.purgeByRepo("acme/nothing-here")).toBe(0);
+    });
+
+    it("rejects an invalid or path-traversal repoFullName the same way acquire does", () => {
+      const allocator = tempAllocator({ maxConcurrency: 1 });
+      expect(() => allocator.purgeByRepo("bad")).toThrow("invalid_repo_full_name");
+      for (const bad of ["../widgets", "acme/..", "acme/wid\tgets"]) {
+        expect(() => allocator.purgeByRepo(bad)).toThrow("invalid_repo_full_name");
+      }
+    });
+  });
+
+  describe("countWorktreeAllocatorFreeSlotsByRepo (#8320, --dry-run's read-only counterpart)", () => {
+    it("counts a FREE slot with a stale repo_full_name, matching purgeByRepo's own condition exactly", () => {
+      const allocator = tempAllocator({ maxConcurrency: 1 });
+      const db = new DatabaseSync(allocator.dbPath);
+      db.exec("UPDATE worktree_slots SET repo_full_name = 'acme/widgets' WHERE slot_index = 0");
+      expect(countWorktreeAllocatorFreeSlotsByRepo(db, "acme/widgets")).toBe(1);
+      db.close();
+    });
+
+    it("does not count an ACTIVE slot for the target repo", () => {
+      const allocator = tempAllocator({ maxConcurrency: 1 });
+      allocator.acquire("attempt-active", "acme/widgets");
+      const db = new DatabaseSync(allocator.dbPath, { readOnly: true });
+      expect(countWorktreeAllocatorFreeSlotsByRepo(db, "acme/widgets")).toBe(0);
+      db.close();
+    });
+
+    it("returns 0 when no row matches the repo", () => {
+      const allocator = tempAllocator({ maxConcurrency: 1 });
+      const db = new DatabaseSync(allocator.dbPath, { readOnly: true });
+      expect(countWorktreeAllocatorFreeSlotsByRepo(db, "acme/nothing-here")).toBe(0);
+      db.close();
+    });
+
+    it("rejects an invalid repoFullName", () => {
+      const allocator = tempAllocator({ maxConcurrency: 1 });
+      const db = new DatabaseSync(allocator.dbPath, { readOnly: true });
+      expect(() => countWorktreeAllocatorFreeSlotsByRepo(db, "bad")).toThrow("invalid_repo_full_name");
+      db.close();
+    });
   });
 
   it("isProcessAlive returns false for invalid or dead pids", () => {


### PR DESCRIPTION
## Summary

- `packages/loopover-miner/lib/worktree-allocator.ts`'s `worktree_slots` table has a `repo_full_name` column but was absent from `purge-cli.ts`'s right-to-be-forgotten sweep (`REAL_PURGE_TARGETS`) — the same recurring gap class already fixed for other stores in #7091/#6599/#8009. Unlike those stores, `worktree_slots` is a FIXED pool (`slot_index` is the primary key; every slot 0..maxConcurrency-1 always exists), so it can't use the generic `purgeStoreByRepo` helper's bare `DELETE FROM table WHERE repoColumn = ?` — that would shrink the pool below `maxConcurrency`. Added a hand-written `purgeByRepo` on `WorktreeAllocator` (mirroring `governor-state.ts`'s own precedent for non-generic purge logic) that only `UPDATE`s a row where `status = 'free' AND repo_full_name = ?`, and never touches an `'active'` row (a live, in-flight attempt's real worktree checkout on disk). Registered the store in `REAL_PURGE_TARGETS` with a new `dryRunCount` field on `PurgeTarget` (since its match condition can't be expressed as the generic `spec`/`specs` shape either), wired through `--dry-run`'s read-only counting path with the exact same `status = 'free'` condition.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

Closes #8320

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npx vitest run test/unit/miner-worktree-allocator.test.ts test/unit/miner-purge-cli.test.ts test/unit/miner-attempt-cli.test.ts` — all tests pass except 4 pre-existing, unrelated Windows-only failures (hardcoded POSIX path assertions and POSIX file-mode-bit assertions in tests I did not touch); verified identical on unmodified `main` with my changes stashed, confirming they are not caused by this diff
- [ ] `npm run actionlint`
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This change touches only `packages/loopover-miner/**` and its tests (no UI/MCP/worker/OpenAPI surface touched), so the UI/MCP/workers/OpenAPI-specific checks above were not run locally; they are unaffected by this diff and are still exercised by the full CI gate. `packages/loopover-miner/**` is not Codecov-gated per this repo's `vitest.config.ts`.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session/CORS code touched.)
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — internal miner CLI tooling only, no API/OpenAPI/MCP surface.)
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI touched.)
- [ ] Visible UI changes include a `UI Evidence` section below. (N/A — no visible UI change.)
- [ ] Public docs/changelogs are updated where needed. (N/A — no docs/changelog change needed.)

## UI Evidence

N/A — this is a backend CLI tooling change with no visible UI surface.

## Notes

- Never deletes a `worktree_slots` row, and never touches an `'active'` row, per the issue's explicit requirement — only a `'free'` row with a stale `repo_full_name` is cleared, which real acquire/release/reclaim paths already prevent in the overwhelming majority of cases; this exists purely as a defensive backstop.
