### PR TITLE
test(signals): cover decidePublicSurface's oss_maintainer + not_checked willLabel fallback (#8324)

### DIFF
--- a/test/unit/settings-preview.test.ts
+++ b/test/unit/settings-preview.test.ts
@@ -83,6 +83,47 @@ describe("decidePublicSurface", () => {
     expect(decision.actions).toEqual(["comment", "label"]);
   });
 
+  describe("oss_maintainer + not_checked willLabel fallback (#8324)", () => {
+    // shouldApplyPrLabel itself always returns false for oss_maintainer + any non-"confirmed" status (including
+    // "not_checked"), so any willLabel: true below is coming exclusively from decidePublicSurface's own inline
+    // fallback disjunct, not double-satisfied by the imported function.
+    it("labels when autoLabelEnabled and publicSurface is comment_and_label", () => {
+      const decision = decidePublicSurface({
+        settings: settings({ publicAudienceMode: "oss_maintainer", autoLabelEnabled: true, publicSurface: "comment_and_label" }),
+        authorLogin: "miner",
+        minerStatus: "not_checked",
+      });
+      expect(decision.willLabel).toBe(true);
+    });
+
+    it("labels when autoLabelEnabled and publicSurface is label_only", () => {
+      const decision = decidePublicSurface({
+        settings: settings({ publicAudienceMode: "oss_maintainer", autoLabelEnabled: true, publicSurface: "label_only" }),
+        authorLogin: "miner",
+        minerStatus: "not_checked",
+      });
+      expect(decision.willLabel).toBe(true);
+    });
+
+    it("does NOT label when autoLabelEnabled but publicSurface is comment_only (excluded by the disjunct's own publicSurface check)", () => {
+      const decision = decidePublicSurface({
+        settings: settings({ publicAudienceMode: "oss_maintainer", autoLabelEnabled: true, publicSurface: "comment_only" }),
+        authorLogin: "miner",
+        minerStatus: "not_checked",
+      });
+      expect(decision.willLabel).toBe(false);
+    });
+
+    it("does NOT label when autoLabelEnabled is false, regardless of publicSurface", () => {
+      const decision = decidePublicSurface({
+        settings: settings({ publicAudienceMode: "oss_maintainer", autoLabelEnabled: false, publicSurface: "comment_and_label" }),
+        authorLogin: "miner",
+        minerStatus: "not_checked",
+      });
+      expect(decision.willLabel).toBe(false);
+    });
+  });
+
   it("skips disabled surfaces, bots, maintainer authors, non-miners, and unavailable detection", () => {
     expect(decidePublicSurface({ settings: settings({ publicSurface: "off", checkRunMode: "off" }), authorLogin: "miner", minerStatus: "confirmed" }).skipReason).toBe("surface_off");
     expect(decidePublicSurface({ settings: settings(), authorLogin: null, minerStatus: "confirmed" }).skipReason).toBe("missing_author");


### PR DESCRIPTION
## Summary

- `decidePublicSurface`'s `willLabel` computation (`src/signals/settings-preview.ts:147-149`) has an inline fallback disjunct for `publicAudienceMode: "oss_maintainer"` + `minerStatus: "not_checked"` that had zero test coverage — `grep -n "not_checked" test/unit/settings-preview.test.ts` returned no matches before this PR.
- Adds four tests covering every combination of `autoLabelEnabled` and `publicSurface` for this branch: labels when `comment_and_label` or `label_only` with `autoLabelEnabled: true`, does NOT label for `comment_only` (excluded by the disjunct's own `publicSurface` check) or when `autoLabelEnabled: false`.
- `shouldApplyPrLabel` itself always returns `false` for `oss_maintainer` + any non-`"confirmed"` status (including `"not_checked"`), confirmed by reading its source — so `willLabel: true` in these new tests is exercising exclusively the inline fallback disjunct, not double-satisfied by the imported function. Pure test-addition; no production code in `settings-preview.ts` was changed, per the issue's explicit scope.

Closes #8324

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This PR only touches `test/unit/settings-preview.test.ts` (test-only, no `src/` production-code change) — no UI/MCP/workers/OpenAPI surface is affected. Verified via `npx vitest run test/unit/settings-preview.test.ts`: all 36 tests pass, including the 4 new ones. Coverage on the changed condition (verified directly against `coverage/lcov.info`): the `willLabel` computation's line shows all 6 tracked branch points hit (`BRDA:148,21,0,37` through `BRDA:148,21,5,2` — every count non-zero), confirming full branch coverage across the whole `||`/`&&` chain including the previously-uncovered `not_checked` fallback.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session/CORS changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP surface changed.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes.)
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots. (N/A — no visible UI changes.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (N/A.)

## Notes

- No divergence from `shouldApplyPrLabel`'s intent was found while writing these tests — the fallback disjunct behaves exactly as its own inline logic states, so there's nothing to flag for maintainer triage beyond the new coverage itself.
