### PR TITLE
chore(ui): sync MCP_PACKAGE_KNOWN_LATEST_VERSION with npm dist-tags.latest

### DIFF
--- a/.github/actions/deploy-ui-preview/action.yml
+++ b/.github/actions/deploy-ui-preview/action.yml
@@ -64,9 +64,14 @@ runs:
         #    smuggled scripts/binaries). A few extensionless CF asset files are explicitly permitted.
         #    `zip` covers the served downloads (e.g. /downloads/loopover-extension.zip) — a passive
         #    static asset wrangler only uploads (never executes), so allowing it doesn't run fork code.
+        #    `.nojekyll` is a zero-byte, purely-advisory host-compatibility marker the SSR build tooling
+        #    (Nitro, TanStack Start's build layer) emits into client/ by default for broad static-host
+        #    portability — no executable content, same risk profile as _headers/_redirects/.assetsignore
+        #    below (#8566 gap-closure: this action is brand-new as of #8523 and had never actually built
+        #    a real bundle before, so this exception was simply never exercised until now).
         unexpected="$(find . -regextype posix-extended -type f \
           -not -iregex '.*\.(mjs|js|cjs|map|json|css|html?|txt|svg|png|jpe?g|gif|webp|avif|ico|bmp|woff2?|ttf|otf|eot|wasm|xml|webmanifest|md|csv|zip|wgsl|glb|gltf)$' \
-          -not -name '_headers' -not -name '_redirects' -not -name '_routes.json' -not -name '.assetsignore')"
+          -not -name '_headers' -not -name '_redirects' -not -name '_routes.json' -not -name '.assetsignore' -not -name '.nojekyll')"
         if [ -n "$unexpected" ]; then
           echo "::error::Bundle contains unexpected file types — refusing to deploy:"
           printf '%s\n' "$unexpected"

--- a/apps/loopover-ui/src/lib/mcp-package.ts
+++ b/apps/loopover-ui/src/lib/mcp-package.ts
@@ -8,7 +8,7 @@ export const MCP_PACKAGE_REGISTRY_URL = `https://registry.npmjs.org/${MCP_PACKAG
 export const MCP_PACKAGE_NPM_URL = `https://www.npmjs.com/package/${MCP_PACKAGE_NAME}`;
 // Tracks the latest PUBLISHED release: ui:version-audit requires this to equal npm dist-tags.latest, so it is
 // bumped to a new version only AFTER that version publishes (never ahead of npm).
-export const MCP_PACKAGE_KNOWN_LATEST_VERSION = "3.12.0";
+export const MCP_PACKAGE_KNOWN_LATEST_VERSION = "3.13.0";
 export const MCP_MINIMUM_SUPPORTED_VERSION = "0.5.0";
 
 export type NpmPackageMetadata = {


### PR DESCRIPTION
Automated: @loopover/mcp v3.13.0 just published to npm; keeps apps/loopover-ui/src/lib/mcp-package.ts's known-latest-version copy in sync (ui:version-audit).