### PR TITLE
fix(mcp): flush stdout/stderr before exiting the CLI to stop large output truncation

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.ts
+++ b/packages/loopover-mcp/bin/loopover-mcp.ts
@@ -42,7 +42,7 @@ import { validateIdeaSubmission, buildTaskGraph, buildClaimPlan } from "@loopove
 import { z } from "zod";
 import { buildBranchAnalysisPayload, collectLocalDiff, collectLocalBranchMetadata, probeLocalScorer, referenceScorePreviewExample, resolveScorePreviewCommand, resolveWorkspaceCwd, sanitizeLocalScorerStatus, setupGuidanceForLocalScorer, isTestFile } from "../lib/local-branch.js";
 import { formatTable } from "../lib/format-table.js";
-import { argsWantJson, describeCliError, reportCliFailure } from "../lib/cli-error.js";
+import { argsWantJson, describeCliError, reportCliFailure, waitForStdioFlush } from "../lib/cli-error.js";
 import { redactKnownLocalPaths, redactLocalPath } from "../lib/redact-local-path.js";
 // Aliased: this file's own recordStdioToolTelemetry is the chokepoint that calls it, and the two names sitting
 // side by side unaliased would read as the same function (#6238).
@@ -1673,14 +1673,19 @@ function stdioToolDescription(name: any) {
   return tool.description;
 }
 
-/* v8 ignore next 8 -- the CLI dispatch runs only in the launched process (runAsCliEntrypoint); an in-process
-   unit importer keeps it false and drives runCli/maintainCli directly instead (mcp-cli-plan-issues.test.ts). */
+/* v8 ignore next 11 -- the CLI dispatch runs only in the launched process (runAsCliEntrypoint); an in-process
+   unit importer keeps it false and drives runCli/maintainCli directly instead (mcp-cli-plan-issues.test.ts).
+   waitForStdioFlush itself (#8606, the reason process.exit() is no longer called bare here) is exported and
+   unit-tested directly in mcp-cli-error.test.ts. */
 if (runAsCliEntrypoint && cliArgs[0] !== "--stdio") {
   try {
     const exitCode = await runCli(cliArgs);
+    await waitForStdioFlush([process.stdout, process.stderr]);
     process.exit(typeof exitCode === "number" ? exitCode : 0);
   } catch (error) {
-    process.exit(reportCliFailure(argsWantJson(cliArgs), describeCliError(error), 1));
+    const failureExitCode = reportCliFailure(argsWantJson(cliArgs), describeCliError(error), 1);
+    await waitForStdioFlush([process.stdout, process.stderr]);
+    process.exit(failureExitCode);
   }
 }
 

