### PR TITLE
test(retention): cover pruneExpiredRecords's two defensive ?? 0 arms

### DIFF
--- a/test/unit/retention.test.ts
+++ b/test/unit/retention.test.ts
@@ -140,6 +140,74 @@ describe("pruneExpiredRecords", () => {
     const rows = await env.DB.prepare("SELECT delivery_id FROM webhook_events").all<{ delivery_id: string }>();
     expect(rows.results.map((row) => row.delivery_id)).toEqual(["wh-recent"]);
   });
+
+  // #8370: the same defensive-arm coverage dedupeSignalSnapshots already has below, for this function's
+  // identical `?? 0` guards against a D1 driver returning an unexpected row/meta shape.
+  it("dry-run falls back to 0 when the count query returns no row (defensive ?? 0 arm)", async () => {
+    const noRowEnv = {
+      DB: {
+        prepare: (_sql: string) => ({
+          bind: (..._binds: unknown[]) => ({ first: async () => undefined }), // no row → `row?.n ?? 0` fires
+        }),
+      },
+    } as unknown as Env;
+    const results = await pruneExpiredRecords(noRowEnv, {
+      dryRun: true,
+      nowMs: NOW,
+      policy: [{ table: "webhook_events", column: "received_at", days: 90 }],
+    });
+    expect(results).toEqual([{ table: "webhook_events", column: "received_at", cutoff: daysAgo(90), deleted: 0 }]);
+  });
+
+  it("dry-run falls back to 0 when the count row carries a null n (defensive ?? 0 arm, present-row side)", async () => {
+    const nullCountEnv = {
+      DB: {
+        prepare: (_sql: string) => ({
+          bind: (..._binds: unknown[]) => ({ first: async () => ({ n: null }) }), // row present, n null → same fallback
+        }),
+      },
+    } as unknown as Env;
+    const results = await pruneExpiredRecords(nullCountEnv, {
+      dryRun: true,
+      nowMs: NOW,
+      policy: [{ table: "webhook_events", column: "received_at", days: 90 }],
+    });
+    expect(results[0]?.deleted).toBe(0);
+    // Number(null) is 0, but Number(undefined) is NaN — the point of the guard is that neither shape yields NaN.
+    expect(Number.isNaN(results[0]?.deleted)).toBe(false);
+  });
+
+  it("falls back to 0 changes when a delete run() result lacks meta (defensive ?? 0 arm)", async () => {
+    const noMetaEnv = {
+      DB: {
+        prepare: (_sql: string) => ({
+          // no meta → `result.meta?.changes ?? 0` fires, so changes = 0 < batchSize and the loop exits at once
+          bind: (..._binds: unknown[]) => ({ run: async () => ({}) }),
+        }),
+      },
+    } as unknown as Env;
+    const results = await pruneExpiredRecords(noMetaEnv, {
+      nowMs: NOW,
+      policy: [{ table: "webhook_events", column: "received_at", days: 90 }],
+    });
+    expect(results).toEqual([{ table: "webhook_events", column: "received_at", cutoff: daysAgo(90), deleted: 0 }]);
+  });
+
+  it("falls back to 0 changes when meta is present but changes is null (defensive ?? 0 arm, present-meta side)", async () => {
+    const nullChangesEnv = {
+      DB: {
+        prepare: (_sql: string) => ({
+          bind: (..._binds: unknown[]) => ({ run: async () => ({ meta: { changes: null } }) }),
+        }),
+      },
+    } as unknown as Env;
+    const results = await pruneExpiredRecords(nullChangesEnv, {
+      nowMs: NOW,
+      policy: [{ table: "webhook_events", column: "received_at", days: 90 }],
+    });
+    expect(results[0]?.deleted).toBe(0);
+    expect(Number.isNaN(results[0]?.deleted)).toBe(false);
+  });
 });
 
 describe("dedupeSignalSnapshots", () => {


### PR DESCRIPTION
Fixes #8370

## Root cause

`pruneExpiredRecords` in `src/db/retention.ts` has two defensive `?? 0` guards against a D1 driver returning an unexpected shape:

- the dry-run count path — `deleted: Number(row?.n ?? 0)`
- the delete-loop path — `const changes = Number(result.meta?.changes ?? 0)`

Neither had direct coverage. The identical pattern on this file's sibling `dedupeSignalSnapshots` **is** already tested, so this was a gap in one of two twins rather than an untested idea.

## Fix approach

Test-only — `pruneExpiredRecords`'s logic is untouched, per the issue's explicit scope.

Four tests mirroring `dedupeSignalSnapshots`'s existing approach: a hand-built `env.DB` whose `prepare().bind()` returns the degenerate shape, and a single-rule `policy` so exactly one table is walked. Each arm gets **both** of its failure shapes, because they reach the fallback differently:

| Arm | Absent shape | Present-but-null shape |
| --- | --- | --- |
| dry-run `row?.n ?? 0` | `first()` → `undefined` (no row) | `first()` → `{ n: null }` |
| delete `meta?.changes ?? 0` | `run()` → `{}` (no meta) | `run()` → `{ meta: { changes: null } }` |

The split matters: the optional-chain and the `??` are separate branches, and only the absent shape exercises the optional-chain arm. The null-valued cases also assert `Number.isNaN(...) === false`, which is the guard's actual purpose — `Number(null)` is `0` but `Number(undefined)` is `NaN`, so an unguarded read would put `NaN` into the returned `deleted` count.

## Impact / risks

- No production code changed, so no runtime risk.
- No `src/**` lines in the diff, so this carries no Codecov patch percentage; the coverage it *adds* to the two existing branches is the whole deliverable.

## Validation

- Both target branches confirmed covered via lcov: line 78 (`row?.n ?? 0`) and line 88 (`meta?.changes ?? 0`) each report **both** branch paths taken. Measured with the other 18 tests in the file skipped, so the coverage comes from these four tests directly rather than incidentally from the D1-backed tests.
- `npm run typecheck` — clean; `oxlint` — clean.
- Branch is current `main` (`9b9924b3`).

One note for the reviewer: 16 pre-existing tests in this file fail on my local win32 checkout with `ERR_SQLITE_ERROR: column index out of range` from the `test/helpers/d1.ts` shim. That count is **identical on unmodified `main`** — I verified by stashing this change — and my four tests use plain mocks with no D1 involvement, so they pass regardless. Flagging it only so the local-vs-CI difference isn't mistaken for something this PR introduced.
