### PR TITLE
test(scoring): pin the unpinned-fallback and languages-fetch-failed warnings

### DIFF
--- a/test/unit/scoring.test.ts
+++ b/test/unit/scoring.test.ts
@@ -500,6 +500,31 @@ NOVELTY_BONUS_SCALAR = 3
     expect(refreshed.payload.upstreamSourceSha).toBeUndefined();
     expect(refreshed.constants.MERGED_PR_BASE_SCORE).toBe(25);
     expect(refreshed.sourceKind).toBe("raw-github");
+    // #8327: the ONLY operator-facing signal that scoring is running unpinned against a mutable ref --
+    // pin it so a refactor that drops or garbles the string is caught.
+    expect(refreshed.warnings.some((warning) => /unpinned/i.test(warning))).toBe(true);
+  });
+
+  it("#8327: warns and falls back to empty language weights when ONLY the languages fetch fails", async () => {
+    // Prior tests that reached constantsUsable === true always stubbed programming_languages.json to
+    // succeed, and tests where languages failed had constants.py fail first (short-circuiting into the
+    // earlier !constantsUsable path) -- so this warning-push and its {} fallback never executed.
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "token" });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("constants.py")) return new Response(VALID_CONSTANTS_PY + "MERGED_PR_BASE_SCORE = 25\n");
+      if (url.includes("programming_languages.json")) return new Response("not found", { status: 404 });
+      return new Response("not found", { status: 404 });
+    });
+
+    const refreshed = await refreshScoringModelSnapshot(env);
+
+    // The constants path still succeeded ...
+    expect(refreshed.sourceKind).toBe("raw-github");
+    expect(refreshed.constants.MERGED_PR_BASE_SCORE).toBe(25);
+    // ... while language weights degrade to {} with an explicit operator-facing warning.
+    expect(refreshed.programmingLanguages).toEqual({});
+    expect(refreshed.warnings.some((warning) => /Programming language weights fetch failed/.test(warning))).toBe(true);
   });
 
   it("pins the constants fetch to the resolved upstream SHA (immutable) when it can be resolved", async () => {


### PR DESCRIPTION
## Summary

`refreshScoringModelSnapshot` (`src/scoring/model.ts`) pushes two operator-facing warnings that nothing asserted:

**1. The unpinned-fallback warning (~line 59).** The existing *"is fail-open when the upstream SHA fetch fails"* test already drives this branch (its SHA endpoint throws) and checks `payload.upstreamSourceSha` is undefined — but never looked at `warnings`. That string is the **only** signal that scoring is currently running unpinned against a mutable ref, where an upstream force-push silently changes what every repo scores against. Added the assertion to the existing test.

**2. The languages-fetch-failed branch (~line 116-117) had never executed.** Every test reaching `constantsUsable === true` also stubbed `programming_languages.json` to succeed, and every test where languages failed had `constants.py` fail first — short-circuiting into the earlier `!constantsUsable` path before this line. Added a test combining **constants succeed + languages 404**, asserting `sourceKind === "raw-github"`, `programmingLanguages` degrades to `{}`, and the warning text is present.

**Verified both tests actually pin their branches** rather than passing alongside them — deleting each `warnings.push(...)` makes the corresponding test fail, restoring it makes all 89 pass:

| Removed | Result |
| --- | --- |
| `Programming language weights fetch failed` push | new test **fails** ✅ |
| unpinned-ref push | extended SHA-failure test **fails** ✅ |

One correction to the issue's text: it suggests asserting `programmingLanguages` on the *payload*. It is a **top-level** field of the snapshot record (`ScoringModelSnapshotRecord.programmingLanguages`), not `payload.programmingLanguages`, so the assertion targets the real field.

Closes #8327

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Test-only diff (one file, +25 lines): no workflow, MCP, UI, worker, or dependency surface is touched, so those checks are not exercised. Root `tsc --noEmit` is clean and `git diff --check` passes.
- `codecov/patch` has no changed production lines to score. The scoped coverage run emits a non-empty `coverage/lcov.info` containing `src/scoring/model.ts` (the suite imports it directly), satisfying the "Verify coverage report exists" step. `test/unit/scoring.test.ts` passes in full — **89 tests**.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — unit-test additions; no visible UI, frontend, docs, or extension change.
