### PR TITLE
fix(ci): stop setup-workspace citing the removed validate-tests-merge job

### DIFF
--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -1,8 +1,8 @@
 name: Setup workspace
 description: >-
   Strip untrusted npm config, set up Node, and restore/install/save the fork/trusted-scoped
-  node_modules cache. Extracted from ci.yml's validate-code, validate-tests, and validate-tests-merge
-  jobs, which had this exact sequence copy-pasted three times -- the same kind of drift that caused a
+  node_modules cache. Extracted from ci.yml's validate-code and validate-tests jobs, which had this
+  exact sequence copy-pasted at each site -- the same kind of drift that caused a
   real cache-key mismatch bug this repo already hit once (two jobs' Turborepo cache pair silently
   diverged when one was edited and the other wasn't). This doesn't fix that specific bug on its own,
   but a future change to this sequence now only needs to happen here, not be remembered at every call
@@ -13,9 +13,10 @@ description: >-
 inputs:
   save-cache:
     description: >-
-      Whether to save the node_modules cache after a successful install. validate-tests-merge sets
-      this to "false" -- it only ever reads the cache validate-code/validate-tests already populate,
-      never writes to it, so a save here would just be redundant work.
+      Whether to save the node_modules cache after a successful install (default "true"). A
+      general-purpose escape hatch: set it to "false" in a job that should only ever read a cache
+      another job already populated and never write one -- a save there would just be redundant work.
+      No current caller overrides the default; every live caller both restores and saves.
     required: false
     default: "true"
 


### PR DESCRIPTION
## What

`.github/actions/setup-workspace/action.yml`'s header comment and its `save-cache` input
description both cited a `validate-tests-merge` job that no longer exists — it was folded into
`validate-tests` during the 2026-07-24 CI unsharding consolidation (see `ci.yml:958`: "the separate
`validate-tests-merge` job now just... runs here").

## Choice made and why

**Kept the `save-cache` input and rewrote its stale documentation** (rather than deleting it). The
input is a genuine general-purpose escape hatch: a future read-only cache-consumer job would set
`save-cache: "false"` to avoid a redundant save. Keeping it preserves that capability, and a
comments-only edit carries zero runtime risk to a load-bearing shared action.

- Header comment: now says the sequence was extracted from `validate-code` and `validate-tests`
  (the two current callers), dropping the removed third job.
- `save-cache` description: now describes its real current purpose — a default-`"true"` escape hatch
  for a read-only consumer — and notes no live caller overrides the default.

## Caller safety (grep-confirmed)

`save-cache` is referenced only inside `action.yml` itself:

```
$ grep -rn "save-cache" .github/
.github/actions/setup-workspace/action.yml:14:  save-cache:
.github/actions/setup-workspace/action.yml:79:      if: ${{ inputs.save-cache == 'true' && ... }}
```

None of the 5 current callers (`ci.yml` ×2, `orb-stable-release-pr.yml`, `package-release-watch.yml`,
`orb-beta-release.yml`, `mcp-release-watch.yml`) pass `save-cache`, so all keep the `"true"` default.
The input's runtime (line 79) is untouched — behavior is identical for every caller.

## Test coverage

CI-configuration/documentation-only change with no application-code behavioral change; per the issue,
the verification is the grep-based caller check above. YAML parses and `prettier --check` passes.

Closes #8693
