### PR TITLE
fix(ci): stop swallowing control-plane coverage failures with an unjustified || true

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -649,7 +649,7 @@ jobs:
         run: npm run control-plane:test
       - name: Control-plane coverage
         if: ${{ github.event_name == 'push' || needs.changes.outputs.controlPlane == 'true' }}
-        run: npm run control-plane:coverage || true
+        run: npm run control-plane:coverage
       - name: Verify control-plane coverage report exists
         if: ${{ github.event_name == 'push' || needs.changes.outputs.controlPlane == 'true' }}
         run: |


### PR DESCRIPTION
## Summary

`.github/workflows/ci.yml`'s "Control-plane coverage" step ran `npm run control-plane:coverage || true`, unconditionally swallowing a non-zero exit. The next step ("Verify control-plane coverage report exists") only checks that `control-plane/coverage/lcov.info` is non-empty — it never checks the coverage run itself exited cleanly. So a genuine coverage-harvest failure that still manages to write a non-empty but incomplete/wrong `lcov.info` currently stays green and silently uploads bad data to Codecov under the `control-plane` flag.

The identical `|| true` shape on the "REES coverage" step immediately above carries an explicit justifying comment: `c8` instrumentation inflates review-enrichment's timing-sensitive linear-time/ReDoS-guard assertions past their uninstrumented budgets, so a non-zero exit there is a known, documented false alarm (the real pass/fail already happened in the uninstrumented test step just before it). The "Control-plane coverage" step has no such comment, and a repo-wide search (`grep -rln "budget|timing-sensitive|instrumentation|c8" control-plane/`) confirms `control-plane`'s suite has no timing-budget or ReDoS-guard assertions that would explain an instrumentation-induced false failure — this reads as the REES step's shape copied without its justification, not a verified decision for control-plane.

- Removed `|| true` from the "Control-plane coverage" step only. The REES coverage step and `scripts/control-plane-coverage.mjs` are untouched.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves.

Closes #8392

## Validation

- [x] `npm run actionlint`
- [x] `git diff --check`
- [x] Rebuilt `control-plane` (stale dist from an earlier main sync), then ran `npm run control-plane:coverage` from the repo root per the issue's explicit instruction: exits 0, all 201 tests pass, coverage summary is clean (99.95% statements, 99.54% branches, 99.04% functions, 99.95% lines) — confirming the swallow is safe to remove and this change doesn't itself introduce a CI failure.

`.github/**` and `scripts/**` are outside Codecov's `coverage.include`, so this change owes no `codecov/patch` obligation.