### PR TITLE
fix(scripts): scan packages/*/src/**/*.tsx in the branding-drift check

### DIFF
--- a/scripts/check-branding-drift.ts
+++ b/scripts/check-branding-drift.ts
@@ -34,6 +34,7 @@ export const BRANDING_DRIFT_PATHSPECS = [
   "packages/*/lib/**/*.js",
   "packages/*/lib/**/*.ts",
   "packages/*/src/**/*.ts",
+  "packages/*/src/**/*.tsx",
   "packages/*/scripts/**/*.mjs",
   "apps/*/src/**/*.ts",
   "apps/*/src/**/*.tsx",

--- a/test/unit/check-branding-drift-script.test.ts
+++ b/test/unit/check-branding-drift-script.test.ts
@@ -50,6 +50,24 @@ describe("scanBrandingHits", () => {
     expect(capturedArgs).toContain("apps/*/scripts/**/*.mjs");
   });
 
+  it("scans packages/*/src/**/*.tsx, so ui-kit design-system components are covered like apps/* .tsx are", () => {
+    let capturedArgs: string[] = [];
+    const exec = (_root: string, args: string[]) => {
+      capturedArgs = args;
+      return "";
+    };
+    scanBrandingHits({ root: "/fake", exec });
+
+    expect(capturedArgs).toContain("packages/*/src/**/*.tsx");
+  });
+
+  it("includes a packages/*/src/*.tsx hit in the scanned set (a ui-kit component now in scope)", () => {
+    const exec = () => "packages/loopover-ui-kit/src/card.tsx:1\n";
+    const result = scanBrandingHits({ root: "/fake", exec });
+
+    expect(result).toEqual({ "packages/loopover-ui-kit/src/card.tsx": 1 });
+  });
+
   // Real regression guard, mirroring check-manifest-drift-script.test.ts's own real-repo-state test: proves
   // the actual defaultExec (real `git grep` subprocess, real exit-1-means-empty handling) works against this
   // repo's real tracked files, not just the injected fake above.


### PR DESCRIPTION
fix(scripts): scan packages/*/src/**/*.tsx in the branding-drift check

The BRANDING_DRIFT_PATHSPECS listed both .ts and .tsx for the apps/*
scope but only .ts for packages/*, despite the header framing
packages/*/src as mirroring apps/*. That left the 48 loopover-ui-kit
.tsx design-system components — the repo's highest-reuse UI surface —
outside the git-grep scan, so a reintroduced pre-rebrand string in any
of them would never trip the check (the exact class of bug #6786).

Add the missing packages/*/src/**/*.tsx pathspec. No packages .tsx file
currently contains a flagged string, so the baseline is unchanged.

Closes #8657

