### PR TITLE
fix(miner): route orb-export, deny-hook-synthesis, and laptop-init through openLocalStoreDb (#8319)

### DIFF
--- a/packages/loopover-miner/lib/deny-hook-synthesis.ts
+++ b/packages/loopover-miner/lib/deny-hook-synthesis.ts
@@ -3,9 +3,8 @@
 // this module is now a thin wrapper that re-exports those pure helpers and keeps the local SQLite store for
 // refresh + maintainer review before any synthesized rule takes effect. Approved rules merge with
 // {@link DEFAULT_DENY_RULES}; unapproved proposals never block tool calls. No behavior change.
-import { chmodSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import {
   aggregateBlockerHistory,
@@ -25,6 +24,7 @@ import type { DenyRuleProposal, SynthesisConfig } from "@loopover/engine";
 import { DEFAULT_FORGE_CONFIG } from "./forge-config.js";
 import type { DenyRule } from "./deny-hooks.js";
 import { DENY_HOOK_SYNTHESIS_PURGE_SPEC, purgeStoreByRepo } from "./store-maintenance.js";
+import { openLocalStoreDb } from "./local-store.js";
 
 // Re-export the pure synthesis helpers from the engine so this module's public API is unchanged after #5667
 // moved derivation/audit into @loopover/engine. Only the SQLite store below (and its forge/db-path helpers) is
@@ -162,10 +162,9 @@ function ensureDenyRuleProposalsForgeScope(db: DatabaseSync): void {
  */
 export function initDenyHookSynthesisStore(dbPath: string = resolveDenyHookSynthesisDbPath()): DenyHookSynthesisStore {
   const resolvedPath = normalizeDbPath(dbPath);
-  mkdirSync(dirname(resolvedPath), { recursive: true, mode: 0o700 });
-  const db = new DatabaseSync(resolvedPath);
-  chmodSync(resolvedPath, 0o600);
-  db.exec("PRAGMA busy_timeout = 5000");
+  // openLocalStoreDb centralizes the mkdir(0o700)/chmod(0o600)/busy_timeout + crash-safe cleanup registration
+  // (#8319) -- so a SIGINT/SIGTERM/uncaught-exception mid-refresh doesn't leave this file half-written.
+  const db = openLocalStoreDb(resolvedPath);
   db.exec(`
     CREATE TABLE IF NOT EXISTS deny_rule_proposals (
       repo_full_name TEXT NOT NULL,

--- a/packages/loopover-miner/lib/laptop-init.ts
+++ b/packages/loopover-miner/lib/laptop-init.ts
@@ -1,10 +1,11 @@
-import { accessSync, chmodSync, constants, existsSync, mkdirSync } from "node:fs";
+import { accessSync, constants, existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { delimiter, join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { applySchemaMigrations } from "./schema-version.js";
 import { reportCliFailure } from "./cli-error.js";
 import { resolveGitHubToken } from "./github-token-resolution.js";
+import { openLocalStoreDb } from "./local-store.js";
 
 const githubApiBaseUrl = "https://api.github.com";
 const githubApiVersion = "2022-11-28";
@@ -52,9 +53,11 @@ export function resolveLaptopStateDbPath(env: Record<string, string | undefined>
 export function initLaptopState(env: Record<string, string | undefined> = process.env): LaptopInitResult {
   const stateDir = resolveMinerStateDir(env);
   const dbPath = resolveLaptopStateDbPath(env);
-  mkdirSync(stateDir, { recursive: true, mode: 0o700 });
   const created = !existsSync(dbPath);
-  const db = new DatabaseSync(dbPath);
+  // openLocalStoreDb centralizes the mkdir(0o700)/chmod(0o600)/busy_timeout + crash-safe cleanup registration
+  // (#8319) -- this was previously the one store in the package with no busy-timeout and no crash-safety
+  // registration at all, so a SIGINT/SIGTERM/uncaught-exception mid-bootstrap could leave the file half-written.
+  const db = openLocalStoreDb(dbPath);
   db.exec(`
     CREATE TABLE IF NOT EXISTS laptop_meta (
       key TEXT PRIMARY KEY,
@@ -67,7 +70,6 @@ export function initLaptopState(env: Record<string, string | undefined> = proces
     db.prepare("INSERT INTO laptop_meta (key, value) VALUES ('initialized_at', ?)")
       .run(new Date().toISOString());
   }
-  chmodSync(dbPath, 0o600);
   db.close();
   return { stateDir, dbPath, created };
 }

--- a/packages/loopover-miner/lib/orb-export.ts
+++ b/packages/loopover-miner/lib/orb-export.ts
@@ -1,13 +1,12 @@
-import { chmodSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
-import { DatabaseSync } from "node:sqlite";
+import { join } from "node:path";
 import { createHash, createHmac } from "node:crypto";
 import { generateAnonSecret, hmacAnonymize as engineHmacAnonymize } from "@loopover/engine";
 import { readPrOutcomes } from "./pr-outcome.js";
 import type { NormalizedPrOutcomePayload, PrOutcomeLedgerReader } from "./pr-outcome.js";
 import { initEventLedger } from "./event-ledger.js";
 import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
+import { openLocalStoreDb } from "./local-store.js";
 
 // Optional anonymized Orb telemetry export (#4277, network send wired in #5681). The self-host Orb collector
 // (src/selfhost/orb-collector.ts, #1255) is ALWAYS-ON for a maintainer's own instance; a miner runs on a
@@ -125,10 +124,9 @@ export function buildAnonymizedOrbBatch(
  */
 export function openOrbExportStore(dbPath: string = resolveOrbExportDbPath()): OrbExportStore {
   const resolvedPath = normalizeDbPath(dbPath);
-  mkdirSync(dirname(resolvedPath), { recursive: true, mode: 0o700 });
-  const db = new DatabaseSync(resolvedPath);
-  chmodSync(resolvedPath, 0o600);
-  db.exec("PRAGMA busy_timeout = 5000");
+  // openLocalStoreDb centralizes the mkdir(0o700)/chmod(0o600)/busy_timeout + crash-safe cleanup registration
+  // (#8319) -- so a SIGINT/SIGTERM/uncaught-exception mid-export doesn't leave this file half-written.
+  const db = openLocalStoreDb(resolvedPath);
   db.exec(`CREATE TABLE IF NOT EXISTS orb_export_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)`);
 
   const getStatement = db.prepare("SELECT value FROM orb_export_meta WHERE key = ?");

--- a/test/unit/miner-deny-hook-synthesis.test.ts
+++ b/test/unit/miner-deny-hook-synthesis.test.ts
@@ -21,6 +21,7 @@ import type { DenyRuleProposal } from "../../packages/loopover-engine/src/miner/
 // #7525: normalizeRepoFullName is defined in the engine and re-exported unchanged by the miner-lib module
 // above; import it from the engine source directly so the guard's src branches are the ones exercised.
 import { normalizeRepoFullName } from "../../packages/loopover-engine/src/miner/deny-hook-synthesis";
+import { cleanupResourceCount, resetProcessLifecycleForTesting } from "../../packages/loopover-miner/lib/process-lifecycle.js";
 
 const tempDirs: string[] = [];
 const stores: Array<{ close(): void }> = [];
@@ -161,6 +162,16 @@ describe("resolveEffectiveDenyRules() (#4522)", () => {
 describe("initDenyHookSynthesisStore() (#4522)", () => {
   it("rejects a blank/whitespace-only db path", () => {
     expect(() => initDenyHookSynthesisStore("   ")).toThrow("invalid_deny_hook_synthesis_db_path");
+  });
+
+  it("registers the store for crash-safe cleanup via openLocalStoreDb, and unregisters it on close (#8319)", () => {
+    resetProcessLifecycleForTesting();
+    expect(cleanupResourceCount()).toBe(0);
+    const store = tempStore();
+    expect(cleanupResourceCount()).toBe(1);
+    stores.splice(stores.indexOf(store), 1);
+    store.close();
+    expect(cleanupResourceCount()).toBe(0);
   });
 
   it("skips the forge-scope migration on a second open of an already-migrated file", () => {

--- a/test/unit/miner-laptop-init.test.ts
+++ b/test/unit/miner-laptop-init.test.ts
@@ -36,6 +36,7 @@ import {
   resolveLaptopStateDbPath,
   runInit,
 } from "../../packages/loopover-miner/lib/laptop-init.js";
+import { cleanupResourceCount, resetProcessLifecycleForTesting } from "../../packages/loopover-miner/lib/process-lifecycle.js";
 
 const roots: string[] = [];
 
@@ -81,6 +82,16 @@ describe("loopover-miner laptop init (#2329)", () => {
     const second = initLaptopState(env);
     expect(second.created).toBe(false);
     expect(readFileSync(join(first.stateDir, "marker.txt"), "utf8")).toBe("keep-me");
+  });
+
+  it("opens its store via openLocalStoreDb, registering and unregistering it for crash-safe cleanup within the call (#8319)", () => {
+    resetProcessLifecycleForTesting();
+    expect(cleanupResourceCount()).toBe(0);
+    const root = tempRoot();
+    initLaptopState({ LOOPOVER_MINER_CONFIG_DIR: join(root, "state") });
+    // initLaptopState closes its own handle internally before returning (it exposes no db handle), so a
+    // leftover registration here would mean the register→unregister cycle didn't complete cleanly.
+    expect(cleanupResourceCount()).toBe(0);
   });
 
   it("runInit prints human text (0) and machine JSON with --json", async () => {

--- a/test/unit/miner-orb-export.test.ts
+++ b/test/unit/miner-orb-export.test.ts
@@ -19,6 +19,7 @@ import {
   sendAmsExportBatch,
 } from "../../packages/loopover-miner/lib/orb-export.js";
 import type { OrbExportOutcome, OrbExportRow } from "../../packages/loopover-miner/lib/orb-export.js";
+import { cleanupResourceCount, resetProcessLifecycleForTesting } from "../../packages/loopover-miner/lib/process-lifecycle.js";
 
 let dir: string;
 function storePath() {
@@ -67,6 +68,15 @@ describe("orb-export store (#4277)", () => {
     store.setCursor("2026-01-02T00:00:00Z");
     expect(store.getCursor()).toBe("2026-01-02T00:00:00Z");
     store.close();
+  });
+
+  it("registers the store for crash-safe cleanup via openLocalStoreDb, and unregisters it on close (#8319)", () => {
+    resetProcessLifecycleForTesting();
+    expect(cleanupResourceCount()).toBe(0);
+    const store = openOrbExportStore(storePath());
+    expect(cleanupResourceCount()).toBe(1);
+    store.close();
+    expect(cleanupResourceCount()).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary

- Three local SQLite stores in `packages/loopover-miner` hand-rolled the same open boilerplate directly against `node:sqlite`'s `DatabaseSync` instead of routing through `local-store.ts`'s `openLocalStoreDb`, bypassing its crash-safety registration entirely — a SIGINT/SIGTERM/uncaught-exception mid-write was not guaranteed to close the handle cleanly the way every `openLocalStoreDb`-routed store already is (#4826). Closed issue #6595 previously fixed this exact bypass class for `governor-ledger.js`/`prediction-ledger.js`/`plan-store.js`.
- `orb-export.ts`'s `openOrbExportStore` and `deny-hook-synthesis.ts`'s `initDenyHookSynthesisStore`: replaced the manual `mkdirSync`/`new DatabaseSync`/`chmodSync`/`PRAGMA busy_timeout` sequence with `openLocalStoreDb(resolvedPath)`, dropping the now-redundant steps, mirroring `plan-store.ts`'s `openPlanStore` exactly.
- `laptop-init.ts`'s `initLaptopState`: same substitution — this was the one store with no busy-timeout and no crash-safety registration at all.
- No on-disk contract changes (table names, permissions, busy-timeout value all unchanged). `checkLaptopStateSqlite`'s separate read-only `DatabaseSync` open and `laptop-init.ts`'s local `resolveMinerStateDir` duplication are untouched, per the issue's explicit scope.
- Adds a crash-safe-cleanup-registration test to each file's suite, mirroring `local-store.ts`'s own `openLocalStoreDb` registration test (`cleanupResourceCount()`/`resetProcessLifecycleForTesting()`).

Closes #8319

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- `packages/loopover-miner/**` is not Codecov-gated per the issue's own note, and this change touches no UI/MCP/workers/OpenAPI surface. Both `npm run typecheck` (root) and `npm --workspace @loopover/miner run build:tsc` (the package's own, separate tsconfig) pass clean. Verified via `npx vitest run test/unit/miner-orb-export.test.ts test/unit/miner-deny-hook-synthesis.test.ts test/unit/miner-laptop-init.test.ts`: 60/64 tests pass, including all 3 new crash-safety-registration tests. The 4 pre-existing failures (Windows path-separator assertions expecting forward slashes, and a Windows file-lock `EBUSY` on temp-dir cleanup) are confirmed unrelated — reproduced identically on a clean stash of this branch's base commit before any of this PR's changes existed; none of the 4 touch the functions this PR changes.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session/CORS changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP surface changed.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes.)
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots. (N/A — no visible UI changes.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (N/A.)

## Notes

- Verified no import cycle for `laptop-init.ts` importing `openLocalStoreDb` from `./local-store.js`, per the issue's own guidance: `local-store.ts` imports only from `process-lifecycle.js` and `store-db-adapter.js`, neither of which imports `laptop-init.ts`.
