### PR TITLE
test(signals): cover decidePublicSurface's oss_maintainer + not_checked label fallback

### DIFF
--- a/test/unit/settings-preview.test.ts
+++ b/test/unit/settings-preview.test.ts
@@ -134,6 +134,28 @@ describe("decidePublicSurface", () => {
     expect(decision).toMatchObject({ skipped: false, willComment: false, willLabel: false, willCheckRun: false, actions: ["none"] });
     expect(decision.summary).toMatch(/no surface action is enabled/);
   });
+
+  // #8324: the oss_maintainer + not_checked fallback in willLabel (settings-preview.ts:149). For this combo
+  // shouldApplyPrLabel always returns false (line 39), so the inline second disjunct alone decides willLabel —
+  // exercise every operand of its && chain. (The false sides of the audienceMode/minerStatus operands are already
+  // covered by the confirmed / gittensor_only cases above.)
+  it("applies the oss_maintainer + not_checked label fallback per autoLabelEnabled and publicSurface", () => {
+    const decide = (over: Partial<RepositorySettings>) =>
+      decidePublicSurface({
+        settings: settings({ publicAudienceMode: "oss_maintainer", commentMode: "off", checkRunMode: "off", ...over }),
+        authorLogin: "drive-by",
+        authorType: "User",
+        authorAssociation: "NONE",
+        minerStatus: "not_checked",
+      });
+    // autoLabelEnabled + a label-bearing surface → the fallback applies the label.
+    expect(decide({ autoLabelEnabled: true, publicSurface: "comment_and_label" })).toMatchObject({ willLabel: true, actions: ["label"] });
+    expect(decide({ autoLabelEnabled: true, publicSurface: "label_only" })).toMatchObject({ willLabel: true, actions: ["label"] });
+    // comment-only surface → no label even with autoLabel on (the disjunct's own publicSurface check excludes it).
+    expect(decide({ autoLabelEnabled: true, publicSurface: "comment_only" }).willLabel).toBe(false);
+    // autoLabel off → the fallback can't apply the label; falls back to shouldApplyPrLabel's (also false) result.
+    expect(decide({ autoLabelEnabled: false, publicSurface: "comment_and_label" }).willLabel).toBe(false);
+  });
 });
 
 describe("buildRepoSettingsPreview", () => {


### PR DESCRIPTION
## What

`decidePublicSurface` (`src/signals/settings-preview.ts`) documents itself as the "single source of
truth … the preview can never drift from real behavior." Its `willLabel` computation (line ~149) has
an inline second disjunct handling `publicAudienceMode: "oss_maintainer"` + `minerStatus: "not_checked"`
— a real webhook combination — that duplicates `shouldApplyPrLabel`'s own `autoLabelEnabled && (label
surface)` logic while bypassing that function's `oss_maintainer && !confirmed → false` guard (line 39).

That branch had **zero** test coverage (`grep "not_checked" test/unit/settings-preview.test.ts` returned
nothing), so a future change to `shouldApplyPrLabel` could silently diverge from this inline copy with
no test catching it.

## Change

Pure test addition (no production change) in `test/unit/settings-preview.test.ts`. Since for
`oss_maintainer` + `not_checked` the first disjunct (`shouldApplyPrLabel`) always returns `false`, the
inline fallback alone decides `willLabel` — so the new test exercises every operand of its `&&` chain:

- `autoLabelEnabled: true` + `publicSurface: "comment_and_label"` → `willLabel` (label action) included.
- `autoLabelEnabled: true` + `publicSurface: "label_only"` → included.
- `autoLabelEnabled: true` + `publicSurface: "comment_only"` → **not** included (the disjunct's own
  `publicSurface` check excludes it).
- `autoLabelEnabled: false` → **not** included (falls back to `shouldApplyPrLabel`'s own `false`).

No divergence from `shouldApplyPrLabel`'s intent was found while writing these (the inline condition
mirrors line 40 exactly), so nothing is "fixed" here per the issue's guidance.

## Validation

- `npx vitest run test/unit/settings-preview.test.ts` → all pass.
- Every branch of the `willLabel` `||`/`&&` chain now covered (verified via lcov — all BRDA arms on the
  disjunct non-zero).
- Full `npm run test:changed` net green (modulo the pre-existing Windows-only baseline failures that
  pass on Linux CI).

Closes #8324
