### PR TITLE
test(scoring): cover pending-pr-scenarios' ghost-login and case-insensitive matching

### DIFF
--- a/test/unit/pending-pr-scenarios.test.ts
+++ b/test/unit/pending-pr-scenarios.test.ts
@@ -448,6 +448,34 @@ describe("pending PR scenario detection", () => {
     ).toBe("stale_likely_close");
   });
 
+  it("#8329: excludes ghost-account PRs and matches repo/login case-insensitively", async () => {
+    const env = {} as Env;
+    // Return a review keyed to whichever PR number is asked for, so the resulting reviews reveal exactly
+    // which records survived sameRepoFullName + sameLogin.
+    vi.spyOn(repositories, "listPullRequestReviews").mockImplementation(async (_env, _repo, pullNumber: number) => [
+      approvedReview(pullNumber),
+    ]);
+    vi.spyOn(repositories, "listCheckSummaries").mockResolvedValue([]);
+
+    const records = await loadContributorRepoOpenPrSignalRecords(env, "entrius/allways-ui", "miner-a", [
+      // sameLogin's `value &&` short-circuit: a ghost/deleted account has no resolvable login and must be
+      // excluded rather than throwing on .toLowerCase() or matching by accident.
+      pr({ number: 80, authorLogin: null as unknown as string }),
+      pr({ number: 81, authorLogin: undefined }),
+      // Case-insensitive repo match: GitHub treats owner/repo case-insensitively, stored values may differ.
+      pr({ number: 82, repoFullName: "Entrius/Allways-UI" }),
+      // Case-insensitive login match.
+      pr({ number: 83, authorLogin: "Miner-A" }),
+    ]);
+
+    const matched = records.pullRequestReviews.map((review) => review.pullNumber).sort((a, b) => a - b);
+    expect(matched).toEqual([82, 83]);
+    // Explicitly: neither ghost-account PR slipped through.
+    expect(matched).not.toContain(80);
+    expect(matched).not.toContain(81);
+    vi.restoreAllMocks();
+  });
+
   it("loads cached reviews and checks for contributor open PRs", async () => {
     const env = {} as Env;
     vi.spyOn(repositories, "listPullRequestReviews").mockResolvedValue([approvedReview(70)]);


### PR DESCRIPTION
## Summary

`src/scoring/pending-pr-scenarios.ts`'s two filter helpers had untested defensive behavior:

```ts
function sameRepoFullName(left: string, right: string): boolean {
  return left.toLowerCase() === right.toLowerCase();
}
function sameLogin(value: string | null | undefined, login: string): boolean {
  return Boolean(value && value.toLowerCase() === login.toLowerCase());
}
```

- `sameLogin`'s `value &&` short-circuit exists because `PullRequestRecord.authorLogin` is `string | null | undefined` — a real case for ghost/deleted GitHub accounts. Without it, a `null` login would throw on `.toLowerCase()`.
- Both helpers lowercase before comparing because GitHub treats owner/repo and logins case-insensitively while stored values aren't guaranteed consistently cased.

Every existing test passed a concrete, identically-cased login and repo name, so neither behavior was pinned.

Adds a single case covering all four situations the issue lists, asserting through `loadContributorRepoOpenPrSignalRecords`:

| Record | Expected |
| --- | --- |
| `authorLogin: null` | excluded (short-circuit, no throw) |
| `authorLogin: undefined` | excluded |
| `repoFullName: "Entrius/Allways-UI"` vs query `"entrius/allways-ui"` | **included** |
| `authorLogin: "Miner-A"` vs query `"miner-a"` | **included** |

The mock returns a review keyed to the requested pull number, so the assertion reads back the exact set of records that survived the filter (`[82, 83]`) rather than inferring inclusion from an array length.

**Verified the test pins the behavior**, rather than passing alongside it — each helper was reverted independently and the test failed both times:

| Reverted | Result |
| --- | --- |
| `sameLogin` short-circuit → `(value as string).toLowerCase()` | **fails** ✅ |
| `sameRepoFullName` normalization → `left === right` | **fails** ✅ |

Closes #8329

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Test-only diff (one file, +28 lines): no workflow, MCP, UI, worker, or dependency surface is touched, so those checks are not exercised. Root `tsc --noEmit` is clean and `git diff --check` passes.
- `codecov/patch` has no changed production lines to score. The scoped coverage run emits a non-empty `coverage/lcov.info` containing `src/scoring/pending-pr-scenarios.ts` (the suite imports it directly), satisfying the "Verify coverage report exists" step. `test/unit/pending-pr-scenarios.test.ts` passes in full — **18 tests**.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — a unit-test addition; no visible UI, frontend, docs, or extension change.

## Notes

- `authorLogin: null` is passed as `null as unknown as string` because the `pr()` fixture's `Partial<PullRequestRecord>` narrows it, while the underlying `PullRequestRecord.authorLogin` really is `string | null | undefined` — the cast reproduces the genuine runtime shape the helper guards against, without loosening the fixture for every other test.
