### PR TITLE
test(scoring): cover pending-pr helpers' ghost-login exclusion and case-insensitive matching

### DIFF
--- a/test/unit/pending-pr-scenarios.test.ts
+++ b/test/unit/pending-pr-scenarios.test.ts
@@ -461,4 +461,22 @@ describe("pending PR scenario detection", () => {
     expect(records.pullRequestChecks).toHaveLength(0);
     vi.restoreAllMocks();
   });
+
+  // #8329: exercise both branches of sameLogin's `value &&` short-circuit and the case-insensitive matching of
+  // sameRepoFullName/sameLogin — a ghost/deleted account (null/undefined authorLogin) must be excluded, while a
+  // repoFullName or login that differs only in letter case must still match.
+  it("excludes null/undefined authorLogin and matches case-insensitively on repo and login", async () => {
+    const env = {} as Env;
+    vi.spyOn(repositories, "listPullRequestReviews").mockImplementation(async (_env, _repo, pullNumber) => [approvedReview(pullNumber)]);
+    vi.spyOn(repositories, "listCheckSummaries").mockResolvedValue([]);
+    const records = await loadContributorRepoOpenPrSignalRecords(env, "entrius/allways-ui", "miner-a", [
+      pr({ number: 80, authorLogin: null }), // ghost account → sameLogin short-circuits to excluded
+      pr({ number: 81, authorLogin: undefined }), // deleted account → excluded
+      pr({ number: 82, repoFullName: "Entrius/Allways-UI" }), // repo differs only in case → still matches
+      pr({ number: 83, authorLogin: "Miner-A" }), // login differs only in case → still matches
+    ]);
+    // Only the two case-differing (but genuinely matching) PRs are counted; both ghost-account PRs are excluded.
+    expect(records.pullRequestReviews.map((review) => review.pullNumber).sort((a, b) => a - b)).toEqual([82, 83]);
+    vi.restoreAllMocks();
+  });
 });


### PR DESCRIPTION
## What

`src/scoring/pending-pr-scenarios.ts`'s two filter helpers had a real branch-coverage gap on
the logic that decides which of a contributor's open PRs count toward their pending-PR signals:

- `sameLogin`'s `value &&` short-circuit — which exists to exclude ghost/deleted GitHub
  accounts whose `authorLogin` is `null`/`undefined` (`PullRequestRecord.authorLogin` is typed
  `string | null | undefined`) — had no test proving the falsy-`value` side (a `null` login is
  excluded, not matched or thrown).
- The `.toLowerCase()` case-normalization in both `sameLogin` and `sameRepoFullName` — GitHub
  owner/repo and login are case-insensitive but stored values aren't guaranteed consistent —
  had no test proving a case-only difference still matches.

Every existing test set `authorLogin` to a concrete same-case string, so neither branch was
exercised.

## Change

Pure test addition (no source change) in `test/unit/pending-pr-scenarios.test.ts`: one case
feeding `loadContributorRepoOpenPrSignalRecords` four PRs —

- `authorLogin: null` and `authorLogin: undefined` for the searched login → both **excluded**
  (covers `sameLogin`'s falsy-`value` short-circuit);
- a `repoFullName` differing only in case → **included** (covers `sameRepoFullName`'s
  case-normalization);
- an `authorLogin` differing only in case → **included** (covers `sameLogin`'s truthy side +
  case-normalization).

The per-PR review mock lets the test assert exactly which pull numbers survive the filter
(`[82, 83]`), pinning the include/exclude outcome for each branch.

## Validation

- `npx vitest run test/unit/pending-pr-scenarios.test.ts` → all pass.
- Full `npm run test:changed` net green (modulo the pre-existing Windows-only
  subprocess/symlink baseline failures that pass on Linux CI).

Closes #8329
