### PR TITLE
fix(selfhost): consume the injected central PostHog key as a POSTHOG_API_KEY fallback

### DIFF
--- a/src/selfhost/posthog.ts
+++ b/src/selfhost/posthog.ts
@@ -14,10 +14,12 @@
 //
 // Env-var decision (#8287's own deliverable): POSTHOG_API_KEY/POSTHOG_HOST are the SAME vars #6235's MCP
 // telemetry (src/mcp/telemetry.ts) already reads off the typed Cloudflare Env -- one project key activates
-// both surfaces, the MCP tool-call allowlist (#6228) is untouched. Everything else here (POSTHOG_MIN_SEVERITY,
-// POSTHOG_REPO_MIN_SEVERITY, POSTHOG_ENVIRONMENT, POSTHOG_SERVER_NAME, POSTHOG_RELEASE) is self-host-only,
-// read off real process.env, never added to src/env.d.ts's typed Env, matching that file's precedent for
-// self-host-exclusive config.
+// both surfaces, the MCP tool-call allowlist (#6228) is untouched. POSTHOG_API_KEY additionally falls back to
+// LOOPOVER_CENTRAL_POSTHOG_KEY when unset (#8626) -- the fleet-wide key the hosted control-plane injects into a
+// tenant container; operator-set POSTHOG_API_KEY keeps precedence, this is only a hosted-image fallback source.
+// Everything else here (POSTHOG_MIN_SEVERITY, POSTHOG_REPO_MIN_SEVERITY, POSTHOG_ENVIRONMENT, POSTHOG_SERVER_NAME,
+// POSTHOG_RELEASE, and LOOPOVER_CENTRAL_POSTHOG_KEY) is self-host-only, read off real process.env, never added to
+// src/env.d.ts's typed Env, matching that file's precedent for self-host-exclusive config.
 import { randomUUID } from "node:crypto";
 import { hostname } from "node:os";
 import {
@@ -133,7 +135,12 @@ function operationalProperties(context: Record<string, unknown> | undefined): Re
  *  the SAME var #6235's MCP telemetry reads (env-var decision, #8287). `env` is real process.env, matching
  *  initSentry's identical NodeJS.ProcessEnv shape. */
 export async function initPostHog(env: NodeJS.ProcessEnv): Promise<boolean> {
-  const apiKey = processEnvString(env, "POSTHOG_API_KEY");
+  // #8626: POSTHOG_API_KEY is the operator's own explicit config (highest precedence, unchanged); when it is
+  // unset, fall back to LOOPOVER_CENTRAL_POSTHOG_KEY -- the fleet-wide key the hosted control-plane injects into
+  // a tenant container (control-plane/src/container-driver.ts) so a hosted image reports to the loopover-owned
+  // project without the operator setting anything. A hosted-injected fallback, never a silent override of an
+  // operator's explicit POSTHOG_API_KEY. When neither is set, initPostHog stays a complete no-op (returns false).
+  const apiKey = processEnvString(env, "POSTHOG_API_KEY") ?? processEnvString(env, "LOOPOVER_CENTRAL_POSTHOG_KEY");
   if (!apiKey) return false;
   await loadNodeHasher();
   const { PostHog } = await import("posthog-node");

--- a/test/unit/selfhost-posthog.test.ts
+++ b/test/unit/selfhost-posthog.test.ts
@@ -77,6 +77,25 @@ describe("initPostHog", () => {
     expect(options.enableExceptionAutocapture).toBe(true);
     expect(options.before_send).toBe(scrubPostHogEvent);
   });
+
+  it("falls back to LOOPOVER_CENTRAL_POSTHOG_KEY when POSTHOG_API_KEY is unset (#8626)", async () => {
+    const enabled = await initPostHog({ LOOPOVER_CENTRAL_POSTHOG_KEY: "phc_central" } as unknown as NodeJS.ProcessEnv);
+    expect(enabled).toBe(true);
+    expect(mocks.PostHog).toHaveBeenCalledWith("phc_central", expect.objectContaining({ host: "https://us.i.posthog.com" }));
+  });
+
+  it("keeps POSTHOG_API_KEY's precedence when both it and LOOPOVER_CENTRAL_POSTHOG_KEY are set (#8626)", async () => {
+    const enabled = await initPostHog({ POSTHOG_API_KEY: "phc_operator", LOOPOVER_CENTRAL_POSTHOG_KEY: "phc_central" } as unknown as NodeJS.ProcessEnv);
+    expect(enabled).toBe(true);
+    expect(mocks.PostHog).toHaveBeenCalledWith("phc_operator", expect.anything());
+    expect(mocks.PostHog).not.toHaveBeenCalledWith("phc_central", expect.anything());
+  });
+
+  it("stays a no-op when neither POSTHOG_API_KEY nor LOOPOVER_CENTRAL_POSTHOG_KEY is set (#8626)", async () => {
+    const enabled = await initPostHog({} as unknown as NodeJS.ProcessEnv);
+    expect(enabled).toBe(false);
+    expect(mocks.PostHog).not.toHaveBeenCalled();
+  });
 });
 
 describe("resolvePostHogRelease", () => {


### PR DESCRIPTION
## Summary

The hosted control-plane injects a fleet-wide `LOOPOVER_CENTRAL_POSTHOG_KEY` into each tenant container so the self-host image reports errors to the loopover-owned PostHog project. But `initPostHog()` in `src/selfhost/posthog.ts` only ever read `POSTHOG_API_KEY` — so the injected central key was **never consumed**, and hosted tenant containers reported to nothing.

- `initPostHog()` now resolves the key as `processEnvString(env, "POSTHOG_API_KEY") ?? processEnvString(env, "LOOPOVER_CENTRAL_POSTHOG_KEY")`: the operator's own `POSTHOG_API_KEY` keeps **highest precedence** (unchanged), and the hosted-injected central key is used only as a **fallback** when `POSTHOG_API_KEY` is unset — a hosted-image fallback, never a silent override of an operator's explicit config.
- When **neither** var is set, `initPostHog` still returns `false` and stays a complete no-op — self-host's existing opt-in behavior is unchanged.
- The module's self-host env-var header block is updated to name `LOOPOVER_CENTRAL_POSTHOG_KEY` as a fallback source alongside `POSTHOG_API_KEY`.
- **Consumer-side fix only** — the control-plane injection side is already correct and out of scope (its tests are left passing unmodified).

## Tests

`test/unit/selfhost-posthog.test.ts` (82 pass, +3): the central key activates the client when `POSTHOG_API_KEY` is unset (asserts the client is constructed with the central key); `POSTHOG_API_KEY` still wins when both are set (client uses the operator key, never the central one); neither-set stays a no-op (`false`, client never constructed). These are the exact regression guards against an injected-but-never-consumed env var recurring — both branches of the new fallback covered.

## Validation

- [x] `selfhost-posthog` test file green (82); `tsc` clean on the changed file.
- [x] No behavior change when neither var is set; operator `POSTHOG_API_KEY` precedence preserved.
- [x] No secret/wallet/hotkey/trust/reward terms; control-plane injection side untouched.

Closes #8626