### PR TITLE
feat(miner): record feasibility-verdict reasons as rule-fired signals on the infeasible path

### DIFF
--- a/packages/loopover-miner/lib/attempt-cli.ts
+++ b/packages/loopover-miner/lib/attempt-cli.ts
@@ -20,7 +20,7 @@ import {
   resolveCodingAgentModeFromConfig,
   resolveFirstConfiguredCodingAgentDriverName,
 } from "@loopover/engine";
-import type { AttemptDbFork, AttemptDbForkConfig, CodingAgentExecutionMode, FeasibilityVerdict, LocalWriteActionSpec } from "@loopover/engine";
+import type { AttemptDbFork, AttemptDbForkConfig, CodingAgentExecutionMode, FeasibilityVerdict, LocalWriteActionSpec, SignalStore } from "@loopover/engine";
 import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
 import { resolveAttemptDbForkConfig } from "./attempt-db-fork-config.js";
 import { constructProductionCodingAgentDriver } from "./coding-agent-construction.js";
@@ -33,8 +33,9 @@ import { resolveMinerGoalSpec } from "./miner-goal-spec.js";
 import { resolveClaimConflict } from "./claim-conflict-resolver.js";
 import type { ClaimConflictResult, resolveClaimConflict as ResolveClaimConflictFn } from "./claim-conflict-resolver.js";
 import { parsePrNumberFromExecResult } from "./pr-number-parse.js";
-import { initEventLedger } from "./event-ledger.js";
+import { appendEvent, initEventLedger, readEvents } from "./event-ledger.js";
 import type { EventLedger } from "./event-ledger.js";
+import { createSignalTrackingStore } from "./signal-tracking-store.js";
 import { initAttemptLog } from "./attempt-log.js";
 import type { AttemptLog } from "./attempt-log.js";
 import { initGovernorLedger } from "./governor-ledger.js";
