### PR TITLE
fix(orb): degrade issue-side new-account label to a default instead of a non-null assertion (#8687)

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -6739,7 +6739,10 @@ async function handleIssueWebhookEvent(
               installationId,
               payload.repository.full_name,
               issue.number,
-              issueSettings.newAccountLabel!,
+              // #8687: mirror the PR-side twins (processors.ts:2765,3123) -- degrade to the "new-account"
+              // default rather than a bare non-null assertion, so a settings source that omits the field
+              // (e.g. a manifest overlay) labels consistently across the issue and PR paths.
+              issueSettings.newAccountLabel ?? "new-account",
               { createMissingLabel: issueSettings.createMissingLabel, mode: newAccountMode },
             ).catch(
               /* v8 ignore next -- fail-safe: a label-application failure must never block the rest of the handler */

--- a/test/unit/queue-3.test.ts
+++ b/test/unit/queue-3.test.ts
@@ -4490,6 +4490,45 @@ describe("queue processors", () => {
     expect(seen.labels).not.toContain("new-account");
   });
 
+  it("account-age throttle (#8687 issue path): falls back to the default 'new-account' label when settings omit newAccountLabel", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertInstallation(env, {
+      installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" }, target_type: "User", repository_selection: "all", permissions: { metadata: "read", issues: "write" }, events: ["issues"] },
+      repositories: [{ name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }],
+    });
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      autonomy: { close: "auto", review_state_label: "auto" },
+    });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { accountAgeThresholdDays: 30 } });
+    // The DB default normally always populates newAccountLabel; strip it at the one settings-resolution seam so
+    // the issue-side call site's `?? "new-account"` fallback (previously a bare non-null assertion that would
+    // have labeled with `undefined`) is exercised end-to-end, matching the already-correct PR-side twins.
+    const original = repositorySettingsModule.resolveRepositorySettings;
+    const settingsSpy = vi.spyOn(repositorySettingsModule, "resolveRepositorySettings").mockImplementation(async (e, r) => {
+      const resolved = { ...(await original(e, r)) };
+      delete resolved.newAccountLabel;
+      return resolved;
+    });
+    const seen = { labels: [] as string[], closed: false };
+    vi.stubGlobal("fetch", stubIssueAccountAgeFetch(62, new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(), seen));
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "account-age-issue-default-label-8687",
+      eventName: "issues",
+      payload: {
+        action: "opened",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        issue: { number: 62, title: "Newbie's issue", state: "open", user: { login: "newbie" }, labels: [], body: "x" },
+      },
+    });
+
+    expect(seen.labels).toContain("new-account");
+    settingsSpy.mockRestore();
+  });
+
   it("account-age throttle (#2561 issue path): the repo OWNER's own issue is never labeled even on a brand-new account", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, {


### PR DESCRIPTION
## Problem

Closes #8687.

`RepositorySettings.newAccountLabel` is optional. The two **PR-side** call sites (`src/queue/processors.ts:2765,3123`) resolve it defensively — `settings.newAccountLabel ?? "new-account"` — but the **issue-side** site (`:6742`) used a bare non-null assertion, `issueSettings.newAccountLabel!`, despite its own comment claiming "same contract as the PR maintenance path".

A settings source that omits the field (a manifest overlay, or a future source) would label the issue with `undefined` on the issue path while the PR path silently falls back to `"new-account"`. It's masked today only because `resolveRepositorySettings`'s DB defaults always populate the field.

## Fix

Use the same `?? "new-account"` fallback as the already-correct PR-side twins. The PR-side sites are unchanged.

## Tests

A new test in `test/unit/queue-3.test.ts` (mirroring the existing account-age issue-path tests) strips `newAccountLabel` from the resolved settings via the one settings-resolution seam, fires an `issues opened` webhook for a below-account-age-threshold author, and asserts the applied label is `"new-account"` — previously `undefined`. Reverting the source change makes it fail. The existing "configured newAccountLabel" and default-label tests still pass (both `??` branches covered). `git diff --check` clean.