### PR TITLE
fix(miner): remove stale not-yet-migrated cast/comment for resolveReplaySnapshotDbPath

### DIFF
--- a/packages/loopover-miner/lib/migrate-cli.ts
+++ b/packages/loopover-miner/lib/migrate-cli.ts
@@ -61,10 +61,7 @@ const STORES: MigrateStoreDescriptor[] = [
   { name: "attempt-log", resolveDbPath: resolveAttemptLogDbPath, open: initAttemptLog },
   {
     name: "replay-snapshot",
-    // resolveReplaySnapshotDbPath's own (not-yet-converted) .d.ts types `env` as `NodeJS.ProcessEnv`, unlike
-    // every sibling resolver here (`Record<string, string | undefined>`) -- a pre-existing inconsistency, not
-    // introduced by this batch. process.env genuinely satisfies both shapes at runtime, so this cast is safe.
-    resolveDbPath: resolveReplaySnapshotDbPath as (env?: Record<string, string | undefined>) => string,
+    resolveDbPath: resolveReplaySnapshotDbPath,
     open: openReplaySnapshotStore,
   },
   {

--- a/packages/loopover-miner/lib/status.ts
+++ b/packages/loopover-miner/lib/status.ts
@@ -398,8 +398,7 @@ function storeIntegrityChecks(env: Record<string, string | undefined>): DoctorCh
     ["plan-store", resolvePlanStoreDbPath(env)],
     ["governor-state", resolveGovernorStateDbPath(env)],
     ["attempt-log", resolveAttemptLogDbPath(env)],
-    // replay-snapshot's .d.ts still types env as ProcessEnv (not yet migrated); cast is lossless.
-    ["replay-snapshot", resolveReplaySnapshotDbPath(env as NodeJS.ProcessEnv)],
+    ["replay-snapshot", resolveReplaySnapshotDbPath(env)],
     ["worktree-allocator", resolveWorktreeAllocatorDbPath(env)],
     ["contribution-profile", resolveContributionProfileCacheDbPath(env)],
     ["policy-verdict-cache", resolvePolicyVerdictCacheDbPath(env)],


### PR DESCRIPTION
## Summary

`packages/loopover-miner/lib/migrate-cli.ts` and `packages/loopover-miner/lib/status.ts` both carried a comment and a type cast claiming `resolveReplaySnapshotDbPath`'s `env` parameter was still typed as `NodeJS.ProcessEnv` ("not yet migrated"). This is no longer true: `replay-snapshot.ts`'s `resolveReplaySnapshotDbPath` has typed `env` as `Record<string, string | undefined>` (matching every sibling resolver) since commit `321a734b7` — which landed before `migrate-cli.ts`'s comment was even written, and a day before the same stale comment was copied into `status.ts`. The casts were harmless no-ops but actively misled a future reader into thinking a real type inconsistency still existed.

- Removed the cast + comment at both call sites; both now call `resolveReplaySnapshotDbPath(env)` directly with no cast.

No production behavior change — the two casts were already no-ops at runtime.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves.

Closes #8642

## Validation

- [x] `npm run typecheck` — passes with both casts removed, no new error surfaces at either call site.
- [x] `git diff --check`
- [x] `npm run docs:drift-check`
- [x] `npm run manifest:drift-check`
- [x] Repo-wide grep confirms no other call site carries this same stale comment for `resolveReplaySnapshotDbPath`.

Per the issue's own Test Coverage Requirements: this is a type-level/comment-accuracy fix with no behavioral change, so no new test is required — `npm run typecheck` passing is the verification.