--- a/packages/loopover-mcp/lib/cli-error.ts
+++ b/packages/loopover-mcp/lib/cli-error.ts
@@ -19,3 +19,22 @@ export function argsWantJson(args: readonly string[]): boolean {
 export function describeCliError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
+
+/** A writable stream's own buffered-byte count, e.g. `process.stdout`/`process.stderr`. */
+export type FlushableStream = { readonly writableLength: number };
+
+/** #8606: resolves once every stream has finished writing everything queued on it. POSIX writes to a piped
+ *  stdout/stderr (as opposed to a TTY or a file) are asynchronous, so calling `process.exit()` right after a
+ *  large write can terminate the process before the OS has actually drained it, truncating what a piped
+ *  consumer reads (e.g. the CLI's packaged CHANGELOG.md output, >64KB). Callers should await this immediately
+ *  before exiting. `setImmediate` is safe to poll on indefinitely here: it costs nothing while the buffer is
+ *  empty (resolves on the first check) and only re-schedules while real bytes are still in flight. */
+export function waitForStdioFlush(streams: readonly FlushableStream[]): Promise<void> {
+  return new Promise((resolve) => {
+    const poll = () => {
+      if (streams.some((stream) => stream.writableLength > 0)) setImmediate(poll);
+      else resolve();
+    };
+    poll();
+  });
+}

--- a/test/unit/mcp-cli-error.test.ts
+++ b/test/unit/mcp-cli-error.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { argsWantJson, describeCliError, reportCliFailure } from "../../packages/loopover-mcp/lib/cli-error.js";
+import { argsWantJson, describeCliError, reportCliFailure, waitForStdioFlush } from "../../packages/loopover-mcp/lib/cli-error.js";
 
 describe("mcp cli-error (#5928)", () => {
   afterEach(() => {
@@ -38,5 +38,34 @@ describe("mcp cli-error (#5928)", () => {
     expect(describeCliError(new Error("boom"))).toBe("boom");
     expect(describeCliError("plain")).toBe("plain");
     expect(describeCliError(42)).toBe("42");
+  });
+
+  describe("waitForStdioFlush (#8606)", () => {
+    it("resolves without waiting a tick when every stream is already fully drained", async () => {
+      const settled = vi.fn();
+      void waitForStdioFlush([{ writableLength: 0 }, { writableLength: 0 }]).then(settled);
+      // A poll that finds nothing buffered resolves synchronously inside the executor, before any
+      // setImmediate is ever scheduled -- only a microtask tick (not a macrotask) should be needed.
+      await Promise.resolve();
+      expect(settled).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps polling until every stream drains, then resolves", async () => {
+      const stdout = { writableLength: 12 };
+      const stderr = { writableLength: 0 };
+      const settled = vi.fn();
+      void waitForStdioFlush([stdout, stderr]).then(settled);
+
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(settled).not.toHaveBeenCalled();
+
+      stdout.writableLength = 0;
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(settled).toHaveBeenCalledTimes(1);
+    });
+
+    it("treats an empty stream list as already flushed", async () => {
+      await expect(waitForStdioFlush([])).resolves.toBeUndefined();
+    });
   });
 });


### PR DESCRIPTION
## Summary

- `loopover-mcp changelog --json` truncated its output mid-write whenever the packaged `CHANGELOG.md` grew past the OS pipe buffer size (~64KB) — `test/unit/mcp-cli-profiles.test.ts`'s "reports package status and prints the packaged changelog" test was failing deterministically on `main` as a result, blocking a green `test:ci` gate for every branch.
- Root cause: the CLI dispatcher called `process.exit()` immediately after a command finished. Writes to a piped `process.stdout` are asynchronous on POSIX, so `process.exit()` could terminate the process before the OS finished draining a large write.
- Fix: added `waitForStdioFlush()` (`packages/loopover-mcp/lib/cli-error.ts`) and `await` it before each `process.exit()` call. Setting `process.exitCode` and relying on a natural exit instead isn't safe either — it was tried and reproducibly deadlocked whenever this CLI is spawned via `child_process` with default (piped, unclosed) stdio, e.g. Node's own `execFile`, which is exactly how this repo's own CLI test harness spawns it.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] Linked issue — not applicable; this is a maintainer PR fixing a bug discovered directly while diagnosing a failing test on `main`.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] Targeted tests: `test/unit/mcp-cli-error.test.ts` (new `waitForStdioFlush` unit tests, both branches + empty-list edge case) and the full `test/unit/mcp-cli-*.test.ts` + `mcp-tool-rename-aliases.test.ts` suite (76 files / 426 tests) — all green.
- [x] Scoped coverage check on the diff: `waitForStdioFlush` is 100% line/branch/function covered per `coverage/lcov.info`. The dispatcher's own 4 touched lines (the `await waitForStdioFlush(...)` call sites) remain structurally uncoverable — they only execute in a real subprocess spawn, same as the rest of this file's CLI dispatch block (see the existing `v8 ignore` comment and `codecov.yml`'s note on `packages/loopover-mcp/bin/loopover-mcp.ts`).
- [x] `npm run test:ci` (full local gate) run twice end-to-end against an earlier version of this fix (before extracting `waitForStdioFlush` into `lib/cli-error.ts` for testability) — both green aside from 3 (then 2) flakes, each independently confirmed unrelated: CPU contention from concurrent test runs in sibling worktrees, and a local `ui-kit` build-order gap in manual invocation.
- Skipped as not applicable to this change: `npm run actionlint` (no workflow files touched), `npm run test:workers` (no worker code touched), `npm run ui:*` (no UI code touched), `npm audit` (no dependency changes — verified via `git diff --name-only` against the rebase base).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] N/A: no auth/cookie/CORS/GitHub App/Cloudflare/session changes.
- [x] N/A: no API/OpenAPI/MCP protocol-surface behavior changed (CLI process-exit timing only).
- [x] N/A: no UI changes.
- [x] N/A: no public docs/changelog changes needed for this fix.

## Notes

- Reproduced the truncation and the deadlock independently before settling on this fix; both are described in the commit message.