### PR TITLE
test(miner): rename miner-cli-json-error-coverage.test.ts to drop the coverage-padding filename

### DIFF
--- a/test/unit/miner-cli-json-error-paths.test.ts
+++ b/test/unit/miner-cli-json-error-paths.test.ts
@@ -69,7 +69,12 @@ async function expectJsonErrorAsync(
   stderr.mockRestore();
 }
 
-describe("miner CLI --json error coverage (#4836)", () => {
+// Shared --json error-envelope contract across the miner CLI's subcommands (#4836): every run* entry
+// point must fail with { ok: false, error: string } on stdout, exit code 2, and nothing on stderr.
+// Grouped by CLI surface (not split per-sibling file) because the thing under test IS the shared
+// envelope, exercised via expectJsonError/expectJsonErrorAsync above -- splitting it apart would
+// duplicate that helper and lose the "one contract, many entry points" narrative.
+describe("miner CLI --json error paths (#4836)", () => {
   it("portfolio queue list/next/done/claim-batch failures", () => {
     expectJsonError(() => runQueueList(["--verbose", "--json"]), /Unknown option/);
     expectJsonError(


### PR DESCRIPTION
Closes #8579.

## Summary
Unlike the other bolt-on files in the '-coverage' family (#8574), this one is a legitimate single-concern suite: the shared `--json` error-envelope contract (`{ ok: false, error }`, exit code 2, nothing on stderr) exercised across many miner CLI subcommands via one shared `expectJsonError`/`expectJsonErrorAsync` helper. Distributing it into each CLI's own sibling file (Option B) would duplicate that helper across ~9 files and lose the "one contract, many entry points" narrative.

Went with Option A from the issue: rename only, no content change (`miner-cli-json-error-coverage.test.ts` -> `miner-cli-json-error-paths.test.ts`), retitled the top-level describe to drop the "coverage" framing, and added a comment explaining why the file stays consolidated so it doesn't get flagged again.

## Test plan
- `npx vitest run test/unit/miner-cli-json-error-paths.test.ts` — 8/8 pass
- `npm run typecheck` — clean
- Pure rename, no test-body changes — no coverage impact to verify.