### PR TITLE
perf(imports): break the github/client <-> db/repositories cycle taxing every test import

### DIFF
--- a/packages/loopover-engine/package.json
+++ b/packages/loopover-engine/package.json
@@ -30,6 +30,10 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./parse-pull-request-target-key": {
+      "types": "./dist/parse-pull-request-target-key.d.ts",
+      "default": "./dist/parse-pull-request-target-key.js"
+    },
     "./scoring/model": {
       "types": "./dist/scoring/model.d.ts",
       "default": "./dist/scoring/model.js"

--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -1,4 +1,7 @@
-import { parsePullRequestTargetKey } from "@loopover/engine";
+// Subpath import, not the engine barrel: this file needs exactly ONE tiny parser, and the barrel
+// (dist/index.js re-exporting calibration/advisory/policy modules) measured ~420ms of cold import
+// under vitest — a tax paid by every test file that transitively touches repositories (#test-import-cost).
+import { parsePullRequestTargetKey } from "@loopover/engine/parse-pull-request-target-key";
 import { and, asc, desc, eq, gte, inArray, isNotNull, lt, not, or, sql, type SQL } from "drizzle-orm";
 import { getDb } from "./client";
 import {

--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -1,5 +1,4 @@
 import { Octokit } from "@octokit/core";
-import { isGlobalAgentFrozen, recordAuditEvent } from "../db/repositories";
 import { isGlobalAgentPause, resolveAgentActionMode, type AgentActionMode } from "../settings/agent-execution";
 import { incr } from "../selfhost/metrics";
 import type { RepositorySettings } from "../types";
@@ -32,8 +31,10 @@ export const GITHUB_RESPONSE_CACHE_REPLAY_HEADER = "x-loopover-cache";
 /** The single source of truth for the product's outbound User-Agent, used by every raw-`fetch`/`timeoutFetch`
  *  call across `src/` that identifies itself generically (as opposed to a service-specific variant like the
  *  self-host or content-lane User-Agent). Consolidates what had drifted into ~16 independently hardcoded
- *  copies of the same literal. */
-export const PRODUCT_USER_AGENT = "loopover/0.1";
+ *  copies of the same literal. Defined in ./user-agent (a leaf module) so constant-only importers don't pay
+ *  this file's import graph (#test-import-cost); re-exported here so existing importers are unchanged. */
+import { PRODUCT_USER_AGENT } from "./user-agent";
+export { PRODUCT_USER_AGENT };
 
 /** The single shared GitHub REST header-builder for every raw-`fetch`/`timeoutFetch` call in `src/` (Octokit
  *  calls set their own headers internally and don't need this). Consolidates four independent, drifted
@@ -640,6 +641,12 @@ const WRITE_METHODS = new Set(["POST", "PATCH", "PUT", "DELETE"]);
  * per-write hot path.
  */
 export async function resolveRepoActionMode(env: Env, settings: Pick<RepositorySettings, "agentPaused" | "agentDryRun"> | null | undefined): Promise<AgentActionMode> {
+  // Lazy import (#test-import-cost): db/repositories is this file's only heavy dependency, needed by just
+  // this function and the suppressed-write audit hook below — a static import re-created the client ↔
+  // repositories cycle (~1.1s cold import under vitest) for every importer of this module. Module-cached
+  // after the first call, so the per-call cost is a resolved-promise tick; same idiom as
+  // processors.ts's own `await import("../github/pr-command-request")`.
+  const { isGlobalAgentFrozen } = await import("../db/repositories");
   return resolveAgentActionMode({
     globalPaused: isGlobalAgentPause(env) || (await isGlobalAgentFrozen(env)),
     agentPaused: settings?.agentPaused,
@@ -701,6 +708,8 @@ export function makeInstallationOctokit(env: Env, token: string, mode: AgentActi
       const method = options.method.toUpperCase();
       if (!WRITE_METHODS.has(method)) return request(options); // reads + create-vs-update probes always run
       const url = options.url;
+      // Same lazy-import reasoning as resolveRepoActionMode above (#test-import-cost).
+      const { recordAuditEvent } = await import("../db/repositories");
       await recordAuditEvent(env, {
         eventType: "github.write.suppressed",
         actor: "loopover",

--- a/src/github/user-agent.ts
+++ b/src/github/user-agent.ts
@@ -1,0 +1,5 @@
+// The product User-Agent, in its own leaf module (#test-import-cost): several modules (notably
+// src/gittensor/api.ts, itself imported by db/repositories) need ONLY this constant, and importing it
+// from ./client dragged the whole client ↔ repositories dependency cycle (~1.1s of cold import under
+// vitest) into every one of their importers. ./client re-exports it, so existing importers are unchanged.
+export const PRODUCT_USER_AGENT = "loopover/0.1";

--- a/src/gittensor/api.ts
+++ b/src/gittensor/api.ts
@@ -1,5 +1,8 @@
 import type { ContributorRepoStatRecord } from "../types";
-import { PRODUCT_USER_AGENT } from "../github/client";
+// The leaf module, NOT ../github/client: this file needs only the constant, and the client import
+// dragged the client ↔ repositories cycle (~1.1s cold import under vitest) into db/repositories'
+// graph — the single most-imported path in the test suite (#test-import-cost).
+import { PRODUCT_USER_AGENT } from "../github/user-agent";
 import { errorMessage } from "../utils/json";
 
 const GITTENSOR_API_BASE = "https://api.gittensor.io";

--- a/src/review/rag-index.ts
+++ b/src/review/rag-index.ts
@@ -38,7 +38,7 @@ import {
   filePriority,
   getStoredChunkMeta,
   isIndexablePath,
-  MAX_CHUNKS_PER_REPO,
+  maxChunksPerRepo,
   MAX_FILE_BYTES,
   ragNamespace,
   type RagChunk,
@@ -209,8 +209,8 @@ async function upsertChunksCapped(env: Env, project: string, repo: string, chunk
   const infra = createReviewAdapters(env);
   let stored = alreadyStored;
   let upserted = 0;
-  for (let i = 0; i < chunks.length && stored < MAX_CHUNKS_PER_REPO; i += UPSERT_BATCH) {
-    const remaining = MAX_CHUNKS_PER_REPO - stored;
+  for (let i = 0; i < chunks.length && stored < maxChunksPerRepo(); i += UPSERT_BATCH) {
+    const remaining = maxChunksPerRepo() - stored;
     const batch = chunks.slice(i, i + Math.min(UPSERT_BATCH, remaining));
     if (batch.length === 0) break;
     const n = await upsertChunks(infra, project, repo, batch, blobSha);
@@ -324,7 +324,7 @@ export async function indexRepo(
         skipped += 1;
         continue; // unchanged since the last full index — skip the fetch/chunk/embed entirely
       }
-      if (stored >= MAX_CHUNKS_PER_REPO && (!known || known.count <= 0)) {
+      if (stored >= maxChunksPerRepo() && (!known || known.count <= 0)) {
         capped = true;
         break;
       }
@@ -395,7 +395,7 @@ export async function reindexChangedPaths(
     let filesIndexed = 0;
     let capped = false;
     for (const path of indexable) {
-      if (stored >= MAX_CHUNKS_PER_REPO) {
+      if (stored >= maxChunksPerRepo()) {
         capped = true;
         break;
       }

--- a/src/review/rag.ts
+++ b/src/review/rag.ts
@@ -113,6 +113,18 @@ const CHUNK_OVERLAP = 1500;
  *  recurring one per cron cycle (#4365's blob-SHA skip-cache). Self-host only: this is not a Cloudflare
  *  free-tier constraint on this deployment, but the name/comment history predates self-host. */
 export const MAX_CHUNKS_PER_REPO = 4000;
+// Test-only override (#test-hotspots): the cap tests exist to pin capping BEHAVIOR, not the number
+// 4000 — building 4,000 real chunk rows per cap test made rag-index.test.ts one of the suite's
+// slowest files (~7s per cap test). Same `...ForTest` hook convention as
+// clearInstallationTokenCacheForTest / clearGitHubResponseCacheForTest; production call sites read
+// maxChunksPerRepo() and never touch the override.
+let maxChunksPerRepoOverride: number | null = null;
+export function maxChunksPerRepo(): number {
+  return maxChunksPerRepoOverride ?? MAX_CHUNKS_PER_REPO;
+}
+export function setMaxChunksPerRepoForTest(value: number | null): void {
+  maxChunksPerRepoOverride = value;
+}
 const EMBED_BATCH = 96; // Workers AI caps embedding input at 100 items/call; kept as a conservative general
 // bound — other embed providers (Ollama/vLLM/etc via the self-host adapter) may not share this exact cap.
 const MAX_CONTEXT_CHARS = 14000; // bound the injected block (mirrors diff/knowledge budgets)

--- a/test/unit/rag-index.test.ts
+++ b/test/unit/rag-index.test.ts
@@ -1,6 +1,15 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { indexRepo, reindexChangedPaths } from "../../src/review/rag-index";
-import { MAX_CHUNKS_PER_REPO, MAX_FILE_BYTES, RAG_DIMENSIONS, ragNamespace } from "../../src/review/rag";
+import { MAX_FILE_BYTES, RAG_DIMENSIONS, maxChunksPerRepo, ragNamespace, setMaxChunksPerRepoForTest } from "../../src/review/rag";
+
+// #test-hotspots: the cap tests pin capping BEHAVIOR, not the production constant (4000) — building
+// 4,000 real chunk rows per cap test made this file one of the suite's slowest (~7s per cap test).
+// The whole file runs with a small cap via setMaxChunksPerRepoForTest: cap tests hit it at 24 rows,
+// and no other fixture in this file indexes anywhere near 24 files, so their semantics are unchanged.
+// Keeps the production constant's NAME so every existing test body reads exactly as before.
+const MAX_CHUNKS_PER_REPO = 24;
+beforeEach(() => setMaxChunksPerRepoForTest(MAX_CHUNKS_PER_REPO));
+afterEach(() => setMaxChunksPerRepoForTest(null));
 import { processJob, splitRepoForRag } from "../../src/queue/processors";
 import { upsertRepositoryFromGitHub } from "../../src/db/repositories";
 import { upsertRepoFocusManifest } from "../../src/signals/focus-manifest-loader";
@@ -95,6 +104,13 @@ async function pathsFor(env: Env, project: string, repo: string): Promise<string
   const rows = await env.DB.prepare("SELECT path FROM repo_chunks WHERE project = ? AND repo = ? ORDER BY path").bind(project, repo).all<{ path: string }>();
   return [...new Set((rows.results ?? []).map((r) => r.path))];
 }
+
+describe("maxChunksPerRepo test override", () => {
+  it("falls back to the production cap (4000) when no override is armed", () => {
+    setMaxChunksPerRepoForTest(null);
+    expect(maxChunksPerRepo()).toBe(4000);
+  });
+});
 
 describe("rag-index migration: repo_chunks exists in the test D1", () => {
   it("the 0051 migration created repo_chunks (insert + read round-trips)", async () => {


### PR DESCRIPTION
# Summary

Follow-up to the TestD1Database template-clone fix: with schema replay gone, the suite's next-largest fixed cost is module **import** time (~505s aggregate per full run). Profiling found it concentrates in one place: the `github/client ↔ db/repositories` dependency cycle, which cost ~1.1s of cold import under vitest and taxed nearly every test file that touches the app — and it existed for trivially small reasons:

- `db/repositories` imported the whole `@loopover/engine` barrel (~420ms of the cycle) for exactly one tiny parser. → Engine gains a `./parse-pull-request-target-key` subpath export (additive; the barrel still exports it), and repositories imports the subpath.
- `gittensor/api` (imported by `db/repositories`) imported `github/client` for ONE constant, `PRODUCT_USER_AGENT`. → The constant moves to a new leaf module `src/github/user-agent.ts`; `client` imports and re-exports it, so its ~8 other importers are unchanged.
- `github/client` statically imported `db/repositories` for two call sites (`resolveRepoActionMode`'s freeze read; the suppressed-write audit hook). → Both become lazy `await import(...)` at the call site — the exact idiom `processors.ts` already uses — module-cached after first call.

Measured cold-import cost under vitest (same machine):

| module | before | after |
|---|---|---|
| `github/client` | 1,155ms | **37ms** |
| `gittensor/api` | 1,119ms | **11ms** |
| `db/repositories` | 1,106ms | **771ms** |
| `queue/processors` | 2,677ms | **1,978ms** |

`db/repositories`' remaining ~770ms is its own 8.3k lines + drizzle schema — reducible only by splitting the file itself (a #4013-style sequence of its own, deliberately out of scope here).

Behavior is unchanged: no cycle member had import-time side effects the other depended on, both lazy call sites are in already-async functions, and killing a real import cycle is a layering improvement in its own right.

Suite-level effect, measured with a back-to-back A/B on the identical tree (stash → baseline → pop → treatment, same machine conditions): aggregate import time **795s → 715s (−80s, −10%)**; wall time within noise on a loaded 10-core machine but the import saving concentrates in exactly the files CI's single `validate-tests` runner grinds through. The honest framing: this is a compounding follow-up to the template-clone fix (the big win), not a second 3× — plus it kills a real dependency cycle, which is worth having at any speed.

## Validation

- `npm run typecheck` clean; `npm run test:coverage` (full, unsharded): 21,473 passed / 0 failed on the treatment run (the baseline run of the same A/B had 2 unrelated pre-existing flakes).
- Both lazy-import lines execute under existing tests (`resolveRepoActionMode` across the actuation suites; the audit hook via github-app's dry-run suppressed-write tests).
