### PR TITLE
feat(quota): add soft-threshold quota-warning evaluator

### DIFF
--- a/packages/loopover-engine/src/tenant-quota.ts
+++ b/packages/loopover-engine/src/tenant-quota.ts
@@ -99,3 +99,32 @@ export function evaluateTenantQuota(usage: TenantUsage, quota: TenantQuota): Ten
     remaining,
   };
 }
+
+/**
+ * #7662: the soft-warning counterpart to {@link evaluateTenantQuota}. Returns the FIRST dimension — same
+ * compute→time→concurrency precedence as the hard check — whose remaining headroom has fallen to or below
+ * `warnThreshold` of its cap (default 0.2 ⇒ ≤20% left / ≥80% consumed), the pre-exhaustion band a soft
+ * "running low" notification fires in — or null when every bounded dimension still has comfortable headroom.
+ * A dimension already exhausted (remaining 0) is owned by the hard check and is NOT warned on here; a
+ * zero/undefined cap yields no meaningful fraction and is skipped. Pure: the caller decides whether/when to
+ * actually fire a notification from the result (the delivery wiring rides #7647's admission-check point).
+ */
+export function evaluateTenantQuotaWarning(
+  usage: TenantUsage,
+  quota: TenantQuota,
+  warnThreshold = 0.2,
+): { warned: boolean; dimension: QuotaDimension | null; remaining: TenantQuotaDecision["remaining"] } {
+  const { remaining } = evaluateTenantQuota(usage, quota);
+  const byDimension: ReadonlyArray<[QuotaDimension, number, number]> = [
+    ["compute", remaining.computeUnits, finiteNonNegativeInt(quota.computeUnits)],
+    ["time", remaining.wallClockMs, finiteNonNegativeInt(quota.wallClockMs)],
+    ["concurrency", remaining.concurrentLoops, finiteNonNegativeInt(quota.maxConcurrentLoops)],
+  ];
+  for (const [dimension, left, cap] of byDimension) {
+    if (cap <= 0) continue;
+    if (left > 0 && left / cap <= warnThreshold) {
+      return { warned: true, dimension, remaining };
+    }
+  }
+  return { warned: false, dimension: null, remaining };
+}

--- a/test/unit/tenant-quota.test.ts
+++ b/test/unit/tenant-quota.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { evaluateTenantQuota } from "../../packages/loopover-engine/src/tenant-quota";
+import { evaluateTenantQuota, evaluateTenantQuotaWarning } from "../../packages/loopover-engine/src/tenant-quota";
 
 const QUOTA = { computeUnits: 100, wallClockMs: 60_000, maxConcurrentLoops: 3 };
 
@@ -70,5 +70,42 @@ describe("evaluateTenantQuota (#4796)", () => {
     expect(under.allowed).toBe(true);
     // Re-evaluating the over-quota tenant does not change the under-quota tenant's independent decision.
     expect(evaluateTenantQuota({ computeUnitsUsed: 5, wallClockMsUsed: 5_000, activeLoops: 1 }, QUOTA)).toEqual(under);
+  });
+});
+
+describe("evaluateTenantQuotaWarning (#7662)", () => {
+  it("does not warn when every dimension has comfortable headroom", () => {
+    const w = evaluateTenantQuotaWarning({ computeUnitsUsed: 40, wallClockMsUsed: 10_000, activeLoops: 1 }, QUOTA);
+    expect(w).toEqual({ warned: false, dimension: null, remaining: { computeUnits: 60, wallClockMs: 50_000, concurrentLoops: 2 } });
+  });
+
+  it("warns on the first low dimension at/below the soft threshold (85/100 compute ⇒ 15% left ≤ 20%)", () => {
+    const w = evaluateTenantQuotaWarning({ computeUnitsUsed: 85, wallClockMsUsed: 0, activeLoops: 0 }, QUOTA);
+    expect(w.warned).toBe(true);
+    expect(w.dimension).toBe("compute");
+  });
+
+  it("reports the time dimension when compute is healthy but wall-clock is low (precedence respected)", () => {
+    const w = evaluateTenantQuotaWarning({ computeUnitsUsed: 10, wallClockMsUsed: 50_000, activeLoops: 0 }, QUOTA);
+    expect(w.dimension).toBe("time");
+  });
+
+  it("does not warn a dimension already exhausted — the hard check owns remaining 0", () => {
+    const w = evaluateTenantQuotaWarning({ computeUnitsUsed: 100, wallClockMsUsed: 0, activeLoops: 0 }, QUOTA);
+    expect(w.warned).toBe(false);
+    expect(w.dimension).toBeNull();
+  });
+
+  it("skips a dimension whose cap is zero/undefined (no meaningful fraction)", () => {
+    const w = evaluateTenantQuotaWarning(
+      { computeUnitsUsed: 0, wallClockMsUsed: 1_000, activeLoops: 0 },
+      { computeUnits: 0, wallClockMs: 60_000, maxConcurrentLoops: 3 },
+    );
+    expect(w.warned).toBe(false);
+  });
+
+  it("honors a custom warn threshold (30% left: no warn at the 20% default, warns at 40%)", () => {
+    expect(evaluateTenantQuotaWarning({ computeUnitsUsed: 70, wallClockMsUsed: 0, activeLoops: 0 }, QUOTA).warned).toBe(false);
+    expect(evaluateTenantQuotaWarning({ computeUnitsUsed: 70, wallClockMsUsed: 0, activeLoops: 0 }, QUOTA, 0.4).dimension).toBe("compute");
   });
 });


### PR DESCRIPTION
## What

Adds the pure soft-warning evaluator #7662 needs: `evaluateTenantQuotaWarning`
(`packages/loopover-engine/src/tenant-quota.ts`) — the counterpart to the existing hard
`evaluateTenantQuota`. Today `evaluateTenantQuota`'s per-dimension `remaining` figures are
never checked against any soft threshold; this reports the **first** dimension (same
compute→time→concurrency precedence as the hard check) whose headroom has fallen to or below
`warnThreshold` of its cap (default `0.2` ⇒ ≤20% left / ≥80% consumed) — the pre-exhaustion
band a "running low" notification fires in — or `null` when every bounded dimension is healthy.

- A dimension already exhausted (remaining 0) is **not** warned on here — the hard block owns it.
- A zero/undefined cap yields no meaningful fraction and is skipped.
- Pure and side-effect-free: the caller decides whether/when to fire a notification from it.

## Scope note

This is the evaluation half. The notification-event-kind + delivery wiring must hook into the
**same admission-check point #7647 adds** to `src/queue/job-dispatch.ts` (the issue is explicit:
do not invent a separate call site). That call site does not exist until #7647 lands
(`evaluateTenantQuota` is not yet called anywhere in `job-dispatch.ts`), so the firing is a
follow-up on top of this evaluator rather than a second invented mechanism — the evaluator lands
independently and is structurally ready for that wiring.

## Validation

- New tests in `test/unit/tenant-quota.test.ts` (imports the engine source directly, so Codecov
  sees the coverage): healthy → no warn; first low dimension warned at the threshold; precedence
  (time reported when compute healthy); an exhausted dimension not warned; a zero-cap dimension
  skipped; a custom threshold honored. 100% branch coverage on the new function (verified via lcov).
- `npx vitest run test/unit/tenant-quota.test.ts` → 14/14 pass; `@loopover/engine` rebuilds clean.

Closes #7662
