### PR TITLE
fix(orb): correct two false 'private to this file' location comments

### DIFF
--- a/src/queue/review-evasion.ts
+++ b/src/queue/review-evasion.ts
@@ -2,9 +2,11 @@
 // the file's own module-split sequence, after transient-locks.ts, signal-snapshot.ts,
 // duplicate-detection.ts, and slop-detection.ts). Only the top-level "maybe*" entry points are
 // exported (each called from exactly one webhook-handler call site still in processors.ts) -- every other
-// function/type/constant here (withPrActuationLock, evaluateCloseEnforcementGate, hasMaintainerOrOwnerPermission,
-// the "close*If*" implementations, ReopenRecloseOutcome, REVIEW_EVASION_CLOSED_EVENT_TYPE) is private to this
-// file, since none of them had any caller outside this cluster in the original file either.
+// function/constant here (withPrActuationLock, evaluateCloseEnforcementGate, hasMaintainerOrOwnerPermission,
+// the "close*If*" implementations, REVIEW_EVASION_CLOSED_EVENT_TYPE) is private to this file, since none of
+// them had any caller outside this cluster in the original file either. The one exception is the exported
+// `ReopenRecloseOutcome` type, which processors.ts imports and consumes -- reshaping it needs a cross-file
+// impact check there.
 // maybeCloseSynchronizeAmendment (#synchronize-close-policy) is a later, 6th addition alongside the original
 // 5 extracted here -- same shape and reasoning as its siblings, added directly to this module rather than
 // growing processors.ts again.

--- a/src/review/linked-issue-label-propagation-fetch.ts
+++ b/src/review/linked-issue-label-propagation-fetch.ts
@@ -41,7 +41,7 @@ type MaintainerCheckResult = "maintainer" | "not_maintainer" | "inconclusive";
 /** Whether `login` holds a maintainer-equivalent permission on `repoFullName` -- the literal repo owner,
  *  a fleet-operator in the global `ADMIN_GITHUB_LOGINS` allowlist, or a live GitHub collaborator with
  *  admin/maintain/write access (#priority-linked-issue-gate-ownership). Mirrors
- *  `hasMaintainerOrOwnerPermission` in `src/queue/processors.ts` (kept as its own copy here rather than
+ *  `hasMaintainerOrOwnerPermission` in `src/queue/review-evasion.ts` (kept as its own copy here rather than
  *  imported, since that one is private to a file this module's header comment explicitly must NOT pull
  *  into its import graph -- see the file-level comment above). A CONFIRMED answer (including a 404,
  *  `getRepositoryCollaboratorPermission`'s real "not a collaborator" signal) resolves deterministically;


### PR DESCRIPTION
Fixes #8650

## Root cause

Two module comments make checkable, false location claims:

1. `src/queue/review-evasion.ts`'s header listed `ReopenRecloseOutcome` among names "private to this file, since none of them had any caller outside this cluster." But `export type ReopenRecloseOutcome` (line 333) is imported by `src/queue/processors.ts:403` and consumed at `processors.ts:6175`. Every *other* name in that parenthetical is correctly unexported — only this one broke the stated invariant, so a future contributor reshaping the type could reasonably skip the cross-file impact check `processors.ts` actually requires.

2. `src/review/linked-issue-label-propagation-fetch.ts:44` said its local copy "Mirrors `hasMaintainerOrOwnerPermission` in `src/queue/processors.ts`" — but that function lives in `src/queue/review-evasion.ts:553` (unexported), not `processors.ts`.

## Fix

- Removed `ReopenRecloseOutcome` from `review-evasion.ts`'s "private to this file" list and added a note that it is exported and consumed by `processors.ts`, so reshaping it needs a cross-file impact check there.
- Corrected the `linked-issue-label-propagation-fetch.ts` comment to name `review-evasion.ts` as the real location.

Both are comment-only; no behavioral change.

## Verification of the corrected claims

```
$ grep -n "export type ReopenRecloseOutcome" src/queue/review-evasion.ts
333:export type ReopenRecloseOutcome = "reclosed" | "allowed";
$ grep -n "ReopenRecloseOutcome" src/queue/processors.ts
403:  type ReopenRecloseOutcome,
6175:    const reopenOutcome: ReopenRecloseOutcome =
$ grep -rn "function hasMaintainerOrOwnerPermission" src/queue/*.ts
src/queue/review-evasion.ts:553:async function hasMaintainerOrOwnerPermission(...)
```

## Coverage

Per the issue: a doc/comment-accuracy fix with no behavioral change and no new runtime branch, so no test is required. The diff adds no coverable source lines, so `codecov/patch` is not affected. Both changed files are imported by existing `test/**` suites (e.g. `agent-action-executor.test.ts`, `linked-issue-label-propagation-fetch.test.ts`), so the scoped CI run still exercises `src/**`.

## Validation

- `npm run typecheck` clean; branch cut from current `main`; `git diff --check` clean
