### PR TITLE
fix(ui): degrade an unrecognized skip reason to neutral 'info' tone, not 'ready' (#8666)

### DIFF
--- a/apps/loopover-ui/src/components/site/audit-feed-model.ts
+++ b/apps/loopover-ui/src/components/site/audit-feed-model.ts
@@ -125,5 +125,8 @@ export function skipReasonTone(reason: string): "ready" | "info" | "warn" | "deg
   if (reason === "bot_author" || reason === "not_official_gittensor_miner") return "info";
   if (reason === "surface_off" || reason === "maintainer_author") return "warn";
   if (reason === "miner_detection_unavailable" || reason === "missing_author") return "degraded";
-  return "ready";
+  // #8666: an unrecognized reason degrades to the neutral "info" tone (matching
+  // contributor-quality-table-model's `band` convention), not "ready" -- a green/healthy tone would imply a
+  // successful state for a value that is actually unclassified, since none of the enumerated reasons map to "ready".
+  return "info";
 }

--- a/apps/loopover-ui/src/components/site/audit-feed.test.tsx
+++ b/apps/loopover-ui/src/components/site/audit-feed.test.tsx
@@ -11,6 +11,7 @@ import {
   normalizeSinceInput,
   normalizeSkippedPrAuditExport,
   pullRequestHref,
+  skipReasonTone,
 } from "@/components/site/audit-feed-model";
 import { AuditFeed } from "@/components/site/audit-feed";
 
@@ -60,6 +61,19 @@ describe("audit feed helpers", () => {
     ).toBe(
       "/v1/app/skipped-pr-audit?limit=50&offset=50&repoFullName=repo-owner%2Fowned-repo&reason=bot_author&since=2026-05-28T00%3A00%3A00.000Z",
     );
+  });
+
+  it("maps each enumerated skip reason to its tone and degrades an unrecognized reason to neutral 'info', not 'ready' (#8666)", () => {
+    expect(skipReasonTone("bot_author")).toBe("info");
+    expect(skipReasonTone("not_official_gittensor_miner")).toBe("info");
+    expect(skipReasonTone("surface_off")).toBe("warn");
+    expect(skipReasonTone("maintainer_author")).toBe("warn");
+    expect(skipReasonTone("miner_detection_unavailable")).toBe("degraded");
+    expect(skipReasonTone("missing_author")).toBe("degraded");
+    // An unrecognized/legacy reason must NOT read as a green "ready" (healthy) pill -- it degrades to the
+    // neutral "info" tone, matching contributor-quality-table-model's convention for unknown enum-like values.
+    expect(skipReasonTone("some_future_reason")).not.toBe("ready");
+    expect(skipReasonTone("some_future_reason")).toBe("info");
   });
 
   it("formats skip reasons and pull request links", () => {


### PR DESCRIPTION
## Problem

Closes #8666.

`apps/loopover-ui/src/components/site/audit-feed-model.ts`'s `skipReasonTone` fell back to `"ready"` — a green, healthy-looking tone — for an unrecognized reason string. None of the four enumerated reasons map to `"ready"`; it existed solely as the fallback for an *unrecognized* value. `SkippedPrAuditItem.reason` is typed as plain `string`, so if the backend emits a new or legacy skip reason, the audit feed silently displays it as a successful-looking "ready" pill rather than flagging it as unclassified.

The sibling `contributor-quality-table-model.ts` degrades an unrecognized enum-like value to the neutral `"info"` tone; `skipReasonTone` diverged from that established convention.

## Fix

Change the fallback branch from `"ready"` to `"info"`. Behavior for the four enumerated reasons is unchanged.

## Tests

A new direct test in `audit-feed.test.tsx`'s "audit feed helpers" block (the file's convention for model-function tests) asserts each enumerated reason maps to its expected tone (`info`/`warn`/`degraded`) **and** that an unrecognized reason returns `"info"`, not `"ready"`. Reverting the source change makes it fail. All 16 tests in the file pass; `git diff --check` clean.