### PR TITLE
feat(engine): add the attestation-evidence envelope seam

### DIFF
--- a/packages/loopover-engine/src/calibration/attestation-envelope.ts
+++ b/packages/loopover-engine/src/calibration/attestation-envelope.ts
@@ -1,0 +1,165 @@
+// Attestation-evidence envelope (#8541) -- the typed seam the attested-evaluation epic needs BEFORE any TEE
+// infrastructure exists. A backtest run already persists `metadata.corpusChecksum` plus head/base SHAs
+// (services/threshold-backtest-run.ts), which is what makes a verdict third-party reproducible for a public
+// corpus. This module describes "that run executed inside an attested environment" as a shape, so the later
+// runner work attaches evidence to runs instead of inventing an ad-hoc object at the call site.
+//
+// Deliberately pure and infrastructure-free: structural validation ONLY. Cryptographically verifying an
+// attestation report (checking the TEE vendor's signature chain, measurement allow-lists, freshness) is
+// separate maintainer work in the parent epic -- doing any of it here would be unreviewable scope and would
+// bake a verification policy into what is meant to be a transport shape. Same purity contract as the rest of
+// this module family: no IO, no randomness, no wall-clock reads.
+
+import { createHash } from "node:crypto";
+
+/** TEE technologies this envelope can describe. */
+export type AttestationTeeTechnology = "sev-snp" | "tdx";
+
+/** Outcome of verifying the attestation report. `unverified` is the honest default: evidence was captured
+ *  but nothing has checked it yet -- distinct from `failed`, which records a verifier's negative verdict. */
+export type AttestationVerification =
+  | { status: "unverified" }
+  | { status: "verified"; verifierId: string; verifiedAt: string }
+  | { status: "failed"; verifierId: string; verifiedAt: string; reason: string };
+
+export type AttestationEnvelope = {
+  /** Literal 1 -- a future shape change bumps this rather than silently widening the current one. */
+  schemaVersion: 1;
+  teeTechnology: AttestationTeeTechnology;
+  /** Opaque label for the runtime image/class the workload ran as. Non-empty, <= 128 chars. */
+  runtimeClass: string;
+  /** Launch measurement, lowercase hex, 32-128 hex chars (widths differ per TEE technology). */
+  measurement: string;
+  /** sha256, lowercase hex, exactly 64 chars -- see {@link buildAttestationReportData} for the binding. */
+  reportData: string;
+  /** The raw attestation report, base64, non-empty and <= 65536 chars. Never parsed here. */
+  attestationReport: string;
+  verification: AttestationVerification;
+};
+
+const TEE_TECHNOLOGIES: readonly string[] = ["sev-snp", "tdx"];
+const RUNTIME_CLASS_MAX = 128;
+const MEASUREMENT_MIN_HEX = 32;
+const MEASUREMENT_MAX_HEX = 128;
+const REPORT_DATA_HEX = 64;
+const ATTESTATION_REPORT_MAX = 65536;
+const LOWERCASE_HEX = /^[0-9a-f]+$/;
+const ISO_DATETIME = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$/;
+const BASE64 = /^[A-Za-z0-9+/]+={0,2}$/;
+const ENVELOPE_KEYS: readonly string[] = [
+  "schemaVersion",
+  "teeTechnology",
+  "runtimeClass",
+  "measurement",
+  "reportData",
+  "attestationReport",
+  "verification",
+];
+const VERIFICATION_KEYS: Record<AttestationVerification["status"], readonly string[]> = {
+  unverified: ["status"],
+  verified: ["status", "verifierId", "verifiedAt"],
+  failed: ["status", "verifierId", "verifiedAt", "reason"],
+};
+
+/**
+ * The 32-byte payload a TEE binds into its attestation report, as lowercase hex: sha256 of
+ * `${corpusChecksum}:${headSha}:${baseSha}`. Binding all three is what makes the report prove WHICH
+ * evaluation ran (#8136) -- the corpus alone would not pin the code revision, and the SHAs alone would not
+ * pin the data. Mirrors backtest-split.ts's own `createHash("sha256")` usage; no new dependency.
+ */
+export function buildAttestationReportData(binding: { corpusChecksum: string; headSha: string; baseSha: string }): string {
+  return createHash("sha256").update(`${binding.corpusChecksum}:${binding.headSha}:${binding.baseSha}`).digest("hex");
+}
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function validateVerification(value: unknown, errors: string[]): void {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    errors.push("verification: expected an object");
+    return;
+  }
+  const record = value as Record<string, unknown>;
+  const status = record["status"];
+  if (status !== "unverified" && status !== "verified" && status !== "failed") {
+    errors.push('verification.status: expected "unverified", "verified", or "failed"');
+    return;
+  }
+  for (const key of Object.keys(record)) {
+    if (!VERIFICATION_KEYS[status].includes(key)) errors.push(`verification.${key}: unexpected key`);
+  }
+  if (status === "unverified") return;
+
+  if (!nonEmptyString(record["verifierId"])) errors.push("verification.verifierId: expected a non-empty string");
+  // Shape first: Date.parse alone accepts looser forms (a bare "2026-07-25" and other
+  // implementation-defined fallbacks), while the regex alone would accept "2026-13-45T99:99:99Z".
+  const verifiedAt = record["verifiedAt"];
+  if (!nonEmptyString(verifiedAt) || !ISO_DATETIME.test(verifiedAt) || Number.isNaN(Date.parse(verifiedAt))) {
+    errors.push("verification.verifiedAt: expected an ISO-8601 datetime string");
+  }
+  if (status === "failed" && !nonEmptyString(record["reason"])) {
+    errors.push("verification.reason: expected a non-empty string");
+  }
+}
+
+/**
+ * Structurally validate an unknown value as an {@link AttestationEnvelope}. Never throws for ANY input --
+ * `null`, primitives, arrays and objects with extra keys all return `{ valid: false }` with one error per
+ * failing field path, so a caller can log exactly what was wrong with a rejected envelope. Extra keys are
+ * rejected rather than ignored: this shape is persisted evidence, and silently dropping an unrecognized
+ * field would lose data a future schemaVersion may depend on.
+ */
+export function validateAttestationEnvelope(
+  value: unknown,
+): { valid: true; envelope: AttestationEnvelope } | { valid: false; errors: string[] } {
+  const errors: string[] = [];
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return { valid: false, errors: ["envelope: expected an object"] };
+  }
+  const record = value as Record<string, unknown>;
+
+  for (const key of Object.keys(record)) {
+    if (!ENVELOPE_KEYS.includes(key)) errors.push(`${key}: unexpected key`);
+  }
+
+  if (record["schemaVersion"] !== 1) errors.push("schemaVersion: expected the literal 1");
+
+  if (typeof record["teeTechnology"] !== "string" || !TEE_TECHNOLOGIES.includes(record["teeTechnology"])) {
+    errors.push('teeTechnology: expected "sev-snp" or "tdx"');
+  }
+
+  const runtimeClass = record["runtimeClass"];
+  if (!nonEmptyString(runtimeClass) || runtimeClass.length > RUNTIME_CLASS_MAX) {
+    errors.push(`runtimeClass: expected a non-empty string of at most ${RUNTIME_CLASS_MAX} characters`);
+  }
+
+  const measurement = record["measurement"];
+  if (
+    typeof measurement !== "string" ||
+    !LOWERCASE_HEX.test(measurement) ||
+    measurement.length < MEASUREMENT_MIN_HEX ||
+    measurement.length > MEASUREMENT_MAX_HEX
+  ) {
+    errors.push(`measurement: expected ${MEASUREMENT_MIN_HEX}-${MEASUREMENT_MAX_HEX} lowercase hex characters`);
+  }
+
+  const reportData = record["reportData"];
+  if (typeof reportData !== "string" || reportData.length !== REPORT_DATA_HEX || !LOWERCASE_HEX.test(reportData)) {
+    errors.push(`reportData: expected exactly ${REPORT_DATA_HEX} lowercase hex characters`);
+  }
+
+  const attestationReport = record["attestationReport"];
+  if (
+    !nonEmptyString(attestationReport) ||
+    attestationReport.length > ATTESTATION_REPORT_MAX ||
+    !BASE64.test(attestationReport)
+  ) {
+    errors.push(`attestationReport: expected non-empty base64 of at most ${ATTESTATION_REPORT_MAX} characters`);
+  }
+
+  validateVerification(record["verification"], errors);
+
+  if (errors.length > 0) return { valid: false, errors };
+  return { valid: true, envelope: record as AttestationEnvelope };
+}

