### PR TITLE
test(scoring): cover pending-pr-scenarios' sameLogin/sameRepoFullName match branches

### DIFF
--- a/test/unit/pending-pr-scenarios.test.ts
+++ b/test/unit/pending-pr-scenarios.test.ts
@@ -461,4 +461,36 @@ describe("pending PR scenario detection", () => {
     expect(records.pullRequestChecks).toHaveLength(0);
     vi.restoreAllMocks();
   });
+
+  it("excludes PRs whose authorLogin is null or undefined via sameLogin's short-circuit (#8329)", async () => {
+    const env = {} as Env;
+    // Only the target login's own open PR (#70) should be loaded; the null/undefined-author rows must be
+    // excluded by sameLogin (`Boolean(value && ...)`), not matched or thrown on.
+    const reviewsSpy = vi.spyOn(repositories, "listPullRequestReviews").mockResolvedValue([approvedReview(70)]);
+    vi.spyOn(repositories, "listCheckSummaries").mockResolvedValue([]);
+    const records = await loadContributorRepoOpenPrSignalRecords(env, "entrius/allways-ui", "miner-a", [
+      pr({ number: 70 }),
+      pr({ number: 73, authorLogin: null }),
+      pr({ number: 74, authorLogin: undefined }),
+    ]);
+    // Reviews/checks are fetched per matched PR only, so exactly one PR (the target login's) was matched.
+    expect(records.pullRequestReviews).toHaveLength(1);
+    expect(reviewsSpy).toHaveBeenCalledTimes(1);
+    expect(reviewsSpy).toHaveBeenCalledWith(env, "entrius/allways-ui", 70);
+    vi.restoreAllMocks();
+  });
+
+  it("matches a repoFullName that differs from the query only in letter case (#8329)", async () => {
+    const env = {} as Env;
+    // The PR record's repoFullName differs in case from the query argument; sameRepoFullName lowercases both,
+    // so the PR is still matched and its cached reviews loaded.
+    const reviewsSpy = vi.spyOn(repositories, "listPullRequestReviews").mockResolvedValue([approvedReview(70)]);
+    vi.spyOn(repositories, "listCheckSummaries").mockResolvedValue([]);
+    const records = await loadContributorRepoOpenPrSignalRecords(env, "entrius/allways-ui", "miner-a", [
+      pr({ number: 70, repoFullName: "Entrius/Allways-UI" }),
+    ]);
+    expect(records.pullRequestReviews).toHaveLength(1);
+    expect(reviewsSpy).toHaveBeenCalledWith(env, "Entrius/Allways-UI", 70);
+    vi.restoreAllMocks();
+  });
 });


### PR DESCRIPTION
## What & why

Closes #8329.

`loadContributorRepoOpenPrSignalRecords` (`src/scoring/pending-pr-scenarios.ts`) filters a repo's open PRs by `sameLogin` — which short-circuits a `null`/`undefined` `authorLogin` via `Boolean(value && value.toLowerCase() === login.toLowerCase())` — and `sameRepoFullName` (case-insensitive). Neither branch had direct coverage, and the repo's patch gate counts branches.

## What's added (test-only — no source change)

Two tests extending the existing loader test in `test/unit/pending-pr-scenarios.test.ts`:
- **null/undefined author excluded:** PRs with `authorLogin: null` and `authorLogin: undefined` are dropped by `sameLogin`'s short-circuit (not matched, not thrown on) — asserted by mocking the per-PR review fetch and confirming only the target login's own PR (#70) is loaded (`listPullRequestReviews` called exactly once, for #70).
- **case-insensitive repo match:** a `PullRequestRecord` whose `repoFullName` is `"Entrius/Allways-UI"` still matches the query `"entrius/allways-ui"` — `sameRepoFullName` lowercases both.

`loadContributorRepoOpenPrSignalRecords`'s logic is untouched — this is coverage for existing, correct code.

## Validation

- `test/unit/pending-pr-scenarios.test.ts`: **19 tests pass** (17 existing + 2 new); typecheck clean; `git diff --check` clean.
- Coverage-catch verified: making `sameRepoFullName` case-sensitive fails the case test, proving it exercises that branch.
- Branched off current `main`, mergeable-clean.