### PR TITLE
fix(selfhost): unset POSTHOG_CLI_HOST when blank, don't pass empty

### DIFF
--- a/.github/workflows/release-selfhost.yml
+++ b/.github/workflows/release-selfhost.yml
@@ -166,6 +166,10 @@ jobs:
           set -euo pipefail
           test -n "$POSTHOG_CLI_API_KEY"
           test -n "$POSTHOG_CLI_PROJECT_ID"
+          # posthog-cli treats a PRESENT-but-empty POSTHOG_CLI_HOST as an explicit (invalid) URL, not as
+          # "unset, use the default" -- unset it outright when blank, mirroring the old SENTRY_URL handling
+          # this replaced.
+          if [ -z "${POSTHOG_CLI_HOST:-}" ]; then unset POSTHOG_CLI_HOST; fi
           # No separate "create release" step -- PostHog release metadata is a byproduct of the inject/
           # upload calls below, unlike Sentry's releases/commits/deploys/finalize lifecycle this replaces.
           npx -y "$POSTHOG_CLI_PACKAGE" sourcemap inject --directory dist --release-version "$POSTHOG_RELEASE"
@@ -259,6 +263,7 @@ jobs:
           POSTHOG_RELEASE: ${{ steps.version.outputs.release }}
         run: |
           set -euo pipefail
+          if [ -z "${POSTHOG_CLI_HOST:-}" ]; then unset POSTHOG_CLI_HOST; fi
           # PostHog's release-read path can lag briefly behind the upload write above.
           # review-enrichment/src/upload-sourcemaps.ts's runReleaseValidation() already retry-polls this
           # same script for REES's own deploy path -- mirror that here instead of failing the whole

--- a/.github/workflows/release-selfhost.yml
+++ b/.github/workflows/release-selfhost.yml
@@ -167,8 +167,8 @@ jobs:
           test -n "$POSTHOG_CLI_API_KEY"
           test -n "$POSTHOG_CLI_PROJECT_ID"
           # posthog-cli treats a PRESENT-but-empty POSTHOG_CLI_HOST as an explicit (invalid) URL, not as
-          # "unset, use the default" -- unset it outright when blank, mirroring the old SENTRY_URL handling
-          # this replaced.
+          # "unset, use the default" -- unset it outright when blank, same guard this pipeline's old
+          # Sentry-org-URL override once needed for the identical reason.
           if [ -z "${POSTHOG_CLI_HOST:-}" ]; then unset POSTHOG_CLI_HOST; fi
           # No separate "create release" step -- PostHog release metadata is a byproduct of the inject/
           # upload calls below, unlike Sentry's releases/commits/deploys/finalize lifecycle this replaces.


### PR DESCRIPTION
## Summary

Third fix in this same chain (#8619 → #8621 → this): confirmed live that `orb-v3.4.0-beta.8`'s release build failed with `Oops! Invalid Host: "Host must be a valid URL"` from `posthog-cli` itself. `POSTHOG_CLI_API_KEY`/`POSTHOG_CLI_PROJECT_ID` both resolved correctly this time (the #8621 fix worked) — but `POSTHOG_CLI_HOST` isn't configured as a secret (US-cloud default, correctly left unset), and `secrets.POSTHOG_CLI_HOST` resolves to an **empty string**, not an absent variable, when a secret name doesn't exist. `posthog-cli` treats a present-but-empty host as an explicit invalid URL rather than "use the default."

Mirrors the old `SENTRY_URL` handling this pipeline replaced (`if [ -z "${SENTRY_URL:-}" ]; then unset SENTRY_URL; fi`). `scripts/deploy-selfhost-prebuilt.sh`'s own `${host:+-e POSTHOG_CLI_HOST=...}` conditional expansion already avoided this correctly — only the GitHub Actions YAML (which has no equivalent conditional-env-inclusion syntax) needed the explicit `unset`.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — valid YAML
- [x] `npm run actionlint` — clean
- [x] Will re-trigger the beta build once merged and confirm the full pipeline (inject → validate → upload → validate-release → Docker build/push) completes end to end