--- a/packages/loopover-engine/src/index.ts
+++ b/packages/loopover-engine/src/index.ts
@@ -181,6 +181,7 @@ export * from "./calibration/backtest-split.js";
 export * from "./calibration/backtest-threshold.js";
 export * from "./calibration/provider-track-record.js";
 export * from "./calibration/reliability-curve.js";
+export * from "./calibration/attestation-envelope.js";
 export {
   GOVERNOR_LEDGER_EVENT_TYPES,
   normalizeGovernorLedgerEvent,

--- a/packages/loopover-engine/test/attestation-envelope.test.ts
+++ b/packages/loopover-engine/test/attestation-envelope.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { buildAttestationReportData, validateAttestationEnvelope } from "../dist/index.js";
+
+const BASE = {
+  schemaVersion: 1,
+  teeTechnology: "sev-snp",
+  runtimeClass: "loopover-backtest-runner",
+  measurement: "a".repeat(64),
+  reportData: "b".repeat(64),
+  attestationReport: "QUJD",
+  verification: { status: "unverified" },
+};
+
+test("barrel: the public entrypoint re-exports the attestation-envelope primitives (#8541)", () => {
+  assert.equal(typeof buildAttestationReportData, "function");
+  assert.equal(typeof validateAttestationEnvelope, "function");
+});
+
+test("buildAttestationReportData pins the corpusChecksum:headSha:baseSha binding (#8541)", () => {
+  assert.equal(
+    buildAttestationReportData({ corpusChecksum: "abc123", headSha: "head456", baseSha: "base789" }),
+    "fcc875115df49bf143b18fc8a8071e9a946858407fabf61e59ef1607d1cfb140",
+  );
+});
+
+test("validateAttestationEnvelope accepts a well-formed envelope and each verification variant (#8541)", () => {
+  assert.equal(validateAttestationEnvelope(BASE).valid, true);
+  assert.equal(
+    validateAttestationEnvelope({ ...BASE, verification: { status: "verified", verifierId: "v1", verifiedAt: "2026-07-25T00:00:00.000Z" } }).valid,
+    true,
+  );
+  assert.equal(
+    validateAttestationEnvelope({
+      ...BASE,
+      verification: { status: "failed", verifierId: "v1", verifiedAt: "2026-07-25T00:00:00.000Z", reason: "signature mismatch" },
+    }).valid,
+    true,
+  );
+});
+
+test("validateAttestationEnvelope rejects structurally invalid input without throwing (#8541)", () => {
+  for (const bad of [null, undefined, 42, "envelope", [], { ...BASE, schemaVersion: 2 }, { ...BASE, reportData: "b".repeat(63) }, { ...BASE, rogue: 1 }]) {
+    const result = validateAttestationEnvelope(bad);
+    assert.equal(result.valid, false);
+    assert.ok(Array.isArray(result.errors) && result.errors.length > 0);
+  }
+});

--- a/test/unit/attestation-envelope-engine.test.ts
+++ b/test/unit/attestation-envelope-engine.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest";
+
+// Direct src-path import (not the `@loopover/engine` barrel, which resolves to dist and is NOT in vitest's
+// coverage.include): the engine's own node:test suite runs against dist and is invisible to Codecov, so this
+// vitest mirror is what gives the module its codecov/patch coverage -- the same seam #8438 used for
+// signal-tracking.ts. The companion packages/loopover-engine/test/attestation-envelope.test.ts gates the
+// engine workspace's own `npm run test` against the built barrel.
+import {
+  buildAttestationReportData,
+  validateAttestationEnvelope,
+  type AttestationEnvelope,
+} from "../../packages/loopover-engine/src/calibration/attestation-envelope.js";
+
+const MEASUREMENT = "a".repeat(64);
+const REPORT_DATA = "b".repeat(64);
+
+function envelope(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    schemaVersion: 1,
+    teeTechnology: "sev-snp",
+    runtimeClass: "loopover-backtest-runner",
+    measurement: MEASUREMENT,
+    reportData: REPORT_DATA,
+    attestationReport: "QUJD",
+    verification: { status: "unverified" },
+    ...overrides,
+  };
+}
+
+/** Assert rejection AND that the error names the failing field path (the contract callers log). */
+function expectRejected(value: unknown, fieldPath: string): string[] {
+  const result = validateAttestationEnvelope(value);
+  expect(result.valid).toBe(false);
+  if (result.valid) throw new Error("expected invalid");
+  expect(result.errors.some((error) => error.startsWith(fieldPath))).toBe(true);
+  return result.errors;
+}
+
+describe("buildAttestationReportData (#8541)", () => {
+  it("is the lowercase-hex sha256 of corpusChecksum:headSha:baseSha (pinned vector)", () => {
+    // Precomputed: sha256("abc123:head456:base789"). Pinned so a change to the binding format -- which would
+    // silently invalidate every previously-attested run -- fails here instead of shipping.
+    expect(buildAttestationReportData({ corpusChecksum: "abc123", headSha: "head456", baseSha: "base789" })).toBe(
+      "fcc875115df49bf143b18fc8a8071e9a946858407fabf61e59ef1607d1cfb140",
+    );
+  });
+
+  it("produces exactly 64 lowercase hex chars and is deterministic and field-order sensitive", () => {
+    const data = buildAttestationReportData({ corpusChecksum: "c", headSha: "h", baseSha: "b" });
+    expect(data).toMatch(/^[0-9a-f]{64}$/);
+    expect(data).toBe(buildAttestationReportData({ corpusChecksum: "c", headSha: "h", baseSha: "b" }));
+    // Swapping which value lands in which position must change the digest (the fields are not interchangeable).
+    expect(data).not.toBe(buildAttestationReportData({ corpusChecksum: "h", headSha: "c", baseSha: "b" }));
+  });
+
+  it("emits output usable as an envelope's reportData", () => {
+    const reportData = buildAttestationReportData({ corpusChecksum: "c", headSha: "h", baseSha: "b" });
+    expect(validateAttestationEnvelope(envelope({ reportData })).valid).toBe(true);
+  });
+});
+
+describe("validateAttestationEnvelope (#8541)", () => {
+  it("accepts a well-formed envelope and returns it narrowed", () => {
+    const result = validateAttestationEnvelope(envelope());
+    expect(result.valid).toBe(true);
+    if (!result.valid) throw new Error(result.errors.join("; "));
+    const narrowed: AttestationEnvelope = result.envelope;
+    expect(narrowed.schemaVersion).toBe(1);
+    expect(narrowed.verification.status).toBe("unverified");
+  });
+
+  it("never throws for non-object input, returning a single envelope-level error", () => {
+    for (const value of [null, undefined, 0, 1, "", "envelope", true, false, [], [envelope()], Symbol("x"), 9n]) {
+      const result = validateAttestationEnvelope(value);
+      expect(result.valid).toBe(false);
+      if (result.valid) throw new Error("expected invalid");
+      expect(result.errors).toEqual(["envelope: expected an object"]);
+    }
+  });
+
+  it("rejects an unexpected top-level key by name", () => {
+    const errors = expectRejected(envelope({ rogue: 1 }), "rogue");
+    expect(errors.some((error) => error.includes("unexpected key"))).toBe(true);
+  });
+
+  it("requires the literal schemaVersion 1 (both arms)", () => {
+    expect(validateAttestationEnvelope(envelope({ schemaVersion: 1 })).valid).toBe(true);
+    for (const bad of [0, 2, "1", null, undefined]) expectRejected(envelope({ schemaVersion: bad }), "schemaVersion");
+  });
+
+  it("accepts each supported teeTechnology and rejects anything else", () => {
+    for (const good of ["sev-snp", "tdx"]) expect(validateAttestationEnvelope(envelope({ teeTechnology: good })).valid).toBe(true);
+    for (const bad of ["SEV-SNP", "sgx", "", 1, null]) expectRejected(envelope({ teeTechnology: bad }), "teeTechnology");
+  });
+
+  it("bounds runtimeClass at 1..128 characters (accepts the boundary, rejects just past it)", () => {
+    expect(validateAttestationEnvelope(envelope({ runtimeClass: "x" })).valid).toBe(true);
+    expect(validateAttestationEnvelope(envelope({ runtimeClass: "x".repeat(128) })).valid).toBe(true);
+    expectRejected(envelope({ runtimeClass: "x".repeat(129) }), "runtimeClass");
+    for (const bad of ["", 1, null, undefined]) expectRejected(envelope({ runtimeClass: bad }), "runtimeClass");
+  });
+
+  it("requires measurement to be 32..128 lowercase hex (boundaries accepted, just-past rejected)", () => {
+    expect(validateAttestationEnvelope(envelope({ measurement: "a".repeat(32) })).valid).toBe(true);
+    expect(validateAttestationEnvelope(envelope({ measurement: "a".repeat(128) })).valid).toBe(true);
+    expectRejected(envelope({ measurement: "a".repeat(31) }), "measurement");
+    expectRejected(envelope({ measurement: "a".repeat(129) }), "measurement");
+    expectRejected(envelope({ measurement: "A".repeat(64) }), "measurement"); // uppercase hex
+    expectRejected(envelope({ measurement: "g".repeat(64) }), "measurement"); // non-hex
+    expectRejected(envelope({ measurement: 64 }), "measurement");
+  });
+
+  it("requires reportData to be exactly 64 lowercase hex (63 and 65 both rejected)", () => {
+    expect(validateAttestationEnvelope(envelope({ reportData: "b".repeat(64) })).valid).toBe(true);
+    expectRejected(envelope({ reportData: "b".repeat(63) }), "reportData");
+    expectRejected(envelope({ reportData: "b".repeat(65) }), "reportData");
+    expectRejected(envelope({ reportData: "B".repeat(64) }), "reportData"); // uppercase
+    expectRejected(envelope({ reportData: "z".repeat(64) }), "reportData"); // non-hex
+    expectRejected(envelope({ reportData: null }), "reportData");
+  });
+
+  it("requires attestationReport to be non-empty base64 within the size cap", () => {
+    expect(validateAttestationEnvelope(envelope({ attestationReport: "QUJD" })).valid).toBe(true);
+    expect(validateAttestationEnvelope(envelope({ attestationReport: "QQ==" })).valid).toBe(true);
+    expect(validateAttestationEnvelope(envelope({ attestationReport: "A".repeat(65536) })).valid).toBe(true);
+    expectRejected(envelope({ attestationReport: "A".repeat(65537) }), "attestationReport");
+    expectRejected(envelope({ attestationReport: "" }), "attestationReport");
+    expectRejected(envelope({ attestationReport: "not base64!" }), "attestationReport");
+    expectRejected(envelope({ attestationReport: 1 }), "attestationReport");
+  });
+
+  describe("verification union", () => {
+    const VERIFIED_AT = "2026-07-25T00:00:00.000Z";
+
+    it("accepts every valid variant", () => {
+      expect(validateAttestationEnvelope(envelope({ verification: { status: "unverified" } })).valid).toBe(true);
+      expect(
+        validateAttestationEnvelope(envelope({ verification: { status: "verified", verifierId: "v1", verifiedAt: VERIFIED_AT } })).valid,
+      ).toBe(true);
+      expect(
+        validateAttestationEnvelope(
+          envelope({ verification: { status: "failed", verifierId: "v1", verifiedAt: VERIFIED_AT, reason: "signature mismatch" } }),
+        ).valid,
+      ).toBe(true);
+    });
+
+    it("rejects a non-object or unknown status", () => {
+      for (const bad of [null, "unverified", 1, []]) expectRejected(envelope({ verification: bad }), "verification");
+      expectRejected(envelope({ verification: { status: "pending" } }), "verification.status");
+    });
+
+    it("rejects a missing or invalid member of the verified variant", () => {
+      expectRejected(envelope({ verification: { status: "verified", verifiedAt: VERIFIED_AT } }), "verification.verifierId");
+      expectRejected(envelope({ verification: { status: "verified", verifierId: "", verifiedAt: VERIFIED_AT } }), "verification.verifierId");
+      expectRejected(envelope({ verification: { status: "verified", verifierId: "v1" } }), "verification.verifiedAt");
+      expectRejected(envelope({ verification: { status: "verified", verifierId: "v1", verifiedAt: "not-a-date" } }), "verification.verifiedAt");
+      // Date.parse alone tolerates this; the shape check is what rejects it.
+      expectRejected(envelope({ verification: { status: "verified", verifierId: "v1", verifiedAt: "2026-07-25" } }), "verification.verifiedAt");
+      // Matches the ISO shape but is not a real instant -- covers the Date.parse operand specifically.
+      expectRejected(envelope({ verification: { status: "verified", verifierId: "v1", verifiedAt: "2026-13-45T99:99:99Z" } }), "verification.verifiedAt");
+    });
+
+    it("rejects a missing or empty reason on the failed variant, and extra keys on any variant", () => {
+      expectRejected(envelope({ verification: { status: "failed", verifierId: "v1", verifiedAt: VERIFIED_AT } }), "verification.reason");
+      expectRejected(
+        envelope({ verification: { status: "failed", verifierId: "v1", verifiedAt: VERIFIED_AT, reason: "" } }),
+        "verification.reason",
+      );
+      // unverified carries no other members -- an extra key is named, not ignored.
+      expectRejected(envelope({ verification: { status: "unverified", verifierId: "v1" } }), "verification.verifierId");
+    });
+  });
+
+  it("reports every failing field at once rather than stopping at the first", () => {
+    const errors = expectRejected(
+      { schemaVersion: 2, teeTechnology: "sgx", runtimeClass: "", measurement: "zz", reportData: "b", attestationReport: "", verification: null },
+      "schemaVersion",
+    );
+    for (const field of ["teeTechnology", "runtimeClass", "measurement", "reportData", "attestationReport", "verification"]) {
+      expect(errors.some((error) => error.startsWith(field))).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds the typed evidence seam the attested-evaluation epic needs **before any TEE infrastructure exists**, so the later runner work attaches evidence to backtest runs instead of inventing an ad-hoc object at the call site.

New file `packages/loopover-engine/src/calibration/attestation-envelope.ts` exporting exactly three things:

- **`AttestationEnvelope`** — `schemaVersion: 1` (literal), `teeTechnology: "sev-snp" | "tdx"`, `runtimeClass` (non-empty, ≤128), `measurement` (lowercase hex, 32–128), `reportData` (lowercase hex, exactly 64), `attestationReport` (base64, non-empty, ≤65536), and a discriminated `verification` union (`unverified` / `verified` / `failed`).
- **`buildAttestationReportData(binding)`** — lowercase-hex sha256 of `` `${corpusChecksum}:${headSha}:${baseSha}` `` via `node:crypto`, mirroring `backtest-split.ts`'s existing `createHash` usage. No new dependency.
- **`validateAttestationEnvelope(value)`** — structural validation returning `{ valid: true, envelope }` or `{ valid: false, errors }`, naming each failing field path. **Never throws for any input** — `null`, primitives, arrays, `Symbol`, `BigInt`, and objects with extra keys all return a result. Extra keys are *rejected by name* rather than ignored, since this is persisted evidence and silently dropping an unrecognized field would lose data a future `schemaVersion` may depend on.

Plus one barrel line in `packages/loopover-engine/src/index.ts`, matching the existing calibration exports.

**Scope held exactly to the issue's boundary:** structural validation only — no cryptographic verification of the attestation report, no `src/**` wiring, no new dependencies, and no changes to any existing calibration module. Verifying a TEE vendor's signature chain / measurement allow-list / report freshness is later maintainer work in the parent epic; implementing any of it here would bake a verification policy into what is meant to be a transport shape.

## Coverage

**100% of the new module — lines, statements, functions, and branches** (vitest `json-summary`, the authoritative reporter):

| metric | result |
| --- | --- |
| lines | **100%** (54/54) |
| statements | **100%** (60/60) |
| functions | **100%** (4/4) |
| branches | **100%** (62/62) |

Every rule is exercised on **both** arms as the issue requires — accept at the boundary, reject just past it: `runtimeClass` 128 vs 129; `measurement` 32/128 vs 31/129, plus uppercase-hex and non-hex; `reportData` 64 vs 63/65; `attestationReport` at the 65536 cap vs 65537, empty, and non-base64; each `verification` variant valid, and each with a missing/empty/invalid member; a valid envelope plus an extra key. `buildAttestationReportData` is pinned against a precomputed vector (`sha256("abc123:head456:base789")`) so a change to the binding format — which would silently invalidate every previously-attested run — fails here rather than shipping.

Coverage is **Codecov-visible** via the root-vitest mirror (`test/unit/attestation-envelope-engine.test.ts`) importing the engine **source** path directly — the same seam #8438 used for `signal-tracking.ts`, since the engine's own `node:test` suite runs against `dist/` and is invisible to Codecov. The companion `packages/loopover-engine/test/attestation-envelope.test.ts` gates the engine workspace's own `npm run test` against the built barrel.

Closes #8541

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- One new engine module + one barrel line + two test files. No workflow, MCP, UI, worker, or dependency surface is touched, so `actionlint`, `build:mcp`/`test:mcp-pack`, `ui:*`, `test:workers`, and `npm audit` are not exercised by it.
- Verified locally: root `tsc --noEmit` clean, engine `tsc -p packages/loopover-engine/tsconfig.json` clean, the root vitest mirror passes (17 tests), the engine `node --test` twin passes (4 tests) against a fresh `npm run build --workspace @loopover/engine`, and `git diff --check` is clean.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — a pure engine module and its tests; no visible UI, frontend, docs, or extension change.

## Notes

- `verifiedAt` is validated by shape **and** parseability: `Date.parse` alone accepts a bare `"2026-07-25"` and other implementation-defined forms, while the ISO regex alone would accept `"2026-13-45T99:99:99Z"`. Both operands are covered by tests.
- The envelope is a transport shape only: nothing in this PR reads, writes, or persists it, so there is no behavior change to any existing run.
