### PR TITLE
test(db): cover pruneExpiredRecords' two defensive ?? 0 fallback arms

### DIFF
--- a/test/unit/retention.test.ts
+++ b/test/unit/retention.test.ts
@@ -277,6 +277,56 @@ describe("dedupeSignalSnapshots", () => {
   });
 });
 
+describe("pruneExpiredRecords defensive ?? 0 arms (#8370)", () => {
+  // Mirrors the sibling dedupeSignalSnapshots tests for the identical pattern: mock env.DB so the
+  // row / meta shape is missing the field, and assert the fallback yields 0 rather than NaN or a throw.
+  const RULE = [{ table: "audit_events", column: "created_at", days: 90 }] as const;
+
+  it("dry-run falls back to 0 when the count query returns no row (line 75 arm)", async () => {
+    const noRowEnv = {
+      DB: {
+        prepare: (_sql: string) => ({
+          bind: (..._binds: unknown[]) => ({ first: async () => undefined }), // no row -> `row?.n ?? 0`
+        }),
+      },
+    } as unknown as Env;
+
+    const results = await pruneExpiredRecords(noRowEnv, { dryRun: true, nowMs: NOW, policy: RULE });
+    expect(results).toHaveLength(1);
+    expect(results[0]?.deleted).toBe(0);
+    expect(Number.isNaN(results[0]?.deleted)).toBe(false); // Number(undefined) would be NaN without the ?? 0
+  });
+
+  it("dry-run falls back to 0 when the row is present but n is null (line 75 arm)", async () => {
+    const nullCountEnv = {
+      DB: {
+        prepare: (_sql: string) => ({
+          bind: (..._binds: unknown[]) => ({ first: async () => ({ n: null }) }), // nullish n -> same arm
+        }),
+      },
+    } as unknown as Env;
+
+    const results = await pruneExpiredRecords(nullCountEnv, { dryRun: true, nowMs: NOW, policy: RULE });
+    expect(results[0]?.deleted).toBe(0);
+  });
+
+  it("falls back to 0 changes when a delete run() result lacks meta (line 85 arm)", async () => {
+    const noMetaEnv = {
+      DB: {
+        prepare: (_sql: string) => ({
+          // no meta -> `result.meta?.changes ?? 0` fires, so changes = 0 < batchSize and the loop exits.
+          bind: (..._binds: unknown[]) => ({ run: async () => ({}) }),
+        }),
+      },
+    } as unknown as Env;
+
+    const results = await pruneExpiredRecords(noMetaEnv, { nowMs: NOW, policy: RULE, batchSize: 5 });
+    expect(results).toHaveLength(1);
+    expect(results[0]?.deleted).toBe(0);
+    expect(Number.isNaN(results[0]?.deleted)).toBe(false);
+  });
+});
+
 describe("runRetentionPrune + processJob", () => {
   it("audits a dry-run without deleting", async () => {
     const env = createTestEnv();


### PR DESCRIPTION
## Summary

`src/db/retention.ts`'s `pruneExpiredRecords` guards two D1 driver anomalies with `?? 0` — the dry-run count row (line 75) and the delete-loop `meta.changes` (line 85) — and neither had direct coverage, even though the **identical pattern on the sibling `dedupeSignalSnapshots` already has dedicated tests** (lines 236-264). This mirrors that precedent exactly rather than inventing a new mocking style.

Three cases added:

| Case | Arm | Assertion |
| --- | --- | --- |
| count query returns **no row** | `row?.n ?? 0` | `deleted === 0`, not `NaN` |
| row present but **`n: null`** | `row?.n ?? 0` | `deleted === 0` |
| delete `run()` result **lacks `meta`** | `result.meta?.changes ?? 0` | `deleted === 0`, not `NaN` |

## Worth flagging: the line-85 guard prevents an infinite loop, not just a `NaN`

While revert-proofing I removed each `?? 0` to confirm the tests actually detect its absence. Removing the **line-75** guard fails the test cleanly, as expected. Removing the **line-85** guard does something more serious: `changes` becomes `NaN`, and since every `NaN` comparison is false, the loop's exit condition

```ts
if (changes < batchSize || deleted >= maxPerTable) break;
```

never fires — the batched delete loop **spins forever**. My local run had to be killed on timeout.

So that `?? 0` is load-bearing beyond producing a tidy number, and the new test's failure mode for that arm is a hang rather than an assertion error. I'm noting this rather than quietly leaving it: a hang is a worse CI signal than a failure, and a maintainer may decide the loop deserves its own `Number.isFinite` guard. **I have not changed the loop** — the issue is scoped to test coverage only, and adding a production guard here is a behavior decision that needs a maintainer's read.

Closes #8370

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Test-only diff (one file, +50 lines): no workflow, MCP, UI, worker, or dependency surface is touched. Root `tsc --noEmit` is clean and `git diff --check` passes. `codecov/patch` has no changed production lines to score; the scoped run emits a non-empty `coverage/lcov.info` containing `src/db/retention.ts` (the suite imports it directly), satisfying the "Verify coverage report exists" step.
- **Pre-existing unrelated failures:** `test/unit/retention.test.ts`'s `"dry-run reports eligible rows per table without deleting anything"` and `"deletes rows older than the window and keeps recent ones"` fail on my local checkout. I verified they fail **identically with my changes stashed**, so they are environmental and untouched by this PR; my three new cases pass, and `src/db/retention.ts` is byte-unmodified (`git diff --stat` empty).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — unit-test additions; no visible UI, frontend, docs, or extension change.
