### PR TITLE
test(signals): exercise the gittensor_root arm of local-branch's metadataOnly condition

### DIFF
--- a/test/unit/local-branch.test.ts
+++ b/test/unit/local-branch.test.ts
@@ -2225,6 +2225,38 @@ describe("local MCP git metadata collection", () => {
     expect(analysis.scenarioSummary.eligibilityNotes.length).toBeGreaterThan(0);
   });
 
+  it("#8325: covers both operands of the metadataOnly condition, including the gittensor_root arm", () => {
+    // metadataOnly = scorer?.mode !== "gittensor_root" && scorer?.mode !== "external_command"
+    // (local-branch.ts:497). Every other mode was covered; "gittensor_root" had zero test cases, so the
+    // FIRST operand's false arm was never taken. These three cases exercise each operand independently.
+    const analyze = (localScorer?: { mode: string }) =>
+      buildLocalBranchAnalysis({
+        input: {
+          login: "oktofeesh1",
+          repoFullName: repo.fullName,
+          changedFiles: [{ path: "src/cache.ts", additions: 5, deletions: 0, status: "modified" }],
+          ...(localScorer ? { localScorer: localScorer as never } : {}),
+        },
+        repo,
+        issues: [],
+        pullRequests: [],
+        profile,
+        outcomeHistory,
+        scoringSnapshot,
+        scoringProfile,
+      });
+    const hasMetadataOnly = (analysis: ReturnType<typeof buildLocalBranchAnalysis>) =>
+      analysis.scorePreview.blockedBy.some((entry) => entry.code === "metadata_only");
+
+    // Operand 1 FALSE (short-circuits): a real gittensor_root scorer ran, so the preview is NOT metadata-only.
+    expect(hasMetadataOnly(analyze({ mode: "gittensor_root" }))).toBe(false);
+    // Operand 1 TRUE, operand 2 FALSE: external_command is the other real-scorer mode.
+    expect(hasMetadataOnly(analyze({ mode: "external_command" }))).toBe(false);
+    // BOTH TRUE: any other mode (or no scorer at all) leaves the preview metadata-only.
+    expect(hasMetadataOnly(analyze({ mode: "metadata_only" }))).toBe(true);
+    expect(hasMetadataOnly(analyze())).toBe(true);
+  });
+
   it("populates scenarioSummary.blockerNotes when the score preview has metadata-only signals", () => {
     const analysis = buildLocalBranchAnalysis({
       input: {


### PR DESCRIPTION
## Summary

`src/signals/local-branch.ts:497` computes:

```ts
metadataOnly: scorer?.mode !== "gittensor_root" && scorer?.mode !== "external_command",
```

`"gittensor_root"` appeared **nowhere** in `test/unit/local-branch.test.ts` (2600+ lines, every other mode covered) — `grep -c gittensor_root` returned `0`. This PR exercises that value, asserting through the user-facing effect the flag actually drives: the `metadata_only` entry in `scorePreview.blockedBy` ("Preview used metadata-only inputs, so token and density estimates are rough.").

Cases added:

| `localScorer.mode` | `metadata_only` caveat | operand exercised |
| --- | --- | --- |
| `gittensor_root` | ❌ absent | 1st operand false (short-circuits) |
| `external_command` | ❌ absent | 1st true, 2nd false |
| `metadata_only` | ✅ present | both true |
| *(no scorer)* | ✅ present | both true, undefined-scorer path |

## Two corrections to the issue's premise — flagged, not silently "fixed"

The issue asked me to note discrepancies for maintainer triage rather than change behavior. There are two:

**1. The expected direction is inverted.** The issue says to cover "one case where `mode: "gittensor_root"` … makes `metadataOnly` **true**". It cannot: `gittensor_root` is the *first* thing the condition excludes, so that mode makes `metadataOnly` **false** — the mode means a real scorer ran, so the preview is *not* metadata-only. My tests assert the actual (and sensible) behavior. **No production change made.**

**2. This does not move a Codecov number, and I won't claim it does.** The issue expects to "confirm via `npm run test:coverage` that the previously-uncovered `gittensor_root` branch is now covered". I measured it: v8 emits exactly two branch entries for line 497 (`BRDA:497,35,0` / `BRDA:497,35,1`), and **both were already taken** before this PR — the existing `external_command` tests already drive the conjunction's false arm. Baseline showed `(497,'1'),(497,'1')`; with my tests `(497,'4'),(497,'3')`. Both non-zero either way.

So the gap this closes is **semantic, not lcov-measurable**: the specific `gittensor_root` value was never exercised, and v8's per-line branch model can't distinguish *which* operand caused the false result. The test's real value is pinning that a genuine scorer mode does not emit the metadata-only caveat to contributors — worth having, but I'd rather state its actual scope than overclaim a coverage delta.

Closes #8325

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Test-only diff (one file, +32 lines): no workflow, MCP, UI, worker, or dependency surface is touched, so those checks are not exercised. Root `tsc --noEmit` is clean and `git diff --check` passes.
- `codecov/patch` has no changed production lines to score; the scoped coverage run emits a non-empty `coverage/lcov.info` containing `src/signals/local-branch.ts` (the suite imports it directly), satisfying the "Verify coverage report exists" step.
- **Pre-existing unrelated failure:** `test/unit/local-branch.test.ts`'s *"classifies a type change (regular file replaced by a symlink) as unknown, not modified"* fails on my Windows checkout because the sandbox cannot create real symlinks. I verified it fails identically with my change stashed, so it is environmental and untouched by this PR; the other 73 tests in the file pass.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — a unit-test addition; no visible UI, frontend, docs, or extension change.
