### PR TITLE
test(scoring): cover sameLogin/sameRepoFullName edge cases in pending-pr-scenarios

### DIFF
--- a/test/unit/pending-pr-scenarios.test.ts
+++ b/test/unit/pending-pr-scenarios.test.ts
@@ -461,4 +461,43 @@ describe("pending PR scenario detection", () => {
     expect(records.pullRequestChecks).toHaveLength(0);
     vi.restoreAllMocks();
   });
+
+  it("excludes PRs from ghost/deleted accounts (null or undefined authorLogin) via sameLogin's short-circuit (#8329)", async () => {
+    const env = {} as Env;
+    vi.spyOn(repositories, "listPullRequestReviews").mockResolvedValue([approvedReview(80)]);
+    vi.spyOn(repositories, "listCheckSummaries").mockResolvedValue([]);
+    const records = await loadContributorRepoOpenPrSignalRecords(env, "entrius/allways-ui", "miner-a", [
+      pr({ number: 80, authorLogin: null }),
+      pr({ number: 81, authorLogin: undefined }),
+    ]);
+    // Both records' authorLogin is falsy, so `value &&` short-circuits to false — neither PR matches, so no
+    // signals are loaded (rather than matching by accident or throwing on the null `.toLowerCase()`).
+    expect(records.pullRequestReviews).toHaveLength(0);
+    expect(records.pullRequestChecks).toHaveLength(0);
+    vi.restoreAllMocks();
+  });
+
+  it("matches a PR whose repoFullName differs from the query only in letter case (#8329)", async () => {
+    const env = {} as Env;
+    vi.spyOn(repositories, "listPullRequestReviews").mockResolvedValue([approvedReview(82)]);
+    vi.spyOn(repositories, "listCheckSummaries").mockResolvedValue([]);
+    const records = await loadContributorRepoOpenPrSignalRecords(env, "entrius/allways-ui", "miner-a", [
+      pr({ number: 82, repoFullName: "Entrius/Allways-UI" }),
+    ]);
+    // sameRepoFullName lower-cases both sides, so the case-differing repo still matches and is included.
+    expect(records.pullRequestReviews).toHaveLength(1);
+    vi.restoreAllMocks();
+  });
+
+  it("matches a PR whose authorLogin differs from the query login only in letter case (#8329)", async () => {
+    const env = {} as Env;
+    vi.spyOn(repositories, "listPullRequestReviews").mockResolvedValue([approvedReview(83)]);
+    vi.spyOn(repositories, "listCheckSummaries").mockResolvedValue([]);
+    const records = await loadContributorRepoOpenPrSignalRecords(env, "entrius/allways-ui", "miner-a", [
+      pr({ number: 83, authorLogin: "Miner-A" }),
+    ]);
+    // sameLogin lower-cases both sides, so the case-differing login still matches and is included.
+    expect(records.pullRequestReviews).toHaveLength(1);
+    vi.restoreAllMocks();
+  });
 });


### PR DESCRIPTION
## Summary

`loadContributorRepoOpenPrSignalRecords` (src/scoring/pending-pr-scenarios.ts) filters a contributor's open PRs via two helpers whose edge branches had no coverage:

- `sameLogin(value, login)` — its `value &&` short-circuit handles `PullRequestRecord.authorLogin` being `null`/`undefined` (ghost/deleted GitHub accounts). No test proved such a PR is excluded rather than matching by accident or throwing on `null.toLowerCase()`.
- `sameRepoFullName` / `sameLogin` case-insensitivity — no test proved case-differing repo/login values still match.

Add three tests (mirroring the existing `loadContributorRepoOpenPrSignalRecords` test's `vi.spyOn` harness): null + undefined `authorLogin` are excluded via the short-circuit; a `repoFullName` differing only in case still matches; an `authorLogin` differing only in case still matches.

**Pure test-addition — no production code changed.**

## Tests

`test/unit/pending-pr-scenarios.test.ts` — +3 tests (20 pass). Covers both operands of `sameLogin`'s `value &&` (falsy null/undefined + truthy case-differing) and both helpers' `.toLowerCase()` normalization.

## Validation

- [x] `test/unit/pending-pr-scenarios.test.ts` green (20/20).
- [x] Test-only change (no `src/**` diff); no secret/wallet/hotkey/trust/reward terms.

Closes #8329