### PR TITLE
fix(api): enforce PR ownership on the ai-review-findings REST route

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -228,7 +228,7 @@ import { evaluateEscalation } from "../loop-escalation";
 import { buildResultsPayload } from "../results-payload";
 import { buildProgressSnapshot } from "../loop-progress";
 import { validateIdeaSubmission, buildTaskGraph, buildClaimPlan } from "../idea-intake";
-import { loadPrAiReviewFindings } from "../mcp/pr-ai-review-findings";
+import { loadPrAiReviewFindings, assertContributorOwnsPullRequest } from "../mcp/pr-ai-review-findings";
 import {
   buildMcpCompatibilityMetadata,
   LATEST_RECOMMENDED_MCP_VERSION,
@@ -3463,6 +3463,17 @@ export function createApp() {
     if (!login) return c.json({ error: "login_required" }, 400);
     const unauthorized = await requireContributorAccess(c, login);
     if (unauthorized) return unauthorized;
+    // requireContributorAccess only proves the caller IS `login`; it does not prove `login` authored this PR.
+    // Mirror the MCP tool's guard order (server.ts getPrAiReviewFindings) so the REST surface can't leak another
+    // contributor's AI-review findings: 404 when the PR doesn't exist, 403 when it exists but belongs to someone
+    // else (#8659).
+    const pullRequest = await getPullRequest(c.env, fullName, number);
+    if (!pullRequest) return c.json({ error: "not_found" }, 404);
+    try {
+      assertContributorOwnsPullRequest(pullRequest.authorLogin, login);
+    } catch {
+      return c.json({ error: "forbidden" }, 403);
+    }
     return c.json(await loadPrAiReviewFindings(c.env, { repoFullName: fullName, pullNumber: number, login }));
   });
 

--- a/test/unit/routes-pr-ai-review-findings.test.ts
+++ b/test/unit/routes-pr-ai-review-findings.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { createApp } from "../../src/api/routes";
-import { markAiReviewPublished, putCachedAiReview, upsertRepositoryFromGitHub } from "../../src/db/repositories";
+import { markAiReviewPublished, putCachedAiReview, upsertPullRequestFromGitHub, upsertRepositoryFromGitHub } from "../../src/db/repositories";
 import { upsertRepoFocusManifest } from "../../src/signals/focus-manifest-loader";
 import { createTestEnv } from "../helpers/d1";
 
@@ -8,13 +8,16 @@ import { createTestEnv } from "../helpers/d1";
 // loopover_get_pr_ai_review_findings MCP tool. The route validates, gates on requireContributorAccess, then
 // delegates to loadPrAiReviewFindings (whose own logic is covered by pr-ai-review-findings.test.ts). These
 // tests therefore pin the ROUTE's contract: each delegated status passes through, and every guard branch
-// (invalid number, missing login, non-owning login) is rejected before any data is read.
+// (invalid number, missing login, non-owning/non-existent PR) is rejected before any data is read.
 const apiHeaders = (env: Env) => ({ authorization: `Bearer ${env.LOOPOVER_API_TOKEN}` });
 const PATH = "/v1/repos/acme/widgets/pulls/11/ai-review-findings";
 
