### PR TITLE
fix(selfhost): list globalThis-cast and dual-arg severity env vars in the reference (#8627)

### DIFF
--- a/apps/loopover-ui/src/lib/selfhost-env-reference.ts
+++ b/apps/loopover-ui/src/lib/selfhost-env-reference.ts
@@ -414,6 +414,14 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
     firstReference: "src/services/notify-pagerduty.ts",
   },
   {
+    name: "PAGERDUTY_MIN_SEVERITY",
+    firstReference: "src/services/notify-pagerduty.ts",
+  },
+  {
+    name: "PAGERDUTY_REPO_MIN_SEVERITY",
+    firstReference: "src/services/notify-pagerduty.ts",
+  },
+  {
     name: "PAGERDUTY_ROUTING_KEY",
     firstReference: "src/services/notify-pagerduty.ts",
   },
@@ -442,8 +450,20 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
     firstReference: "src/selfhost/otel.ts",
   },
   {
+    name: "POSTHOG_MIN_SEVERITY",
+    firstReference: "src/selfhost/posthog.ts",
+  },
+  {
     name: "POSTHOG_RELEASE",
     firstReference: "src/selfhost/otel.ts",
+  },
+  {
+    name: "POSTHOG_REPO_MIN_SEVERITY",
+    firstReference: "src/selfhost/posthog.ts",
+  },
+  {
+    name: "POSTHOG_SERVER_NAME",
+    firstReference: "src/selfhost/posthog.ts",
   },
   {
     name: "PUBLIC_API_ORIGIN",
@@ -648,6 +668,8 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| `OTEL_TRACES_SAMPLER` | `src/selfhost/otel.ts` |",
   "| `OTEL_TRACES_SAMPLER_ARG` | `src/selfhost/otel.ts` |",
   "| `PAGERDUTY_COOLDOWN_MINUTES` | `src/services/notify-pagerduty.ts` |",
+  "| `PAGERDUTY_MIN_SEVERITY` | `src/services/notify-pagerduty.ts` |",
+  "| `PAGERDUTY_REPO_MIN_SEVERITY` | `src/services/notify-pagerduty.ts` |",
   "| `PAGERDUTY_ROUTING_KEY` | `src/services/notify-pagerduty.ts` |",
   "| `PGPOOL_MAX` | `src/selfhost/queue-common.ts` |",
   "| `PGVECTOR_ENABLED` | `src/server.ts` |",
@@ -655,7 +677,10 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| `POSTHOG_API_KEY` | `src/selfhost/otel.ts` |",
   "| `POSTHOG_ENVIRONMENT` | `src/selfhost/otel.ts` |",
   "| `POSTHOG_HOST` | `src/selfhost/otel.ts` |",
+  "| `POSTHOG_MIN_SEVERITY` | `src/selfhost/posthog.ts` |",
   "| `POSTHOG_RELEASE` | `src/selfhost/otel.ts` |",
+  "| `POSTHOG_REPO_MIN_SEVERITY` | `src/selfhost/posthog.ts` |",
+  "| `POSTHOG_SERVER_NAME` | `src/selfhost/posthog.ts` |",
   "| `PUBLIC_API_ORIGIN` | `src/selfhost/preflight.ts` |",
   "| `PUBLIC_ORIGIN_ACKNOWLEDGED` | `src/server.ts` |",
   "| `PUBLIC_SITE_ORIGIN` | `src/server.ts` |",

--- a/scripts/gen-selfhost-env-reference.ts
+++ b/scripts/gen-selfhost-env-reference.ts
@@ -91,8 +91,8 @@ function collectEnvReads(source: string, fileName: string): EnvRead[] {
     } else if (ts.isCallExpression(node) && isProcessEnvNameHelperCall(node)) {
       addRead((node.arguments[0] as ts.StringLiteralLike).text);
     } else if (ts.isCallExpression(node) && isEnvNameLiteralArgHelperCall(node)) {
-      const argIndex = ENV_NAME_LITERAL_ARG_HELPERS.get((node.expression as ts.Identifier).text)!;
-      addRead((node.arguments[argIndex] as ts.StringLiteralLike).text);
+      const argIndexes = ENV_NAME_LITERAL_ARG_HELPERS.get((node.expression as ts.Identifier).text)!;
+      for (const argIndex of argIndexes) addRead((node.arguments[argIndex] as ts.StringLiteralLike).text);
     }
     ts.forEachChild(node, visit);
   };
