### PR TITLE
fix(orb): break to the fallback model on a rate limit in e2e-test-gen

### DIFF
--- a/src/services/ai-e2e-test-gen.ts
+++ b/src/services/ai-e2e-test-gen.ts
@@ -39,6 +39,7 @@ import {
   coerceAiUsage,
   estimateNeurons,
   isEnabled,
+  isRateLimitError,
   utcDayStartIso,
 } from "./ai-review";
 
@@ -214,8 +215,12 @@ async function runWorkersE2eTestGen(env: Env, system: string, user: string, maxT
         );
         const parsed = parseE2eTestGenResponse(coerceAiText(result));
         if (parsed) return { testSource: parsed, usage: coerceAiUsage(result) };
-      } catch {
-        /* retry / fall through to fallback */
+      } catch (error) {
+        // #8672: a 429 will not have cleared by the next attempt a few hundred ms later, so retrying THIS
+        // model burns the remaining budget for zero additional chance of success -- move straight to the
+        // fallback model instead (the same guard runWorkersSlopOpinion/runWorkersOpinion already apply).
+        if (isRateLimitError(error)) break;
+        /* non-rate-limit error: retry this model / fall through to the fallback model */
       }
     }
   }

--- a/test/unit/ai-e2e-test-gen.test.ts
+++ b/test/unit/ai-e2e-test-gen.test.ts
@@ -558,4 +558,25 @@ describe("runWorkersE2eTestGen (internal)", () => {
     const finalFlags = run.mock.calls.map((c) => ((c as unknown[])[1] as { finalAttempt?: boolean }).finalAttempt);
     expect(finalFlags).toEqual([false, false, false, false, false, true]);
   });
+
+  it("breaks to the fallback model immediately on a rate-limit error instead of burning all per-model attempts (#8672)", async () => {
+    // Every call 429s. Before #8672 this burned all 3 attempts per model (6 calls); now a rate limit short-
+    // circuits the inner retry loop after the first attempt on each model — 2 models × 1 attempt = 2 calls.
+    const run = vi.fn(async () => {
+      throw new Error("workers_ai_http_429");
+    });
+    const env = enabledEnv(run);
+    await expect(runWorkersE2eTestGen(env, "system", "user", 1024)).resolves.toEqual({ testSource: null });
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  it("still burns all per-model attempts on a NON-rate-limit error (the retry path is unchanged) (#8672)", async () => {
+    // A transient non-429 error keeps the original behavior: 2 models × 3 attempts = 6 calls.
+    const run = vi.fn(async () => {
+      throw new Error("transient_timeout");
+    });
+    const env = enabledEnv(run);
+    await runWorkersE2eTestGen(env, "system", "user", 1024);
+    expect(run).toHaveBeenCalledTimes(6);
+  });
 });


### PR DESCRIPTION
Fixes #8672

## Root cause

`runWorkersE2eTestGen`'s per-model retry loop (`src/services/ai-e2e-test-gen.ts`) had a bare `catch { /* retry / fall through */ }` with no rate-limit check — `isRateLimitError` was never imported in the file. So when the default provider 429s, it burned all 3 `E2E_TEST_GEN_ATTEMPTS_PER_MODEL` retries against the same rate-limited model (half the total 6-call budget) before ever reaching the fallback model.

That directly contradicts the function's own doc comment ("Mirrors `runWorkersSlopOpinion`'s exact shape") — the slop sibling (`ai-slop.ts:169-174`), `planner.ts`, `issue-plan-draft.ts`, and `linked-issue-satisfaction-run.ts` all `break` on a 429, and `isRateLimitError`'s doc explicitly says retrying a live 429 has "near-zero chance of success."

## Fix

Imported `isRateLimitError` from `./ai-review` (where the other loops get it) and added `if (isRateLimitError(error)) break;` to the catch — the identical guard the siblings use. A non-rate-limit error still retries/falls through exactly as before.

## Tests (both in the existing `ai-e2e-test-gen.test.ts`, both arms of the new branch)

- A 429 on every call now breaks to the fallback model after one attempt per model: **2 calls** (2 models × 1), not 6. Verified to genuinely guard the fix — reverting the one-line change makes this test fail (6 calls).
- A non-429 error still burns all attempts: **6 calls** (2 × 3) — the unchanged retry path.

## Validation

- `ai-e2e-test-gen.test.ts`: **47 passed**, rebased onto current `main`
- lcov scoped to the file: the changed catch line and **both branches** of the new `isRateLimitError` guard are covered
- `npm run typecheck` clean; `oxlint` clean on the changed lines (the one warning at line 257 is pre-existing, present on clean `main`, outside this diff); `git diff --check` clean
