### PR TITLE
fix(services): set finalAttempt in the e2e-test-gen and linked-issue-satisfaction retry loops

### DIFF
--- a/src/services/ai-e2e-test-gen.ts
+++ b/src/services/ai-e2e-test-gen.ts
@@ -197,12 +197,19 @@ async function runWorkersE2eTestGen(env: Env, system: string, user: string, maxT
   if (!ai || typeof ai.run !== "function") return { testSource: null };
   const gatewayId = env.AI_GATEWAY_ID?.trim();
   const extra: AiGatewayOptions | undefined = gatewayId ? { gateway: { id: gatewayId } } : undefined;
-  for (const model of E2E_TEST_GEN_MODELS) {
+  for (const [modelIndex, model] of E2E_TEST_GEN_MODELS.entries()) {
     for (let attempt = 0; attempt < E2E_TEST_GEN_ATTEMPTS_PER_MODEL; attempt += 1) {
       try {
         const result = await ai.run(
           model,
-          { max_tokens: maxTokens, temperature: 0, messages: [{ role: "system", content: system }, { role: "user", content: user }] },
+          {
+            max_tokens: maxTokens,
+            temperature: 0,
+            messages: [{ role: "system", content: system }, { role: "user", content: user }],
+            // Only the truly final attempt (last model, last attempt) stays Sentry-visible (error); earlier
+            // attempts are about to be retried, so log them quietly (warn) per selfhost/ai.ts's contract (#8673).
+            finalAttempt: attempt === E2E_TEST_GEN_ATTEMPTS_PER_MODEL - 1 && modelIndex === E2E_TEST_GEN_MODELS.length - 1,
+          },
           extra,
         );
         const parsed = parseE2eTestGenResponse(coerceAiText(result));

--- a/src/services/linked-issue-satisfaction-run.ts
+++ b/src/services/linked-issue-satisfaction-run.ts
@@ -83,12 +83,19 @@ async function runWorkersSatisfactionOpinion(
   if (!ai || typeof ai.run !== "function") return { result: null };
   const gatewayId = env.AI_GATEWAY_ID?.trim();
   const extra: AiGatewayOptions | undefined = gatewayId ? { gateway: { id: gatewayId } } : undefined;
-  for (const model of LINKED_ISSUE_SATISFACTION_MODELS) {
+  for (const [modelIndex, model] of LINKED_ISSUE_SATISFACTION_MODELS.entries()) {
     for (let attempt = 0; attempt < LINKED_ISSUE_SATISFACTION_ATTEMPTS_PER_MODEL; attempt += 1) {
       try {
         const raw = await ai.run(
           model,
-          { max_tokens: maxTokens, temperature: 0, messages: [{ role: "system", content: system }, { role: "user", content: user }] },
+          {
+            max_tokens: maxTokens,
+            temperature: 0,
+            messages: [{ role: "system", content: system }, { role: "user", content: user }],
+            // Only the truly final attempt (last model, last attempt) stays Sentry-visible (error); earlier
+            // attempts are about to be retried, so log them quietly (warn) per selfhost/ai.ts's contract (#8673).
+            finalAttempt: attempt === LINKED_ISSUE_SATISFACTION_ATTEMPTS_PER_MODEL - 1 && modelIndex === LINKED_ISSUE_SATISFACTION_MODELS.length - 1,
+          },
           extra,
         );
         const text = coerceAiText(raw);

--- a/test/unit/ai-e2e-test-gen.test.ts
+++ b/test/unit/ai-e2e-test-gen.test.ts
@@ -532,4 +532,30 @@ describe("runWorkersE2eTestGen (internal)", () => {
     const env = createTestEnv({});
     await expect(runWorkersE2eTestGen(env, "system", "user", 1024)).resolves.toEqual({ testSource: null });
   });
+
+  it("passes finalAttempt:false on a retried attempt so it logs at warn, not error (#8673)", async () => {
+    // Fail on the first attempt, succeed on the second: the first (retried) attempt must carry finalAttempt:false
+    // so selfhost/ai.ts logs it quietly (warn), not as a Sentry-visible error.
+    let call = 0;
+    const run = vi.fn(async () => {
+      call += 1;
+      if (call === 1) throw new Error("transient");
+      return { response: JSON.stringify(["import { test } from '@playwright/test';"]) };
+    });
+    const env = enabledEnv(run);
+    await runWorkersE2eTestGen(env, "system", "user", 1024);
+    expect(((run.mock.calls[0] as unknown[])[1] as { finalAttempt?: boolean }).finalAttempt).toBe(false);
+  });
+
+  it("passes finalAttempt:true only on the truly final attempt (last model, last attempt) (#8673)", async () => {
+    // Every call fails: 2 models × 3 attempts = 6 calls; only the last (6th) is the final attempt and stays loud.
+    const run = vi.fn(async () => {
+      throw new Error("always fails");
+    });
+    const env = enabledEnv(run);
+    await runWorkersE2eTestGen(env, "system", "user", 1024);
+    expect(run).toHaveBeenCalledTimes(6);
+    const finalFlags = run.mock.calls.map((c) => ((c as unknown[])[1] as { finalAttempt?: boolean }).finalAttempt);
+    expect(finalFlags).toEqual([false, false, false, false, false, true]);
+  });
 });

--- a/test/unit/linked-issue-satisfaction-run.test.ts
+++ b/test/unit/linked-issue-satisfaction-run.test.ts
@@ -308,6 +308,30 @@ describe("runLoopOverLinkedIssueSatisfaction gating + fail-safe", () => {
       .first<{ actor: string | null }>();
     expect(row?.actor).toBeNull();
   });
+
+  it("passes finalAttempt:false on a retried attempt so it logs at warn, not error (#8673)", async () => {
+    // Fail once then succeed: the first (retried) attempt must carry finalAttempt:false so selfhost/ai.ts logs
+    // it quietly (warn) rather than as a Sentry-visible error.
+    let call = 0;
+    const run = vi.fn(async () => {
+      call += 1;
+      if (call === 1) throw new Error("transient");
+      return { response: satisfactionJson({ status: "addressed" }) };
+    });
+    await runLoopOverLinkedIssueSatisfaction(enabledEnv(run), baseInput);
+    expect(((run.mock.calls[0] as unknown[])[1] as { finalAttempt?: boolean }).finalAttempt).toBe(false);
+  });
+
+  it("passes finalAttempt:true only on the truly final attempt (last model, last attempt) (#8673)", async () => {
+    // Every call fails with a non-rate-limit error: 2 models × 3 attempts = 6 calls; only the last stays loud.
+    const run = vi.fn(async () => {
+      throw new Error("always fails");
+    });
+    await runLoopOverLinkedIssueSatisfaction(enabledEnv(run), baseInput);
+    expect(run).toHaveBeenCalledTimes(6);
+    const finalFlags = run.mock.calls.map((c) => ((c as unknown[])[1] as { finalAttempt?: boolean }).finalAttempt);
+    expect(finalFlags).toEqual([false, false, false, false, false, true]);
+  });
 });
 
 describe("runLinkedIssueSatisfactionForAdvisory (processor wiring, #1961/#3906)", () => {


### PR DESCRIPTION
## What & why

Closes #8673.

`selfhost/ai.ts` logs a failed `ai.run()` at **error** (Sentry-visible) unless the caller passes `finalAttempt: false` — reserving the loud path for genuinely single-shot callers; a retried attempt should log at quiet **warn**. `ai-slop.ts`, `ai-review.ts`, and `issue-plan-draft.ts` all correctly compute `finalAttempt = last-attempt && last-model` on their multi-attempt loops.

`ai-e2e-test-gen.ts` and `linked-issue-satisfaction-run.ts` run the identical **2-model × 3-attempt** retry loop but **never set `finalAttempt`**. Per the contract, an unset value means single-shot → always loud. So every transient failure that eventually succeeds on a later retry still logged a Sentry-visible `error` for each earlier attempt in these two features — an observability/noise bug (inflated Sentry error volume), not a functional one.

## The fix

Compute `finalAttempt: attempt === ATTEMPTS_PER_MODEL - 1 && modelIndex === MODELS.length - 1` on both `ai.run()` calls (using `.entries()` to get the model index), matching the sibling files. Behavior-neutral for retry/fallback; only the **log level** of retried attempts changes (error → warn).

## Tests (per function, mirroring ai-slop's convention)

- **warn-on-retry:** fail once then succeed → the first (retried) call carries `finalAttempt: false`.
- **error-on-final:** every call fails → 2×3 = 6 calls, and only the last carries `finalAttempt: true` (`[false,false,false,false,false,true]`).

Verified bug-catching: removing either `finalAttempt` line fails that file's tests.

## Validation

- `ai-e2e-test-gen.test.ts` + `linked-issue-satisfaction-run.test.ts`: **111 tests pass**; typecheck clean; **100% of changed lines/branches covered**.
- Branched off current `main`, mergeable-clean.