### PR TITLE
fix(rees): run REES coverage's test child from review-enrichment/

### DIFF
--- a/scripts/rees-coverage-chdir.cjs
+++ b/scripts/rees-coverage-chdir.cjs
@@ -1,0 +1,8 @@
+// Preloaded via --require before node:test loads review-enrichment's test files.
+// c8 (the parent process) must keep its own cwd at the monorepo root so lcov SF: paths
+// remap to `review-enrichment/src/**` for Codecov (#6250); this only chdir's the spawned
+// test child, so tests that read fixtures with bare relative paths (e.g. "analyzer-metadata.json")
+// resolve them against review-enrichment/, matching `npm run test:node`.
+const { join } = require("node:path");
+
+process.chdir(join(__dirname, "..", "review-enrichment"));

--- a/scripts/rees-coverage.ts
+++ b/scripts/rees-coverage.ts
@@ -3,7 +3,7 @@
 // (not bare `src/**`), and expands the test list in-process so Windows/npm quoting cannot drop the suite.
 import { spawnSync } from "node:child_process";
 import { readFileSync, readdirSync, writeFileSync } from "node:fs";
-import { join, relative } from "node:path";
+import { join } from "node:path";
 import { fileURLToPath, URL } from "node:url";
 
 /** Normalize c8's SF: paths to forward slashes for Codecov. Swallows only a missing report
@@ -39,8 +39,10 @@ function main() {
   const c8Bin = join(root, "review-enrichment", "node_modules", "c8", "bin", "c8.js");
   const reportDir = join(root, "review-enrichment", "coverage");
   const testRoot = join(root, "review-enrichment", "test");
+  const chdirPreload = join(root, "scripts", "rees-coverage-chdir.cjs");
 
-  const tests = collectTests(testRoot).map((path) => relative(root, path).split("\\").join("/"));
+  // Absolute paths: the test child's cwd is review-enrichment/ (see chdirPreload), not root.
+  const tests = collectTests(testRoot).map((path) => path.split("\\").join("/"));
   if (tests.length === 0) {
     console.error("rees-coverage: no review-enrichment/test/**/*.test.ts files found");
     process.exit(1);
@@ -57,6 +59,8 @@ function main() {
       "--exclude=**/*.d.ts",
       "--all",
       process.execPath,
+      "--require",
+      chdirPreload,
       "--test",
       "--experimental-strip-types",
       ...tests,


### PR DESCRIPTION
## Summary
- `scripts/rees-coverage.ts` spawned c8 and the `node:test` child it wraps with the same `cwd` (the monorepo root) — needed so c8's lcov `SF:` paths remap to `review-enrichment/src/**` for Codecov — but this left the actual test process running from the wrong directory, so tests reading fixtures via bare relative paths (e.g. `analyzer-metadata.test.ts` reading `"analyzer-metadata.json"`) failed with `ENOENT` even though the fixture exists at `review-enrichment/analyzer-metadata.json`.
- Adds `scripts/rees-coverage-chdir.cjs`, preloaded via `--require` into only the spawned test child, chdir'ing it into `review-enrichment/` before `node:test` loads any files. c8's own process cwd (and its `SF:` path remapping) is untouched.
- Test file arguments switch from root-relative to absolute paths since they're now resolved against a different cwd than before.
- This script is a diagnostic/Codecov-harvesting step (`npm run rees:coverage`, uploaded with `|| true` in CI since c8 instrumentation is known to blow timing-sensitive budgets) — it is not the actual REES gate (`npm --prefix review-enrichment test`, unaffected by this bug and already passing).

## Test plan
- [x] `node --experimental-strip-types scripts/rees-coverage.ts` — 1376/1376 pass, 0 failures (previously 1 ENOENT failure)
- [x] `npm run test:node --prefix review-enrichment` — same test count, clean pass, confirms parity
- [x] `lcov.info`'s `SF:` lines all remain `review-enrichment/src/**` (unchanged from pre-fix behavior)
- [x] `npx tsc --noEmit` clean