### PR TITLE
test(signals): cover decidePublicSurface's oss_maintainer + not_checked label fallback

### DIFF
--- a/test/unit/settings-preview.test.ts
+++ b/test/unit/settings-preview.test.ts
@@ -96,6 +96,32 @@ describe("decidePublicSurface", () => {
     expect(decidePublicSurface({ settings: settings({ commentMode: "all_prs" }), authorLogin: "x", minerStatus: "not_found" })).toMatchObject({ skipped: false, willComment: true, willLabel: false });
   });
 
+  it("#8324: covers the oss_maintainer + not_checked labeling fallback for every autoLabel/publicSurface combination", () => {
+    // shouldApplyPrLabel returns FALSE for oss_maintainer whenever minerStatus !== "confirmed", so this
+    // combination is governed entirely by decidePublicSurface's own inline disjunct — the branch that had
+    // zero coverage (`grep not_checked` matched nothing in this file before this test).
+    const notChecked = (overrides: Partial<RepositorySettings>) =>
+      decidePublicSurface({
+        settings: settings({ publicAudienceMode: "oss_maintainer", ...overrides }),
+        authorLogin: "contributor",
+        authorType: "User",
+        authorAssociation: "NONE",
+        minerStatus: "not_checked",
+      });
+
+    // autoLabelEnabled + a label-bearing surface ⇒ the fallback re-enables labeling.
+    expect(notChecked({ autoLabelEnabled: true, publicSurface: "comment_and_label" })).toMatchObject({ skipped: false, willLabel: true });
+    expect(notChecked({ autoLabelEnabled: true, publicSurface: "label_only" })).toMatchObject({ skipped: false, willLabel: true });
+    // The disjunct's own publicSurface check must exclude a comment-only surface.
+    expect(notChecked({ autoLabelEnabled: true, publicSurface: "comment_only" })).toMatchObject({ skipped: false, willLabel: false });
+    // autoLabelEnabled false ⇒ the fallback cannot fire; shouldApplyPrLabel's own false result stands.
+    expect(notChecked({ autoLabelEnabled: false, publicSurface: "comment_and_label" })).toMatchObject({ skipped: false, willLabel: false });
+
+    // And the `label` action mirrors willLabel exactly (the actions array is what callers act on).
+    expect(notChecked({ autoLabelEnabled: true, publicSurface: "label_only" }).actions).toContain("label");
+    expect(notChecked({ autoLabelEnabled: false, publicSurface: "label_only" }).actions).not.toContain("label");
+  });
+
   it("includes maintainer authors when configured", () => {
     const decision = decidePublicSurface({ settings: settings({ includeMaintainerAuthors: true }), authorLogin: "owner", authorAssociation: "OWNER", minerStatus: "confirmed" });
     expect(decision.skipped).toBe(false);


### PR DESCRIPTION
## Summary

`decidePublicSurface`'s `willLabel` (`src/signals/settings-preview.ts:148`) has an inline second disjunct that re-enables labeling for `publicAudienceMode: "oss_maintainer"` + `minerStatus: "not_checked"` — a combination `shouldApplyPrLabel` itself always answers `false` for (it returns early for `oss_maintainer` whenever `minerStatus !== "confirmed"`). So this branch alone governs whether a webhook run applies a label before the official miner lookup has completed.

Nothing exercised it: `grep -n "not_checked" test/unit/settings-preview.test.ts` matched **zero** lines before this PR.

Adds the four combinations the disjunct distinguishes, plus an assertion that the `actions` array mirrors `willLabel` (that array is what callers actually act on):

| `autoLabelEnabled` | `publicSurface` | expected `willLabel` |
| --- | --- | --- |
| `true` | `comment_and_label` | ✅ true |
| `true` | `label_only` | ✅ true |
| `true` | `comment_only` | ❌ false — the disjunct's own `publicSurface` check excludes it |
| `false` | `comment_and_label` | ❌ false — fallback can't fire; `shouldApplyPrLabel`'s false result stands |

**Measured, not assumed.** I captured branch data before and after on the `willLabel` line:

- **Before:** `BRDA` for line 148 → takes `33, 9, 9, 0, 0, 0` — **three operands never taken**.
- **After:** `39, 15, 15, 6, 4, 3` — every operand covered, zero uncovered branches in the region.

**No behavior change, and no divergence to report.** The issue asked me to flag rather than silently fix any genuine divergence from `shouldApplyPrLabel`'s intent. I checked: `shouldApplyPrLabel` deliberately returns `false` for `oss_maintainer` + non-`confirmed`, and the inline disjunct re-grants labeling *only* for the narrower `not_checked` case while re-checking the same `autoLabelEnabled` + label-bearing-`publicSurface` conditions that function uses. That is a deliberate, consistent narrowing — not a drift — so there is nothing to escalate.

Closes #8324

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Test-only diff (one file, +26 lines), so there is no production surface to exercise: `actionlint` (no workflow change), `build:mcp`/`test:mcp-pack`, `ui:*`, `test:workers`, and `npm audit` are all unaffected.
- **Patch coverage:** this PR adds no production lines, so `codecov/patch` has no changed source to score; its purpose is closing an existing branch gap, verified by the before/after `BRDA` numbers above. The scoped coverage run emits a non-empty `coverage/lcov.info` containing `src/signals/settings-preview.ts` (the suite imports the module directly), so the "Verify coverage report exists" step is satisfied. `test/unit/settings-preview.test.ts` passes in full (33 tests) and root `tsc --noEmit` is clean.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — a unit-test addition; no visible UI, frontend, docs, or extension change.
