### PR TITLE
feat(miner): capture bounded candidate context in eligibility-exclusion fired events

### DIFF
--- a/packages/loopover-miner/lib/discover-cli.ts
+++ b/packages/loopover-miner/lib/discover-cli.ts
@@ -298,8 +298,83 @@ function initDefaultSignalTrackingStore(): SignalStore {
 // runDiscover's real-run branch (own try/catch, degrade silently). Deliberately NOT called from the dry-run
 // branch: a dry run previews what a real run would do (including its own noopQueueStore for the portfolio
 // queue) and must not itself contribute real data to a precision report.
+// #8544: bounded candidate-context capture, mirroring the ORB precedent (#8129/#8130). Caps exist so a
+// pathological repo (hundreds of labels, or a label crafted to be enormous) can't grow the local event
+// ledger without limit; `truncated` records THAT clamping happened so a later backtest knows the stored
+// context is partial rather than treating it as the full picture.
+const MAX_CAPTURED_LABELS = 50;
+const MAX_CAPTURED_ASSIGNEES = 25;
+const MAX_CAPTURED_STRING_CHARS = 200;
+
+type CapturedCandidateContext = {
+  labels?: string[];
+  assignees?: string[];
+  owner?: string;
+  truncated?: true;
+};
+
+/** #8544: clamp one string list to `max` entries and each entry to {@link MAX_CAPTURED_STRING_CHARS},
+ *  reporting whether either clamp actually fired. */
+function boundStringList(values: readonly string[], max: number): { values: string[]; truncated: boolean } {
+  const listTruncated = values.length > max;
+  const kept = listTruncated ? values.slice(0, max) : values;
+  let stringTruncated = false;
+  const bounded = kept.map((value) => {
+    if (value.length <= MAX_CAPTURED_STRING_CHARS) return value;
+    stringTruncated = true;
+    return value.slice(0, MAX_CAPTURED_STRING_CHARS);
+  });
+  return { values: bounded, truncated: listTruncated || stringTruncated };
+}
+
+/** #8544: build the bounded `metadata` for one excluded candidate. Absent source fields are OMITTED entirely
+ *  — no nulls and no empty-array placeholders, so "we captured nothing here" stays distinguishable from
+ *  "this candidate genuinely had no labels". Returns undefined when the candidate carries no context at all,
+ *  so pre-#8544 event shapes are reproduced byte-identically rather than gaining an empty object. */
+function buildCandidateContextMetadata(candidate: {
+  labels?: string[] | undefined;
+  assignees?: string[] | undefined;
+  owner?: string | undefined;
+}): CapturedCandidateContext | undefined {
+  const metadata: CapturedCandidateContext = {};
+  let truncated = false;
+
+  if (candidate.labels !== undefined) {
+    const bounded = boundStringList(candidate.labels, MAX_CAPTURED_LABELS);
+    metadata.labels = bounded.values;
+    truncated ||= bounded.truncated;
+  }
+  if (candidate.assignees !== undefined) {
+    const bounded = boundStringList(candidate.assignees, MAX_CAPTURED_ASSIGNEES);
+    metadata.assignees = bounded.values;
+    truncated ||= bounded.truncated;
+  }
+  if (candidate.owner !== undefined) {
+    // Clamped directly rather than through boundStringList: a single value has no list-length arm, and
+    // routing it through the array helper left an unreachable `?? ""` fallback.
+    const clamped = candidate.owner.slice(0, MAX_CAPTURED_STRING_CHARS);
+    if (clamped.length < candidate.owner.length) truncated = true;
+    metadata.owner = clamped;
+  }
+
+  if (Object.keys(metadata).length === 0) return undefined;
+  if (truncated) metadata.truncated = true;
+  return metadata;
+}
+
 async function recordEligibilityExclusionSignals(
-  excluded: ReadonlyArray<{ candidate: { repoFullName: string; issueNumber: number }; reason: string }>,
+  excluded: ReadonlyArray<{
+    candidate: {
+      repoFullName: string;
+      issueNumber: number;
+      // #8544: already present at runtime via EligibilityExclusion<T>'s generic passthrough (see
+      // FilterCandidate) — read straight through, no new computation at the call site.
+      labels?: string[] | undefined;
+      assignees?: string[] | undefined;
+      owner?: string | undefined;
+    };
+    reason: string;
+  }>,
   options: Pick<RunDiscoverOptions, "initSignalTrackingStore" | "nowMs">,
 ): Promise<void> {
   if (excluded.length === 0) return;
@@ -312,12 +387,15 @@ async function recordEligibilityExclusionSignals(
   if (!store) return;
   const occurredAt = new Date(options.nowMs ?? Date.now()).toISOString();
   for (const entry of excluded) {
+    const metadata = buildCandidateContextMetadata(entry.candidate);
     await store
       .recordRuleFired({
         ruleId: entry.reason,
         targetKey: `${entry.candidate.repoFullName}#issue-${entry.candidate.issueNumber}`,
         outcome: "exclude",
         occurredAt,
+        // Spread-or-omit: a candidate with no context keeps the exact pre-#8544 event shape.
+        ...(metadata ? { metadata } : {}),
       })
       .catch(() => undefined);
   }

--- a/test/unit/miner-discover-cli.test.ts
+++ b/test/unit/miner-discover-cli.test.ts
@@ -1643,12 +1643,18 @@ describe("runDiscover onResult hook (#6522)", () => {
     });
 
     describe("eligibility-exclusion signal tracking (#7982)", () => {
+      // #8544: `captured` keeps the full event (metadata included); `fired` stays the pre-#8544 projection so
+      // every existing assertion in this block is untouched.
+      const captured: Array<Record<string, unknown>> = [];
       function fakeSignalStore() {
         const fired: Array<{ ruleId: string; targetKey: string; outcome: string }> = [];
+        captured.length = 0;
         return {
           fired,
+          captured,
           store: {
             recordRuleFired: vi.fn(async (event: { ruleId: string; targetKey: string; outcome: string }) => {
+              captured.push({ ...event });
               fired.push({ ruleId: event.ruleId, targetKey: event.targetKey, outcome: event.outcome });
             }),
             recordHumanOverride: vi.fn(async () => undefined),
@@ -1672,6 +1678,82 @@ describe("runDiscover onResult hook (#6522)", () => {
           { ruleId: "exclusion_label", targetKey: "acme/widgets#issue-2", outcome: "exclude" },
           { ruleId: "missing_eligibility_label", targetKey: "acme/widgets#issue-3", outcome: "exclude" },
         ]);
+      });
+
+      // #8544: bounded candidate-context metadata on the same fired events.
+      describe("bounded candidate context (#8544)", () => {
+        const runExcluded = async (issueOverrides: Record<string, unknown>) => {
+          const issues = [fanOutIssue({ issueNumber: 2, ...issueOverrides })];
+          const { opts } = discoverWith(issues, new Map([["acme/widgets", trustworthyProfile]]));
+          const { captured, store } = fakeSignalStore();
+          vi.spyOn(console, "log").mockImplementation(() => undefined);
+          await runDiscover(["acme/widgets", "--json"], { ...opts, initSignalTrackingStore: () => store });
+          return captured[0] as { metadata?: Record<string, unknown> } | undefined;
+        };
+
+        it("captures labels, assignees and owner when all three are present", async () => {
+          const event = await runExcluded({ labels: ["blocked"], assignees: ["octocat"], owner: "acme" });
+          expect(event?.metadata).toEqual({ labels: ["blocked"], assignees: ["octocat"], owner: "acme" });
+          expect(event?.metadata).not.toHaveProperty("truncated");
+        });
+
+        it("omits each field that is absent from the candidate rather than storing null or []", async () => {
+          const event = await runExcluded({ labels: ["blocked"], assignees: undefined, owner: undefined });
+          expect(event?.metadata).toEqual({ labels: ["blocked"] });
+          expect(event?.metadata).not.toHaveProperty("assignees");
+          expect(event?.metadata).not.toHaveProperty("owner");
+        });
+
+        it("keeps an empty array distinguishable from an absent field", async () => {
+          const event = await runExcluded({ labels: ["blocked"], assignees: [] });
+          expect((event?.metadata as { assignees?: string[] })?.assignees).toEqual([]);
+        });
+
+        it("labels exactly at the 50 cap are kept whole with no truncated flag", async () => {
+          const labels = ["blocked", ...Array.from({ length: 49 }, (_, i) => `l${i}`)];
+          const event = await runExcluded({ labels });
+          expect((event?.metadata as { labels: string[] }).labels).toHaveLength(50);
+          expect(event?.metadata).not.toHaveProperty("truncated");
+        });
+
+        it("labels one over the cap are clamped to 50 and flagged truncated", async () => {
+          const labels = ["blocked", ...Array.from({ length: 50 }, (_, i) => `l${i}`)];
+          const event = await runExcluded({ labels });
+          expect((event?.metadata as { labels: string[] }).labels).toHaveLength(50);
+          expect(event?.metadata).toHaveProperty("truncated", true);
+        });
+
+        it("assignees exactly at the 25 cap are kept whole; one over is clamped and flagged", async () => {
+          const atCap = await runExcluded({ labels: ["blocked"], assignees: Array.from({ length: 25 }, (_, i) => `u${i}`) });
+          expect((atCap?.metadata as { assignees: string[] }).assignees).toHaveLength(25);
+          expect(atCap?.metadata).not.toHaveProperty("truncated");
+
+          const overCap = await runExcluded({ labels: ["blocked"], assignees: Array.from({ length: 26 }, (_, i) => `u${i}`) });
+          expect((overCap?.metadata as { assignees: string[] }).assignees).toHaveLength(25);
+          expect(overCap?.metadata).toHaveProperty("truncated", true);
+        });
+
+        it("a string exactly at the 200-char cap is kept whole; one char over is clamped and flagged", async () => {
+          const atCap = await runExcluded({ labels: ["blocked", "x".repeat(200)] });
+          expect((atCap?.metadata as { labels: string[] }).labels[1]).toHaveLength(200);
+          expect(atCap?.metadata).not.toHaveProperty("truncated");
+
+          const overCap = await runExcluded({ labels: ["blocked", "x".repeat(201)] });
+          expect((overCap?.metadata as { labels: string[] }).labels[1]).toHaveLength(200);
+          expect(overCap?.metadata).toHaveProperty("truncated", true);
+        });
+
+        it("omits metadata entirely when the candidate carries no context at all (pre-#8544 event shape)", async () => {
+          const event = await runExcluded({ labels: undefined, assignees: undefined, owner: undefined });
+          expect(event).toBeDefined();
+          expect(event).not.toHaveProperty("metadata");
+        });
+
+        it("clamps an over-long owner string and flags it", async () => {
+          const event = await runExcluded({ labels: ["blocked"], owner: "o".repeat(201) });
+          expect((event?.metadata as { owner: string }).owner).toHaveLength(200);
+          expect(event?.metadata).toHaveProperty("truncated", true);
+        });
       });
 
       it("records nothing when nothing was excluded", async () => {


### PR DESCRIPTION
Fixes #8544

## Root cause

`recordEligibilityExclusionSignals` (`discover-cli.ts`) recorded only `ruleId`/`targetKey`/`outcome`, so a fired event preserved *that* a candidate was excluded but nothing about *what it looked like*. The `labels`/`assignees`/`owner` fields are already present at runtime on the filter's excluded entries via `EligibilityExclusion<T>`'s generic passthrough — they were simply dropped.

## Fix approach

Widened the parameter type so each entry's `candidate` carries the optional fields, and passed them straight through — no new computation at the call site, and `contribution-profile-filter.ts` is untouched as the issue requires.

`buildCandidateContextMetadata` applies the exact caps: **50** labels, **25** assignees, **200** characters per string. `truncated: true` is added only when a cap actually fires, and is omitted otherwise.

Two deliberate details:

- **Absent fields are omitted entirely** — no `null`s, no empty-array placeholders. So "we captured nothing here" stays distinguishable from "this candidate genuinely had no labels". An explicitly empty array is preserved as `[]`, which is different information, and there's a test pinning that distinction.
- **A candidate with no context at all produces no `metadata` key**, reproducing the pre-change event shape byte-for-byte rather than emitting an empty object.

Dry-run capture and the best-effort discipline (swallowed store-init and per-write failures) are unchanged — metadata construction is pure and adds no new failure path.

## Coverage

Both arms of every cap, as specified: labels at 50 vs 51, assignees at 25 vs 26, string at 200 vs 201 chars, plus an over-long `owner`, presence/omission of each field, the empty-vs-absent distinction, and the no-context path.

**Zero uncovered lines and zero uncovered branches** across the diff. While verifying that I found one of my own dead branches — routing the single `owner` value through the list helper left an unreachable `?? ""` fallback — so I clamped it directly instead of writing a test for an impossible path.

## Two things worth the reviewer's attention

**1. `codecov/patch` will likely report `0.00%` here, and it is not a real coverage gap.** CI's `validate-tests` job runs `Build miner CLI` before `Test with coverage`, so `lib/*.js` exists and every root test imports the `.js` specifier — v8 attributes coverage to the built `.js` while this diff is on the `.ts`. Measured locally against the `.ts` (with the compiled output removed, reproducing CI's `.js`→`.ts` resolution), the patch is fully covered. This is the same attribution defect described by #8346/#8347/#8348. I applied the `#8479` root-vitest mirror precedent the issue points to — these tests already live in root `test/unit/` — but that remedy fixes *engine* modules, which build to a separate `dist/`; the miner compiles `.ts`→`.js` in place, so source and artifact share a path and no contributor-side import can separate them.

**2. Local suite note.** `test/unit/miner-discover-cli.test.ts` has 2 failures on my Windows checkout (`discover --help` and the usage-error exit) — both subprocess-spawn CLI tests. The count is **identical on unmodified `ec6f6e6f`**, verified by stashing this change and re-running, so they aren't introduced here. My 9 added tests pass; the file goes 70 → 79 passing.

## Validation

- 9/9 new tests pass; full file 79 passed / 2 pre-existing failures
- `npm run typecheck` clean; `oxlint` clean on all changed lines
- `git diff --check upstream/main HEAD` clean; branch cut from current `main` (`ec6f6e6f`)
