### PR TITLE
fix(selfhost): read POSTHOG_CLI_PROJECT_ID/HOST from secrets, not vars

### DIFF
--- a/.github/workflows/release-selfhost.yml
+++ b/.github/workflows/release-selfhost.yml
@@ -159,8 +159,8 @@ jobs:
         if: steps.posthog.outputs.enabled == 'true'
         env:
           POSTHOG_CLI_API_KEY: ${{ secrets.POSTHOG_CLI_API_KEY }}
-          POSTHOG_CLI_PROJECT_ID: ${{ vars.POSTHOG_CLI_PROJECT_ID }}
-          POSTHOG_CLI_HOST: ${{ vars.POSTHOG_CLI_HOST }}
+          POSTHOG_CLI_PROJECT_ID: ${{ secrets.POSTHOG_CLI_PROJECT_ID }}
+          POSTHOG_CLI_HOST: ${{ secrets.POSTHOG_CLI_HOST }}
           POSTHOG_RELEASE: ${{ steps.version.outputs.release }}
         run: |
           set -euo pipefail
@@ -254,8 +254,8 @@ jobs:
         if: steps.posthog.outputs.enabled == 'true'
         env:
           POSTHOG_CLI_API_KEY: ${{ secrets.POSTHOG_CLI_API_KEY }}
-          POSTHOG_CLI_PROJECT_ID: ${{ vars.POSTHOG_CLI_PROJECT_ID }}
-          POSTHOG_CLI_HOST: ${{ vars.POSTHOG_CLI_HOST }}
+          POSTHOG_CLI_PROJECT_ID: ${{ secrets.POSTHOG_CLI_PROJECT_ID }}
+          POSTHOG_CLI_HOST: ${{ secrets.POSTHOG_CLI_HOST }}
           POSTHOG_RELEASE: ${{ steps.version.outputs.release }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

Re-applies a fix that got dropped: #8619 auto-merged with only its first commit before I pushed this fix to the same branch, so it never reached `main`. Confirmed live: the actual beta build (`orb-v3.4.0-beta.7`) failed twice against `main` with `POSTHOG_CLI_PROJECT_ID` resolving empty, even after the value was correctly set as a secret in both environments — because the workflow was still reading `vars.POSTHOG_CLI_PROJECT_ID`, a different namespace from `secrets.*`.

Both `POSTHOG_CLI_PROJECT_ID` and `POSTHOG_CLI_HOST` were configured as environment **secrets** (not variables) in the `release`/`release-beta` GitHub environments — this switches the workflow to read them from `secrets.*` to match.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — valid YAML
- [x] Will re-trigger the beta build once this merges and verify `POSTHOG_CLI_PROJECT_ID` resolves non-empty in the run logs before declaring success