### PR TITLE
fix(orb): add 3 documented maintainer-session routes to the path allowlist

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -6114,6 +6114,9 @@ function canSessionAccessPath(env: Env, identity: Extract<AuthIdentity, { kind: 
   if (isRepoOutcomeCalibrationPath(path)) return true;
   if (isRepoGatePrecisionPath(path)) return true;
   if (isRepoMaintainerNoisePath(path)) return true;
+  if (isRepoAutomationStatePath(path)) return true; // #8653: route's requireRepoMaintainer enforces per-repo authority
+  if (isRepoAmsMinerCohortPath(path)) return true; // #8653: route's requireRepoMaintainer enforces per-repo authority
+  if (isRepoChatQaPath(path)) return true; // #8653: route's requireRepoMaintainer enforces per-repo authority
   if (isRepoSelftuneOverridesPath(path)) return true;
   if (isRepoSettingsPreviewPath(path)) return true;
   if (isRepoOnboardingPackPreviewPath(path)) return true;
@@ -6152,6 +6155,24 @@ function isRepoGatePrecisionPath(path: string): boolean {
 
 function isRepoMaintainerNoisePath(path: string): boolean {
   return /^\/v1\/repos\/[^/]+\/[^/]+\/maintainer-noise$/.test(path);
+}
+
+// #8653: three maintainer-session routes documented themselves as reachable by a maintainer's browser panel
+// (automation-state "Maintainer-gated like /settings", ams-miner-cohort "mirrors maintainer-noise",
+// pulls/:number/chat-qa "exposes ... to apps/loopover-ui's maintainer panel") but were missing from this
+// allowlist, so a real non-operator maintainer session hit the coarse 403 before the handler's own
+// requireRepoMaintainer/requireRepoWriteAccess guard could admit them. Each route's own guard still enforces
+// per-repo authority (a maintainer of A reaching B → 403 forbidden_repo).
+function isRepoAutomationStatePath(path: string): boolean {
+  return /^\/v1\/repos\/[^/]+\/[^/]+\/automation-state$/.test(path);
+}
+
+function isRepoAmsMinerCohortPath(path: string): boolean {
+  return /^\/v1\/repos\/[^/]+\/[^/]+\/ams-miner-cohort$/.test(path);
+}
+
+function isRepoChatQaPath(path: string): boolean {
+  return /^\/v1\/repos\/[^/]+\/[^/]+\/pulls\/[^/]+\/chat-qa$/.test(path);
 }
 
 // #6168: let a browser (session) maintainer reach the self-tune override admin routes; the route's own

--- a/test/unit/access-boundary.test.ts
+++ b/test/unit/access-boundary.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createApp } from "../../src/api/routes";
 import { createSessionForGitHubUser } from "../../src/auth/security";
-import { upsertInstallation, upsertRepositoryFromGitHub } from "../../src/db/repositories";
+import { upsertInstallation, upsertPullRequestFromGitHub, upsertRepositoryFromGitHub } from "../../src/db/repositories";
 import { createTestEnv } from "../helpers/d1";
 
 // The miner ⊕ maintainer access boundary, locked against regression.
@@ -80,6 +80,52 @@ describe("access boundary: per-repo maintainer data is repo-scoped", () => {
     const own = await app.request("/v1/repos/alice/repo-a/agent/pending-actions", { headers: { cookie } }, env);
     expect(own.status).toBe(200);
     await expect(own.json()).resolves.toMatchObject({ repoFullName: "alice/repo-a", pendingActions: [] });
+  });
+
+  // #8653: three maintainer-session routes were missing from canSessionAccessPath, so a maintainer's own
+  // browser session hit the coarse 403 before the route's own guard could admit it. Each route's guard still
+  // scopes per-repo (maintainer of A → 403 forbidden_repo on B).
+  it("a maintainer can REACH automation-state on their OWN repo, scoped per-repo (allowlist parity with /settings)", async () => {
+    const { app, env } = await setup();
+    const { token } = await createSessionForGitHubUser(env, { login: "alice", id: 101 });
+    const cookie = `loopover_session=${token}`;
+    expect((await app.request("/v1/repos/alice/repo-a/automation-state", { headers: { cookie } }, env)).status).toBe(200);
+    const other = await app.request("/v1/repos/bob/repo-b/automation-state", { headers: { cookie } }, env);
+    expect(other.status).toBe(403);
+    expect(await other.json()).toMatchObject({ error: "forbidden_repo" });
+  });
+
+  it("a maintainer can REACH ams-miner-cohort on their OWN repo, scoped per-repo (allowlist parity with maintainer-noise)", async () => {
+    const { app, env } = await setup();
+    const { token } = await createSessionForGitHubUser(env, { login: "alice", id: 101 });
+    const cookie = `loopover_session=${token}`;
+    expect((await app.request("/v1/repos/alice/repo-a/ams-miner-cohort", { headers: { cookie } }, env)).status).toBe(200);
+    const other = await app.request("/v1/repos/bob/repo-b/ams-miner-cohort", { headers: { cookie } }, env);
+    expect(other.status).toBe(403);
+    expect(await other.json()).toMatchObject({ error: "forbidden_repo" });
+  });
+
+  it("a maintainer can REACH pulls/:number/chat-qa on their OWN repo, scoped per-repo (allowlist parity with the maintainer panel)", async () => {
+    const { app, env } = await setup();
+    // chat-qa needs a real PR to resolve; the answer service returns a 200 "disabled" status by default
+    // (advisoryAiRouting.chatQa off with no .loopover.yml), so no AI mock is needed to prove reachability.
+    await upsertPullRequestFromGitHub(env, "alice/repo-a", { number: 7, title: "t", state: "open", user: { login: "someone" }, labels: [], body: "x" });
+    const { token } = await createSessionForGitHubUser(env, { login: "alice", id: 101 });
+    const cookie = `loopover_session=${token}`;
+    const own = await app.request(
+      "/v1/repos/alice/repo-a/pulls/7/chat-qa",
+      { method: "POST", headers: { cookie }, body: JSON.stringify({ question: "why is this blocked?" }) },
+      env,
+    );
+    expect(own.status).toBe(200);
+    // The per-route requireRepoMaintainer still scopes: maintainer of A cannot reach B's chat-qa.
+    const other = await app.request(
+      "/v1/repos/bob/repo-b/pulls/7/chat-qa",
+      { method: "POST", headers: { cookie }, body: JSON.stringify({ question: "why?" }) },
+      env,
+    );
+    expect(other.status).toBe(403);
+    expect(await other.json()).toMatchObject({ error: "forbidden_repo" });
   });
 
   it("a pure miner (no maintainer role on any repo) cannot read ANY repo's maintainer settings", async () => {


### PR DESCRIPTION
Fixes #8653

## Root cause

`canSessionAccessPath` (`src/api/routes.ts`) is the coarse pre-route allowlist that runs in middleware for every non-operator browser session. Three routes call `requireRepoMaintainer` internally and each documents itself as maintainer-session-reachable — but none had a predicate in the allowlist, so a real non-operator maintainer session hit the coarse 403 *before* the handler's own guard could admit it:

- `automation-state` — comment: "Maintainer-gated like `/settings`" (which *is* allowlisted)
- `ams-miner-cohort` — comment: "mirrors maintainer-noise" (which *is* allowlisted)
- `pulls/:number/chat-qa` — comment: exposes to the maintainer panel; confirmed live — `apps/loopover-ui/.../chat-qa-panel.tsx` calls it with `credentials: "include"`

## Fix

Added three path predicates (`isRepoAutomationStatePath`, `isRepoAmsMinerCohortPath`, `isRepoChatQaPath`), mirroring the existing `isRepoMaintainerNoisePath` shape exactly, and wired them into `canSessionAccessPath`. This only decides whether a session may *reach* the path — each route's own `requireRepoMaintainer` still enforces per-repo authority, so a maintainer of A reaching B still gets `403 forbidden_repo`.

## Tests

Added to `test/unit/access-boundary.test.ts` following its established template — for all 3 routes, a maintainer session reaches its **own** repo (200) and is rejected on a **different** maintainer's repo (403 `forbidden_repo`). No AI mock was needed for chat-qa: with the default settings (`advisoryAiRouting.chatQa` off), the real answer service returns a 200 `disabled` status, so a seeded PR is enough to prove reachability.

## Validation

- `test/unit/access-boundary.test.ts`: **12 passed**, on a branch rebased onto current `main`
- lcov scoped to `routes.ts`: every added line and both branches of each new predicate covered
- `npm run typecheck` clean; `oxlint` clean on the changed lines; `git diff --check` clean