@@ -137,6 +138,7 @@ export type RunAttemptOptions = {
   initEventLedger?: () => EventLedger;
   initAttemptLog?: () => AttemptLog;
   initGovernorLedger?: () => GovernorLedger;
+  initSignalTrackingStore?: () => SignalStore;
   buildAttemptDeps?: typeof buildAttemptDeps;
   resolveRejectionSignaled?: typeof ResolveRejectionSignaledFn;
   fetchImpl?: SelfReviewContextFetch;
@@ -299,6 +301,40 @@ export function buildAttemptDeps(
  * runMinerAttempt for real. The worktree is cleaned up (or retained, per the real outcome) in `finally`.
  * See this file's header for the documented gaps (real convergence history).
  */
+// #8543: the default SignalStore, backed by the miner's own shared local event ledger -- identical to
+// discover-cli.ts's initDefaultSignalTrackingStore (same appendEvent/readEvents singleton).
+function initDefaultSignalTrackingStore(): SignalStore {
+  return createSignalTrackingStore({ appendEvent, readEvents });
+}
+
+// #8543: record one RuleFiredEvent per feasibility avoid/raise reason on the infeasible attempt path, in the
+// canonical signal_rule_fired shape. Best-effort discipline mirrored verbatim from discover-cli.ts's
+// recordEligibilityExclusionSignals: store-init failure and each individual write failure are swallowed so
+// the caller's console output, JSON result, and exit code are unaffected. targetKey is byte-identical to
+// that sibling's `${repoFullName}#issue-${issueNumber}` format.
+async function recordFeasibilityVerdictSignals(
+  verdict: { repoFullName: string; issueNumber: number; avoidReasons: readonly string[]; raiseReasons: readonly string[] },
+  options: Pick<RunAttemptOptions, "initSignalTrackingStore" | "nowMs">,
+): Promise<void> {
+  if (verdict.avoidReasons.length === 0 && verdict.raiseReasons.length === 0) return;
+  let store: SignalStore | null = null;
+  try {
+    store = (options.initSignalTrackingStore ?? initDefaultSignalTrackingStore)();
+  } catch {
+    store = null;
+  }
+  if (!store) return;
+  const occurredAt = new Date(options.nowMs ?? Date.now()).toISOString();
+  const targetKey = `${verdict.repoFullName}#issue-${verdict.issueNumber}`;
+  const fired = [
+    ...verdict.avoidReasons.map((reason) => ({ reason, outcome: "avoid" as const })),
+    ...verdict.raiseReasons.map((reason) => ({ reason, outcome: "raise" as const })),
+  ];
+  for (const entry of fired) {
+    await store.recordRuleFired({ ruleId: entry.reason, targetKey, outcome: entry.outcome, occurredAt }).catch(() => undefined);
+  }
+}
+
 export async function runAttempt(args: string[], options: RunAttemptOptions = {}): Promise<number> {
   const parsed = parseAttemptArgs(args);
   if ("error" in parsed) {
@@ -533,6 +569,21 @@ export async function runAttempt(args: string[], options: RunAttemptOptions = {}
         repoFullName: parsed.repoFullName,
         payload: { issueNumber: parsed.issueNumber, reason },
       });
+      // #8543: capture the feasibility verdict's reasons as rule-fired signals so feasibility rules can be
+      // precision-scored the same way discovery's eligibility exclusions already are (#8107). Best-effort:
+      // never changes this branch's console output, JSON result, or exit code.
+      await recordFeasibilityVerdictSignals(
+        {
+          repoFullName: parsed.repoFullName,
+          issueNumber: parsed.issueNumber,
+          avoidReasons: codingTaskSpec.feasibility.avoidReasons,
+          raiseReasons: codingTaskSpec.feasibility.raiseReasons,
+        },
+        {
+          ...(options.initSignalTrackingStore ? { initSignalTrackingStore: options.initSignalTrackingStore } : {}),
+          ...(options.nowMs === undefined ? {} : { nowMs: options.nowMs }),
+        },
+      );
       const infeasibleResult = {
         outcome: "blocked_infeasible",
         reason,

--- a/test/unit/miner-attempt-cli.test.ts
+++ b/test/unit/miner-attempt-cli.test.ts
@@ -16,6 +16,8 @@ import { closeDefaultWorktreeAllocator, openWorktreeAllocator } from "../../pack
 import { closeDefaultPortfolioQueueStore } from "../../packages/loopover-miner/lib/portfolio-queue.js";
 import { closeDefaultGovernorState } from "../../packages/loopover-miner/lib/governor-state.js";
 import { buildAttemptDeps, parseAttemptArgs, runAttempt } from "../../packages/loopover-miner/lib/attempt-cli.js";
+import type { RunAttemptOptions } from "../../packages/loopover-miner/lib/attempt-cli.js";
+import type { RuleFiredEvent, SignalStore } from "../../packages/loopover-engine/src/calibration/signal-tracking.js";
 import * as minerSentryModule from "../../packages/loopover-miner/lib/sentry.js";
 import * as liveIssueSnapshotModule from "../../packages/loopover-miner/lib/live-issue-snapshot.js";
 import * as githubTokenResolutionModule from "../../packages/loopover-miner/lib/github-token-resolution.js";
@@ -1223,6 +1225,140 @@ describe("runAttempt (#5132)", () => {
     );
     // Nothing ran against this worktree -- cleaned up like every other pre-execution block.
     expect(cleanupAttemptWorktreeSpy).toHaveBeenCalledWith(expect.any(String), expect.any(String), true);
+  });
+
+  // #8543: a fake SignalStore that records every recordRuleFired call, so the capture on the infeasible
+  // path can be asserted event-for-event. queryRuleHistory/recordHumanOverride are unused here.
+  function fakeSignalStore(overrides: { recordRuleFired?: (event: RuleFiredEvent) => Promise<void> } = {}) {
+    const fired: RuleFiredEvent[] = [];
+    const store = {
+      recordRuleFired: overrides.recordRuleFired ?? (async (event: RuleFiredEvent) => void fired.push(event)),
+      recordHumanOverride: async () => undefined,
+      queryRuleHistory: async () => ({ fired: [], overrides: [] }),
+    } as unknown as SignalStore;
+    return { store, fired };
+  }
+
+  const infeasibleArgs = ["acme/widgets", "7", "--miner-login", "alice", "--json"] as const;
+  function infeasibleOptions(extra: Partial<RunAttemptOptions>, feasibility: { avoidReasons: string[]; raiseReasons: string[] }) {
+    const { allocator, claimLedger, eventLedger, attemptLog, governorLedger } = tempLedgers();
+    return {
+      ledgers: { allocator, claimLedger, eventLedger, attemptLog, governorLedger },
+      options: {
+        env: { MINER_CODING_AGENT_PROVIDER: "noop" },
+        attemptId: "infeasible-attempt",
+        openWorktreeAllocator: () => allocator,
+        openClaimLedger: () => claimLedger,
+        initEventLedger: () => eventLedger,
+        initAttemptLog: () => attemptLog,
+        initGovernorLedger: () => governorLedger,
+        ...readyPipelineOptions({
+          buildCodingTaskSpec: () => ({
+            ready: false,
+            verdict: "raise",
+            feasibility: { verdict: "raise", ...feasibility, summary: "infeasible" },
+          }),
+          runMinerAttempt: vi.fn(),
+          cleanupAttemptWorktree: vi.fn().mockResolvedValue({ ok: true, removed: true }),
+        }),
+        ...extra,
+      } as RunAttemptOptions,
+    };
+  }
+
+  it("#8543: records one avoid/raise rule-fired signal per feasibility reason on the infeasible path", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const { store, fired } = fakeSignalStore();
+    const { options } = infeasibleOptions(
+      { initSignalTrackingStore: () => store, nowMs: 1_700_000_000_000 },
+      { avoidReasons: ["claim_status_solved", "issue_quality_do_not_use"], raiseReasons: ["duplicate_cluster_high"] },
+    );
+
+    const exitCode = await runAttempt([...infeasibleArgs], options);
+
+    expect(exitCode).toBe(4);
+    expect(fired).toEqual([
+      { ruleId: "claim_status_solved", targetKey: "acme/widgets#issue-7", outcome: "avoid", occurredAt: "2023-11-14T22:13:20.000Z" },
+      { ruleId: "issue_quality_do_not_use", targetKey: "acme/widgets#issue-7", outcome: "avoid", occurredAt: "2023-11-14T22:13:20.000Z" },
+      { ruleId: "duplicate_cluster_high", targetKey: "acme/widgets#issue-7", outcome: "raise", occurredAt: "2023-11-14T22:13:20.000Z" },
+    ]);
+  });
+
+  it("#8543: records NOTHING when the coding-task-spec is ready (capture is scoped to the infeasible branch)", async () => {
+    const { allocator, claimLedger, eventLedger, attemptLog, governorLedger } = tempLedgers();
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const { store, fired } = fakeSignalStore();
+    const worktreeResult = fakeWorktreeResult();
+    const runMinerAttemptSpy = vi.fn().mockResolvedValue({
+      outcome: "submitted",
+      spec: { command: "gh pr create", cwd: worktreeResult.worktreePath, timeoutMs: 1000 },
+      execResult: { code: 0 },
+      loopResult: fakeLoopResult({ outcome: "handoff", totalTurnsUsed: 3, totalCostUsd: 0.42, iterationsUsed: 2, finalMeterTotals: { tokens: 1234, turns: 3, wallClockMs: 500, costUsd: 0.42 } }),
+    });
+
+    const exitCode = await runAttempt(["acme/widgets", "7", "--miner-login", "alice", "--json"], {
+      env: { MINER_CODING_AGENT_PROVIDER: "noop" },
+      nowMs: 999,
+      attemptId: "ready-attempt",
+      openWorktreeAllocator: () => allocator,
+      openClaimLedger: () => claimLedger,
+      initEventLedger: () => eventLedger,
+      initAttemptLog: () => attemptLog,
+      initGovernorLedger: () => governorLedger,
+      initSignalTrackingStore: () => store,
+      ...readyPipelineOptions({ cleanupAttemptWorktree: vi.fn().mockResolvedValue({ ok: true, removed: true }), runMinerAttempt: runMinerAttemptSpy }),
+    });
+
+    // fakeCodingTaskSpec() is ready: true, so the attempt runs to a real submitted outcome and the
+    // feasibility capture -- gated on !codingTaskSpec.ready -- never fires.
+    expect(exitCode).toBe(0);
+    expect(fired).toEqual([]);
+  });
+
+  it("#8543: falls back to the default signal store (no seam) and to Date.now for the timestamp", async () => {
+    // No initSignalTrackingStore and no nowMs injected: exercises initDefaultSignalTrackingStore() and the
+    // `?? Date.now()` / `: {}` default arms. Best-effort discipline means the real default-ledger write is
+    // swallowed either way, so the only observable is the unchanged exit code.
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const { options } = infeasibleOptions({}, { avoidReasons: ["claim_status_solved"], raiseReasons: [] });
+    const exitCode = await runAttempt([...infeasibleArgs], options);
+    expect(exitCode).toBe(4);
+  });
+
+  it("#8543: records nothing when the verdict has no avoid or raise reasons (early return)", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const { store, fired } = fakeSignalStore();
+    const { options } = infeasibleOptions({ initSignalTrackingStore: () => store }, { avoidReasons: [], raiseReasons: [] });
+    const exitCode = await runAttempt([...infeasibleArgs], options);
+    expect(exitCode).toBe(4);
+    expect(fired).toEqual([]);
+  });
+
+  it("#8543: a throwing initSignalTrackingStore does not change exit code, JSON result, or console output", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const { options } = infeasibleOptions(
+      { initSignalTrackingStore: () => { throw new Error("store init boom"); } },
+      { avoidReasons: ["claim_status_solved"], raiseReasons: [] },
+    );
+
+    const exitCode = await runAttempt([...infeasibleArgs], options);
+
+    expect(exitCode).toBe(4);
+    expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toMatchObject({ outcome: "blocked_infeasible", reason: "infeasible_raise" });
+  });
+
+  it("#8543: a store whose recordRuleFired rejects is swallowed -- exit code and result unchanged", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const { store } = fakeSignalStore({ recordRuleFired: async () => { throw new Error("write boom"); } });
+    const { options } = infeasibleOptions(
+      { initSignalTrackingStore: () => store },
+      { avoidReasons: ["claim_status_solved"], raiseReasons: ["duplicate_cluster_high"] },
+    );
+
+    const exitCode = await runAttempt([...infeasibleArgs], options);
+
+    expect(exitCode).toBe(4);
+    expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toMatchObject({ outcome: "blocked_infeasible" });
   });
 
   it("REGRESSION: infeasible WITHOUT --json prints the feasibility verdict on stderr and exits 4", async () => {


### PR DESCRIPTION
## Summary

AMS's calibration capture was one-sided: discovery records its four eligibility-exclusion reasons as rule-fired signals (`recordEligibilityExclusionSignals`), but the **feasibility verdict** — the other deterministic gate an attempt passes through — recorded nothing, so feasibility rules could not be precision-scored the same way (#8107).

Inside `attempt-cli.ts`'s existing `if (!codingTaskSpec.ready)` branch **only**, this records one `RuleFiredEvent` per `feasibility.avoidReasons` entry (`outcome: "avoid"`) and per `raiseReasons` entry (`outcome: "raise"`), with `ruleId` = the reason verbatim, `targetKey` = `` `${repoFullName}#issue-${issueNumber}` `` (byte-identical to discovery's format), an ISO `occurredAt`, and no `metadata`.

Everything goes through `createSignalTrackingStore` (canonical `signal_rule_fired` shape). Adds an `initSignalTrackingStore` seam — same name as discover's — defaulting to `createSignalTrackingStore({ appendEvent, readEvents })` over the shared local event ledger. **Best-effort discipline is mirrored verbatim from `recordEligibilityExclusionSignals`:** store-init failure (`try/catch`) and each per-write failure (`.catch(() => undefined)`) are swallowed, so the branch's console output, JSON result, and exit-4 contract are unchanged. The pure modules (`coding-task-spec.ts`, `feasibility.ts`) are untouched, and the `ready: true` path records nothing.

## Coverage

**100% of the changed lines and branches** — verified against the scoped simulation CI runs (`vitest run --coverage --coverage.all=false`), zero uncovered lines or branches on the diff.

Getting there surfaced a real inconsistency worth noting: four branches were initially unreachable because I passed `runAttempt`'s already-resolved `nowMs` to the helper, whereas `discover-cli` passes the **raw `options`** so the helper's own `nowMs ?? Date.now()` default is exercised. I corrected the call site to forward the raw seam values — this both closes the coverage gap **and** makes the "mirror `recordEligibilityExclusionSignals` verbatim" requirement literally true.

Tests (root vitest, Codecov-visible via the miner-lib source path — the #8479 precedent):
- **both avoid and raise reasons** → exact `ruleId`/`outcome`/`targetKey`/`occurredAt` asserted per event, order and counts matching the arrays;
- **`ready: true`** → zero events recorded (capture is infeasible-only);
- **`initSignalTrackingStore` throws**, and **a store whose `recordRuleFired` rejects** → exit code, JSON result, and console output identical to a run without the seam;
- **no seam injected** → the default store + `Date.now()` fallbacks run;
- **empty reason arrays** → the early return.

I verified the recording is genuinely wired: reverting the capture call makes the "records one signal per reason" test fail while the swallow tests still pass (a no-op also yields exit 4 — correct).

Closes #8543

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Diff is `packages/loopover-miner/lib/attempt-cli.ts` + its root test suite. No workflow, MCP, UI, worker, or dependency surface is touched, so `actionlint`, `build:mcp`/`test:mcp-pack`, `ui:*`, `test:workers`, and `npm audit` are not exercised by it.
- **Diff coverage verified at 100%** (lines and branches) via the scoped run; the coverage is Codecov-visible because the root vitest suite imports the miner-lib source path directly (both `packages/loopover-miner/lib/**/*.ts` and `*.js` are in `vitest.config.ts`'s `coverage.include`). Root `tsc --noEmit` and the miner package `tsc` are clean, and `git diff --check` passes.
- **Pre-existing unrelated failures:** two tests in `test/unit/miner-attempt-cli.test.ts` (`#5185 ... broken appendAttemptLogEvent` and `reports an unexpected allocator failure ...`) fail on my Windows checkout because the sandbox cannot unlink an open sqlite handle (`EBUSY`). I verified they fail **identically with my changes stashed** (2 failed on clean `origin/main` too), so they are environmental and untouched by this PR; my six new cases pass.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — a miner CLI signal-capture change and its tests; no visible UI, frontend, docs, or extension change.

## Notes

- Every `ready: false` occurrence records — no dedup across repeated attempts at the same issue, since each attempt is a distinct decision instance (matching the issue's requirement and discovery's own non-deduped capture).
