### PR TITLE
test(retention): cover pruneExpiredRecords's two defensive ?? 0 fallback arms

### DIFF
--- a/test/unit/retention.test.ts
+++ b/test/unit/retention.test.ts
@@ -140,6 +140,39 @@ describe("pruneExpiredRecords", () => {
     const rows = await env.DB.prepare("SELECT delivery_id FROM webhook_events").all<{ delivery_id: string }>();
     expect(rows.results.map((row) => row.delivery_id)).toEqual(["wh-recent"]);
   });
+
+  it("dry-run falls back to 0 when the count query returns no row (defensive ?? 0 arm, #8370)", async () => {
+    // Mirrors dedupeSignalSnapshots's existing equivalent test: the count `first()` returns undefined, so
+    // `Number(row?.n ?? 0)` must fall back to 0 rather than producing NaN.
+    const noRowEnv = {
+      DB: {
+        prepare: (_sql: string) => ({
+          bind: (..._binds: unknown[]) => ({ first: async () => undefined }),
+        }),
+      },
+    } as unknown as Env;
+    const results = await pruneExpiredRecords(noRowEnv, {
+      dryRun: true,
+      policy: [{ table: "audit_events", column: "created_at", days: 90 }],
+    });
+    expect(results).toEqual([{ table: "audit_events", column: "created_at", cutoff: expect.any(String), deleted: 0 }]);
+  });
+
+  it("delete loop falls back to 0 changes when a run() result lacks meta (defensive ?? 0 arm, #8370)", async () => {
+    // The delete `run()` returns an object with no `meta`, so `Number(result.meta?.changes ?? 0)` must fall back
+    // to 0 -- which is < batchSize, so the batch loop terminates immediately with deleted: 0 (no NaN, no spin).
+    const noMetaEnv = {
+      DB: {
+        prepare: (_sql: string) => ({
+          bind: (..._binds: unknown[]) => ({ run: async () => ({}) }),
+        }),
+      },
+    } as unknown as Env;
+    const results = await pruneExpiredRecords(noMetaEnv, {
+      policy: [{ table: "audit_events", column: "created_at", days: 90 }],
+    });
+    expect(results).toEqual([{ table: "audit_events", column: "created_at", cutoff: expect.any(String), deleted: 0 }]);
+  });
 });
 
 describe("dedupeSignalSnapshots", () => {


### PR DESCRIPTION
## What & why

Closes #8370.

`pruneExpiredRecords` (`src/db/retention.ts`) has two defensive `?? 0` fallback arms guarding against D1 driver anomalies — the dry-run count path (`Number(row?.n ?? 0)`, line 75) and the delete-loop path (`Number(result.meta?.changes ?? 0)`, line 85) — but neither had direct test coverage. The **identical** pattern on this file's sibling `dedupeSignalSnapshots` **does** have dedicated tests, and the repo's Codecov patch gate counts branches, so these two untested nullish-coalescing arms are exactly the gap the gate is meant to catch.

## What's added (test-only — no source change)

Two tests in `test/unit/retention.test.ts`, mirroring `dedupeSignalSnapshots`'s existing equivalents:
- **dry-run fallback:** mock `env.DB` so the count query's `first()` returns `undefined` → assert `row?.n ?? 0` falls back to `deleted: 0` (not `NaN`).
- **delete-loop fallback:** mock the delete `run()` to return an object with no `meta` → assert `result.meta?.changes ?? 0` falls back to `0` (which is `< batchSize`, so the loop terminates immediately with `deleted: 0`).

Per the issue, `pruneExpiredRecords`'s actual logic is untouched — this is coverage for existing, already-correct defensive code.

## Validation

- `test/unit/retention.test.ts`: **22 tests pass** (20 existing + 2 new); typecheck clean; `git diff --check` clean.
- Coverage-catch verified: changing either `?? 0` to a non-zero fallback makes the corresponding new test fail, proving the tests genuinely exercise the fallback arm.
- Branched off current `main`, mergeable-clean.