-async function seedRepo(env: Env, aiReviewMode: string) {
+// Seed PR #11 authored by the requesting login (miner1) so the ownership guard (#8659) passes and the pass-through
+// tests reach loadPrAiReviewFindings; individual tests override the author when they need a 403.
+async function seedRepo(env: Env, aiReviewMode: string, prAuthor = "miner1") {
   await upsertRepositoryFromGitHub(env, { name: "widgets", full_name: "acme/widgets", private: false, owner: { login: "acme" } });
   await upsertRepoFocusManifest(env, "acme/widgets", { settings: { aiReviewMode } });
+  await upsertPullRequestFromGitHub(env, "acme/widgets", { number: 11, title: "PR 11", state: "open", user: { login: prAuthor }, head: { sha: "sha-1" }, labels: [], body: "x" });
 }
 
 describe("GET /v1/repos/:owner/:repo/pulls/:number/ai-review-findings (#6619)", () => {
@@ -108,5 +111,32 @@ describe("GET /v1/repos/:owner/:repo/pulls/:number/ai-review-findings (#6619)", 
     const response = await app.request(`${PATH}?login=miner1`, { headers: apiHeaders(env) }, env);
     const text = JSON.stringify(await response.json());
     expect(text).not.toMatch(/wallet|hotkey|coldkey|trust score|reward estimate/i);
+  });
+
+  it("403s a caller requesting a PR authored by someone else, without leaking its findings (#8659)", async () => {
+    // The caller's own session matches `login=miner1`, but PR #11 was authored by other-miner. The route must
+    // apply the same ownership guard the MCP tool does and reject with 403 -- not return the other author's data.
+    const app = createApp();
+    const env = createTestEnv();
+    await seedRepo(env, "advisory", "other-miner");
+    await putCachedAiReview(env, "acme/widgets", 11, "sha-1", "advisory", { notes: "Private review.", reviewerCount: 1 });
+    await markAiReviewPublished(env, "acme/widgets", 11, "sha-1");
+
+    const response = await app.request(`${PATH}?login=miner1`, { headers: apiHeaders(env) }, env);
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: "forbidden" });
+  });
+
+  it("404s when the target PR does not exist, distinct from the 403 for a wrong-author PR (#8659)", async () => {
+    // Repo seeded, AI review on, but no PR #99 record: the ownership guard fetches the PR first, so a missing PR
+    // is a 404, kept distinct from the 403 an existing-but-not-yours PR returns.
+    const app = createApp();
+    const env = createTestEnv();
+    await upsertRepositoryFromGitHub(env, { name: "widgets", full_name: "acme/widgets", private: false, owner: { login: "acme" } });
+    await upsertRepoFocusManifest(env, "acme/widgets", { settings: { aiReviewMode: "advisory" } });
+
+    const response = await app.request(`/v1/repos/acme/widgets/pulls/99/ai-review-findings?login=miner1`, { headers: apiHeaders(env) }, env);
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: "not_found" });
   });
 });


### PR DESCRIPTION
## What & why

Closes #8659.

`GET /v1/repos/:owner/:repo/pulls/:number/ai-review-findings` (`src/api/routes.ts`) only called `requireContributorAccess(c, login)` — which verifies the caller's session matches the `login` query param, **not** that `login` authored the target PR — then delegated straight to `loadPrAiReviewFindings`. Neither the route nor `loadPrAiReviewFindings` performs an ownership check.

**Consequence:** any authenticated contributor, passing their own login, could query this endpoint for *any* PR number in any repo they can read and receive that PR's structured AI-review findings (file paths, line numbers, severity, review body). The equivalent **MCP tool** (`server.ts` `getPrAiReviewFindings`) already blocks this exact pattern via `getPullRequest` + `assertContributorOwnsPullRequest`; the REST surface for the identical data did not.

## The fix

Mirror the MCP tool's guard order on the REST route, before `loadPrAiReviewFindings` runs:
- fetch the PR with `getPullRequest`; **404** `{ error: "not_found" }` when it doesn't exist;
- `assertContributorOwnsPullRequest(pullRequest.authorLogin, login)` — **403** `{ error: "forbidden" }` when the PR exists but belongs to another author.

No change to `loadPrAiReviewFindings` or any other route.

## Tests

- **403:** PR #11 authored by `other-miner`, requested as session-authenticated `miner1` → 403, no findings leaked (previously 200 with real data).
- **404:** repo seeded, AI review on, but no PR #99 record → 404, distinct from the 403.
- The existing pass-through tests (`ready` / `not_found` / `ai_review_off`) now seed the requesting login's own PR so they still reach the delegate through the new ownership guard.

Verified bug-catching: reverting the guard makes both the 403 and 404 tests fail (the leak reproduces).

## Validation

- `test/unit/routes-pr-ai-review-findings.test.ts`: **10 tests pass**; typecheck clean; `git diff --check` clean.
- **100% of the changed source lines and branches covered** (measured on the diff).
- Branched off current `main`, mergeable-clean.