### PR TITLE
fix(review): delegate merge-train low-signal classification to canonical path-matchers (#8647)

### DIFF
--- a/src/review/merge-train.ts
+++ b/src/review/merge-train.ts
@@ -19,6 +19,8 @@
 // acceptable, bounded tradeoff given the 24h staleness cap already prevents an abandoned PR from blocking
 // forever.
 
+import { isLockfile } from "../signals/path-matchers";
+
 /** The subset of a sibling PR's fields this gate actually needs -- kept minimal and independent of
  *  `PullRequestRecord`'s full shape so this module has zero import surface beyond plain data. */
 export type MergeTrainSibling = {
@@ -43,17 +45,19 @@ export const MERGE_TRAIN_MAX_WAIT_MS = 24 * 60 * 60 * 1000;
 
 export type MergeTrainDecision = { wait: true; blockingPr: number } | { wait: false };
 
-/** Low-priority path buckets (lockfiles, generated/build output, dist/ artifacts) that overlapping alone
- *  never counts as real conflict risk -- ported from `review-grounding.ts`'s `diffFilePriority` classification
- *  (bucket 4, "least useful to review") so this module stays dependency-free rather than importing a whole
- *  review-pipeline module for one number. Kept as a small, explicit suffix/name list rather than a generic
- *  "some overlap" check: a shared `package-lock.json` or `dist/bundle.js` touch is routine noise, not the
- *  same-area conflict risk this gate exists to catch. */
-const LOW_SIGNAL_FILENAME_RE = /(?:^|\/)(?:package-lock\.json|yarn\.lock|pnpm-lock\.yaml|Cargo\.lock)$/i;
-const LOW_SIGNAL_DIR_RE = /(?:^|\/)(?:dist|build|coverage|node_modules)\//i;
+/** Low-priority path buckets (lockfiles, generated/build output, vendored third-party trees) that overlapping
+ *  alone never counts as real conflict risk. Lockfile-NAME matching delegates to the canonical `isLockfile`
+ *  helper -- a dependency-free leaf utility in path-matchers.ts, the same delegation `review-diff.ts` and
+ *  `review-grounding.ts` already use -- so this classification never drifts behind the 24+ canonical lockfile
+ *  formats the way the hand-rolled 4-name regex did (a shared `poetry.lock`, `go.sum`, or `npm-shrinkwrap.json`
+ *  was wrongly treated as real overlap; #8647). The directory bucket mirrors the same canonical generated/
+ *  vendored set: build output (`dist`/`build`/`out`/`coverage`) and installed/vendored dependency trees
+ *  (`node_modules` and the `vendor`/`third_party` family). A shared `package-lock.json` or `third_party/x`
+ *  touch is routine noise, not the same-area conflict risk this gate exists to catch. */
+const LOW_SIGNAL_DIR_RE = /(?:^|\/)(?:dist|build|out|coverage|node_modules|vendor|vendored|third_party|third-party|bower_components|jspm_packages)\//i;
 
 function isMeaningfulPath(path: string): boolean {
-  return !LOW_SIGNAL_FILENAME_RE.test(path) && !LOW_SIGNAL_DIR_RE.test(path);
+  return !isLockfile(path) && !LOW_SIGNAL_DIR_RE.test(path);
 }
 
 /** True when `thisPr` and `sibling` overlap enough to carry real conflict/duplicate-effort risk: a shared

--- a/test/unit/merge-train.test.ts
+++ b/test/unit/merge-train.test.ts
@@ -132,6 +132,18 @@ describe("shouldWaitForOlderSiblings (#selfhost-merge-train)", () => {
       expect(decide(110, "2026-07-07T11:00:00.000Z", siblings, NOW, { thisPrLinkedIssues: [1], thisPrChangedFiles: ["package-lock.json", "dist/bundle.js"] })).toEqual({ wait: false });
     });
 
+    it("does NOT treat a shared non-npm canonical lockfile (poetry.lock/go.sum) as meaningful overlap (#8647)", () => {
+      // The hand-rolled 4-name regex only knew package-lock/yarn/pnpm/Cargo, so these forced a spurious wait;
+      // delegating to the canonical isLockfile covers all 24+ formats.
+      const siblings: MergeTrainSibling[] = [{ number: 105, createdAt: "2026-07-07T10:00:00.000Z", linkedIssues: [99], changedFiles: ["poetry.lock", "backend/go.sum"] }];
+      expect(decide(110, "2026-07-07T11:00:00.000Z", siblings, NOW, { thisPrLinkedIssues: [1], thisPrChangedFiles: ["poetry.lock", "backend/go.sum"] })).toEqual({ wait: false });
+    });
+
+    it("does NOT treat a shared vendored-directory path (vendor/third_party) as meaningful overlap (#8647)", () => {
+      const siblings: MergeTrainSibling[] = [{ number: 105, createdAt: "2026-07-07T10:00:00.000Z", linkedIssues: [99], changedFiles: ["vendor/lib/x.go", "third_party/pkg/y.js"] }];
+      expect(decide(110, "2026-07-07T11:00:00.000Z", siblings, NOW, { thisPrLinkedIssues: [1], thisPrChangedFiles: ["vendor/lib/x.go", "third_party/pkg/y.js"] })).toEqual({ wait: false });
+    });
+
     it("a sibling with no linkedIssues field at all (undefined) can still match via a shared changed file", () => {
       const siblings: MergeTrainSibling[] = [{ number: 105, createdAt: "2026-07-07T10:00:00.000Z", changedFiles: ["src/a.ts"] }];
       expect(decide(110, "2026-07-07T11:00:00.000Z", siblings, NOW, { thisPrLinkedIssues: [1], thisPrChangedFiles: ["src/a.ts"] })).toEqual({ wait: true, blockingPr: 105 });


### PR DESCRIPTION
## Problem

Closes #8647.

`src/review/merge-train.ts:52-53` hand-rolled its own low-signal file/directory detection that had drifted from the canonical pattern its sibling files already use:

- `LOW_SIGNAL_FILENAME_RE` matched only `package-lock.json|yarn.lock|pnpm-lock.yaml|Cargo.lock` (4 names), versus the canonical `LOCKFILE_NAMES` set (24+ entries incl. `npm-shrinkwrap.json`, `poetry.lock`, `go.sum`, `bun.lock`, `composer.lock`, …). Two PRs sharing only, say, a `poetry.lock` or `go.sum` were treated as a real overlap and forced into a spurious merge-train wait.
- `LOW_SIGNAL_DIR_RE` matched only `dist|build|coverage|node_modules`, missing `out` and the vendored-code family (`vendor|vendored|third_party|bower_components|jspm_packages`).

`review-diff.ts` and `review-grounding.ts` already delegate lockfile-name matching to the canonical `isLockfile()`; `merge-train.ts` was the holdout, out of a mistaken concern that importing it would pull in a whole review-pipeline module — `isLockfile` is a dependency-free leaf utility.

## Fix

- Replace the hand-rolled `LOW_SIGNAL_FILENAME_RE` with the canonical `isLockfile()` from `path-matchers.ts` (imported the same way the sibling files do), covering all 24+ lockfile formats and never drifting again.
- Extend `LOW_SIGNAL_DIR_RE` to the canonical generated/vendored set: adds `out` and `vendor|vendored|third_party|third-party|bower_components|jspm_packages`.

All 4 originals remain covered (`cargo.lock` is in `LOCKFILE_NAMES`, matched case-insensitively via `normalizeForMatch`), so there is no regression.

## Tests

Two new tests in `test/unit/merge-train.test.ts` mirror the existing lockfile/`dist` case:
- Two PRs sharing only `poetry.lock` + `go.sum` decide `{wait: false}` (previously `{wait: true}`).
- Two PRs sharing only `vendor/…` + `third_party/…` decide `{wait: false}` (previously `{wait: true}`).

Reverting either source change makes its test fail. All 27 tests pass; `git diff --check` clean.