@@ -115,12 +115,15 @@ function isStaticEnvHelperCall(node: ts.CallExpression): boolean {
 // isStaticEnvHelperCall above (envString) because these take the var NAME as arg[0], not arg[1] after a
 // container.
 const PROCESS_ENV_NAME_HELPERS = new Set(["parsePositiveIntEnv"]);
-const ENV_NAME_LITERAL_ARG_HELPERS = new Map([
-  ["resolveLocalStoreDbPath", 1],
+const ENV_NAME_LITERAL_ARG_HELPERS = new Map<string, readonly number[]>([
+  ["resolveLocalStoreDbPath", [1]],
   // createCliProvider(command, modelEnvKey, options, env) (packages/loopover-engine/src/miner/driver-factory.ts)
   // reads env[modelEnvKey] -- a computed access AST-invisible without this, since modelEnvKey is a parameter,
   // not a literal at the read site. The literal var name is only visible at the CALL site (arg index 1). (#6994)
-  ["createCliProvider", 1],
+  ["createCliProvider", [1]],
+  // resolveSeverityThreshold(env, repoFullName, "MIN_VAR", "REPO_MIN_VAR", ...) reads BOTH name literals at the
+  // call site (args 2 and 3) -- src/selfhost/posthog.ts:81's POSTHOG_MIN_SEVERITY / POSTHOG_REPO_MIN_SEVERITY.
+  ["resolveSeverityThreshold", [2, 3]],
 ]);
 
 function isProcessEnvNameHelperCall(node: ts.CallExpression): boolean {
@@ -129,8 +132,8 @@ function isProcessEnvNameHelperCall(node: ts.CallExpression): boolean {
 
 function isEnvNameLiteralArgHelperCall(node: ts.CallExpression): boolean {
   if (!ts.isIdentifier(node.expression)) return false;
-  const argIndex = ENV_NAME_LITERAL_ARG_HELPERS.get(node.expression.text);
-  return argIndex !== undefined && node.arguments.length > argIndex && ts.isStringLiteralLike(node.arguments[argIndex]!);
+  const argIndexes = ENV_NAME_LITERAL_ARG_HELPERS.get(node.expression.text);
+  return argIndexes !== undefined && argIndexes.every((index) => node.arguments.length > index && ts.isStringLiteralLike(node.arguments[index]!));
 }
 
 function bindingElementName(element: ts.BindingElement): string | null {
@@ -147,13 +150,26 @@ function unwrapEnvExpression(node: ts.Expression): ts.Expression {
   return node;
 }
 
+// True for `globalThis.process` (through any `as` casts / parens) -- the base of the `globalThis`-cast
+// `process.env` access src/selfhost/posthog.ts:179 uses for POSTHOG_SERVER_NAME. A property-access base, not a
+// bare identifier, so isEnvContainer's identifier branch alone never matched it (the Sentry-era predecessor
+// read the same knob as a plain `env.SENTRY_SERVER_NAME`, which did match).
+function isGlobalThisProcess(rawNode: ts.Expression): boolean {
+  const node = unwrapEnvExpression(rawNode);
+  if (!ts.isPropertyAccessExpression(node) || node.name.text !== "process") return false;
+  const base = unwrapEnvExpression(node.expression);
+  return ts.isIdentifier(base) && base.text === "globalThis";
+}
+
 function isEnvContainer(rawNode: ts.Expression): boolean {
   const node = unwrapEnvExpression(rawNode);
   if (ts.isIdentifier(node)) return node.text === "env";
   return (
     ts.isPropertyAccessExpression(node) &&
     node.name.text === "env" &&
-    ((ts.isIdentifier(node.expression) && (node.expression.text === "process" || node.expression.text === "c")) || isEnvContainer(node.expression))
+    ((ts.isIdentifier(node.expression) && (node.expression.text === "process" || node.expression.text === "c")) ||
+      isGlobalThisProcess(node.expression) ||
+      isEnvContainer(node.expression))
   );
 }
 

--- a/test/unit/selfhost-env-reference-script.test.ts
+++ b/test/unit/selfhost-env-reference-script.test.ts
@@ -102,6 +102,37 @@ describe("gen-selfhost-env-reference (#2081)", () => {
     expect(after).toEqual(before);
   });
 
+  it("REGRESSION (#8627): recognizes a globalThis-cast process.env read (POSTHOG_SERVER_NAME shape)", () => {
+    const root = mkdtempSync(join(tmpdir(), "gt-env-reference-globalthis-"));
+    mkdirSync(join(root, "src", "selfhost"), { recursive: true });
+    // src/selfhost/posthog.ts:179 reads the server-name knob through a globalThis cast rather than a bare
+    // `env.` / `process.env.` access. The base of `.env` is a `.process` property access (not an identifier),
+    // so the old isEnvContainer walked past it and the var went unlisted in the generated reference.
+    writeFileSync(
+      join(root, "src", "selfhost", "posthog.ts"),
+      "const name = (globalThis as unknown as { process?: { env?: Record<string, string | undefined> } }).process?.env?.POSTHOG_SERVER_NAME;\n",
+    );
+    expect(collectSelfHostEnvVars({ rootDir: root })).toEqual([
+      { name: "POSTHOG_SERVER_NAME", firstReference: "src/selfhost/posthog.ts" },
+    ]);
+  });
+
+  it("REGRESSION (#8627): collects BOTH literal name args of resolveSeverityThreshold", () => {
+    const root = mkdtempSync(join(tmpdir(), "gt-env-reference-severity-"));
+    mkdirSync(join(root, "src", "selfhost"), { recursive: true });
+    // resolveSeverityThreshold(env, repoFullName, "<MIN>", "<REPO_MIN>", ...defaults) reads two env vars whose
+    // names appear only as literals at the call site (args 2 and 3) -- src/selfhost/posthog.ts:81. A single-index
+    // helper map caught at most one; both must be listed.
+    writeFileSync(
+      join(root, "src", "selfhost", "posthog.ts"),
+      'const t = resolveSeverityThreshold(env, repoFullName, "POSTHOG_MIN_SEVERITY", "POSTHOG_REPO_MIN_SEVERITY");\n',
+    );
+    expect(collectSelfHostEnvVars({ rootDir: root })).toEqual([
+      { name: "POSTHOG_MIN_SEVERITY", firstReference: "src/selfhost/posthog.ts" },
+      { name: "POSTHOG_REPO_MIN_SEVERITY", firstReference: "src/selfhost/posthog.ts" },
+    ]);
+  });
+
   it("scans configured JavaScript roots and rejects file-shaped directories", () => {
     const root = fixtureRoot();
 


### PR DESCRIPTION
## Problem

Closes #8627.

The self-host env-reference generator (`scripts/gen-selfhost-env-reference.ts`) failed to list three PostHog env vars that `src/selfhost/posthog.ts` actually reads:

- `POSTHOG_SERVER_NAME` — read at `posthog.ts:179` via `(globalThis as unknown as {...}).process?.env?.POSTHOG_SERVER_NAME`. The `.env` base here is a `.process` **property access**, not a bare `process`/`env` identifier, so `isEnvContainer` walked past it.
- `POSTHOG_MIN_SEVERITY` / `POSTHOG_REPO_MIN_SEVERITY` — passed as two name **literals** to `resolveSeverityThreshold(env, repo, "POSTHOG_MIN_SEVERITY", "POSTHOG_REPO_MIN_SEVERITY")` at `posthog.ts:81`. The literal-arg helper map only supported a single argument index.

## Fix

- `isEnvContainer`: recognize `globalThis.process(.env)` (through casts/parens) as an env container, via a small `isGlobalThisProcess` helper. Generalized — not special-cased to the one literal.
- `ENV_NAME_LITERAL_ARG_HELPERS`: carry **multiple** literal-name arg indices per helper, and register `resolveSeverityThreshold` at args `[2, 3]`. `isEnvNameLiteralArgHelperCall` and the collect handler now iterate all configured indices.

Because the helper fix is general, it also correctly surfaces `PAGERDUTY_MIN_SEVERITY` / `PAGERDUTY_REPO_MIN_SEVERITY` (`src/services/notify-pagerduty.ts:103`, the same helper) — these were missing for the identical reason. The regenerated reference now lists all five, each attributed to its real source file.

## Tests

- Two regression tests in `test/unit/selfhost-env-reference-script.test.ts` (globalThis-cast read; dual-literal `resolveSeverityThreshold`). Reverting either fix fails its test.
- `npm run selfhost:env-reference -- --check` passes with the regenerated reference committed.
- Full existing suite for the generator (8 tests) passes.