### PR TITLE
fix(engine): restore default blend on NaN/negative calibration weights

### DIFF
--- a/packages/loopover-engine/src/finding-severity-calibration.ts
+++ b/packages/loopover-engine/src/finding-severity-calibration.ts
@@ -143,6 +143,10 @@ function finiteNonNegative(value: number | undefined, fallback: number): number 
   return value;
 }
 
+function isInvalidWeight(value: number | undefined): boolean {
+  return value !== undefined && (!Number.isFinite(value) || value < 0);
+}
+
 function finiteNonNegativeInt(value: number | undefined): number {
   if (value === undefined || !Number.isFinite(value) || value < 0) return 0;
   return Math.floor(value);
@@ -365,8 +369,19 @@ function normalizeCompositeWeights(weights: FindingSeverityCalibrationWeights | 
   const total = raw.objectiveAnchor + raw.pairwiseJudge + raw.structuredFindingSeverity;
   // Preserve explicitly-zeroed weights rather than substituting the defaults: a caller that zeroes every component
   // must reach the objective-only fallback in the composite scorer, not silently get the default 45/35/20 blend
-  // (converges with reviewer-consensus-calibration.ts's already-correct behavior; #6170).
-  if (total <= 0) return { objectiveAnchor: 0, pairwiseJudge: 0, structuredFindingSeverity: 0 };
+  // (converges with reviewer-consensus-calibration.ts / #6170; #7443 / #8643).
+  // NaN/negative inputs still recover to DEFAULT_COMPOSITE_WEIGHTS when the clamped total is empty — same as
+  // pairwise-calibration.ts — so the invalid-weight suite keeps asserting the 45/35/20 default.
+  if (total <= 0) {
+    if (
+      isInvalidWeight(weights?.objectiveAnchor) ||
+      isInvalidWeight(weights?.pairwiseJudge) ||
+      isInvalidWeight(weights?.structuredFindingSeverity)
+    ) {
+      return DEFAULT_COMPOSITE_WEIGHTS;
+    }
+    return { objectiveAnchor: 0, pairwiseJudge: 0, structuredFindingSeverity: 0 };
+  }
   return {
     objectiveAnchor: raw.objectiveAnchor / total,
     pairwiseJudge: raw.pairwiseJudge / total,

--- a/packages/loopover-engine/src/gate-verdict-calibration.ts
+++ b/packages/loopover-engine/src/gate-verdict-calibration.ts
@@ -147,6 +147,10 @@ function finiteNonNegative(value: number | undefined, fallback: number): number 
   return value;
 }
 
+function isInvalidWeight(value: number | undefined): boolean {
+  return value !== undefined && (!Number.isFinite(value) || value < 0);
+}
+
 function roundScore(value: number): number {
   return Math.round(Math.min(1, Math.max(0, value)) * 1_000_000) / 1_000_000;
 }
@@ -318,8 +322,19 @@ function normalizeCompositeWeights(weights: GateVerdictCalibrationWeights | unde
   const total = raw.objectiveAnchor + raw.pairwiseJudge + raw.structuredGateVerdict;
   // Preserve explicitly-zeroed weights rather than substituting the defaults: a caller that zeroes every component
   // must reach the objective-only fallback in the composite scorer, not silently get the default 45/35/20 blend
-  // (converges with reviewer-consensus-calibration.ts's already-correct behavior; #6170).
-  if (total <= 0) return { objectiveAnchor: 0, pairwiseJudge: 0, structuredGateVerdict: 0 };
+  // (converges with reviewer-consensus-calibration.ts / #6170; #7443 / #8643).
+  // NaN/negative inputs still recover to DEFAULT_COMPOSITE_WEIGHTS when the clamped total is empty — same as
+  // pairwise-calibration.ts — so the invalid-weight suite keeps asserting the 45/35/20 default.
+  if (total <= 0) {
+    if (
+      isInvalidWeight(weights?.objectiveAnchor) ||
+      isInvalidWeight(weights?.pairwiseJudge) ||
+      isInvalidWeight(weights?.structuredGateVerdict)
+    ) {
+      return DEFAULT_COMPOSITE_WEIGHTS;
+    }
+    return { objectiveAnchor: 0, pairwiseJudge: 0, structuredGateVerdict: 0 };
+  }
   return {
     objectiveAnchor: raw.objectiveAnchor / total,
     pairwiseJudge: raw.pairwiseJudge / total,

--- a/packages/loopover-engine/src/reviewer-consensus-calibration.ts
+++ b/packages/loopover-engine/src/reviewer-consensus-calibration.ts
@@ -154,6 +154,10 @@ function finiteNonNegative(value: number | undefined, fallback: number): number 
   return value;
 }
 
+function isInvalidWeight(value: number | undefined): boolean {
+  return value !== undefined && (!Number.isFinite(value) || value < 0);
+}
+
 function roundScore(value: number): number {
   return Math.round(Math.min(1, Math.max(0, value)) * 1_000_000) / 1_000_000;
 }
@@ -401,8 +405,20 @@ function normalizeCompositeWeights(weights: ReviewerConsensusCalibrationWeights 
   };
   const total = raw.objectiveAnchor + raw.pairwiseJudge + raw.structuredReviewerConsensus;
   // Preserve explicitly-zeroed weights rather than substituting the defaults: a caller that zeroes every component
-  // must reach the objective-only fallback in the composite scorer, not silently get the default 45/35/20 blend.
-  if (total <= 0) return { objectiveAnchor: 0, pairwiseJudge: 0, structuredReviewerConsensus: 0 };
+  // must reach the objective-only fallback in the composite scorer, not silently get the default 45/35/20 blend
+  // (converges with pairwise-calibration.ts / #6170; #7443 / #8643).
+  // NaN/negative inputs still recover to DEFAULT_COMPOSITE_WEIGHTS when the clamped total is empty — same as
+  // pairwise-calibration.ts — so the invalid-weight suite keeps asserting the 45/35/20 default.
+  if (total <= 0) {
+    if (
+      isInvalidWeight(weights?.objectiveAnchor) ||
+      isInvalidWeight(weights?.pairwiseJudge) ||
+      isInvalidWeight(weights?.structuredReviewerConsensus)
+    ) {
+      return DEFAULT_COMPOSITE_WEIGHTS;
+    }
+    return { objectiveAnchor: 0, pairwiseJudge: 0, structuredReviewerConsensus: 0 };
+  }
   return {
     objectiveAnchor: raw.objectiveAnchor / total,
     pairwiseJudge: raw.pairwiseJudge / total,

--- a/packages/loopover-engine/test/finding-severity-calibration.test.ts
+++ b/packages/loopover-engine/test/finding-severity-calibration.test.ts
@@ -483,3 +483,20 @@ test("computeFindingSeverityCompositeCalibrationScore falls back to objective-on
   assert.deepEqual(result.weights, { objectiveAnchor: 1, pairwiseJudge: 0, structuredFindingSeverity: 0 });
   assert.equal(result.compositeScore, 0.4);
 });
+
+test("computeFindingSeverityCompositeCalibrationScore normalizes invalid weights without producing NaN (#8643)", () => {
+  const result = computeFindingSeverityCompositeCalibrationScore({
+    objectiveAnchor: 0.4,
+    pairwise: 0.4,
+    findingSeverity: [signal()],
+    weights: { objectiveAnchor: Number.NaN, pairwiseJudge: -1, structuredFindingSeverity: -1 },
+  });
+
+  // NaN/negative inputs must recover to the documented 45/35/20 default, not collapse to objective-only.
+  assert.deepEqual(result.weights, {
+    objectiveAnchor: 0.45,
+    pairwiseJudge: 0.35,
+    structuredFindingSeverity: 0.2,
+  });
+  assert.equal(result.compositeScore, 0.52);
+});

--- a/packages/loopover-engine/test/gate-verdict-calibration.test.ts
+++ b/packages/loopover-engine/test/gate-verdict-calibration.test.ts
@@ -602,6 +602,27 @@ test("computeGateVerdictCompositeCalibrationScore falls back to objective-only w
   assert.equal(result.compositeScore, 0.4);
 });
 
+test("computeGateVerdictCompositeCalibrationScore normalizes invalid weights without producing NaN (#8643)", () => {
+  const result = computeGateVerdictCompositeCalibrationScore({
+    objectiveAnchor: 0.4,
+    pairwise: 0.4,
+    gateVerdicts: [
+      {
+        repoFullName: "acme/widgets",
+        replayRunId: "replay-1",
+        gateRunId: "gate-1",
+        optedIn: true,
+        dimensions: [{ dimension: "correctness", outcome: "pass" }],
+      },
+    ],
+    weights: { objectiveAnchor: Number.NaN, pairwiseJudge: -1, structuredGateVerdict: -1 },
+  });
+
+  // NaN/negative inputs must recover to the documented 45/35/20 default, not collapse to objective-only.
+  assert.deepEqual(result.weights, { objectiveAnchor: 0.45, pairwiseJudge: 0.35, structuredGateVerdict: 0.2 });
+  assert.equal(result.compositeScore, 0.52);
+});
+
 test("computeGateVerdictCompositeCalibrationScore preserves a malformed-repo (invalid_repo) rejected row instead of dropping it (#6170)", () => {
   const result = computeGateVerdictCompositeCalibrationScore({
     objectiveAnchor: 0.5,

--- a/packages/loopover-engine/test/reviewer-consensus-calibration.test.ts
+++ b/packages/loopover-engine/test/reviewer-consensus-calibration.test.ts
@@ -309,6 +309,24 @@ test("composite honors custom weights and falls back to objective-only when all 
   assert.equal(allZero.compositeScore, 0.4);
 });
 
+test("computeReviewerConsensusCompositeCalibrationScore normalizes invalid weights without producing NaN (#8643)", () => {
+  const ingestion = ingestReviewerConsensusCalibrationSignals([signal()]);
+  const result = computeReviewerConsensusCompositeCalibrationScore({
+    objectiveAnchor: 0.4,
+    pairwise: 0.4,
+    reviewerConsensus: ingestion,
+    weights: { objectiveAnchor: Number.NaN, pairwiseJudge: -1, structuredReviewerConsensus: -1 },
+  });
+
+  // NaN/negative inputs must recover to the documented 45/35/20 default, not collapse to objective-only.
+  assert.deepEqual(result.weights, {
+    objectiveAnchor: 0.45,
+    pairwiseJudge: 0.35,
+    structuredReviewerConsensus: 0.2,
+  });
+  assert.equal(result.compositeScore, 0.52);
+});
+
 test("composite sanitizes pre-ingested reviewer-consensus rows before auditing", () => {
   const poisoned = {
     accepted: [


### PR DESCRIPTION
## Summary

- Align `gate-verdict`, `reviewer-consensus`, and `finding-severity` `normalizeCompositeWeights` with `pairwise-calibration.ts`: NaN/negative weights fall back to each file's documented default blend instead of collapsing to a 100%-objective-anchor composite.
- Keep explicit all-zero weights returning real zeros so existing objective-only fallback tests stay valid.
- Add an invalid-weight unit test in each of the three suites (mirroring `pairwise-calibration.test.ts`).

Closes #8643

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) - a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ?99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Skipped monorepo-wide UI/MCP/workers/actionlint/audit checks: this PR only changes `packages/loopover-engine` calibration composers and their unit tests. Validated with `tsc` + targeted `node --test` for the invalid-weight and explicit all-zero cases in all three suites (plus pairwise). Full `codecov/patch` will run in CI.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable - engine-only change, no visible UI.

| State / title                         | JPG/PNG evidence                                                                     |
| ------------------------------------- | ------------------------------------------------------------------------------------ |
| N/A                                   |                                                                                      |

## Notes

- Mirrors the `isInvalidWeight()` distinction already present in `pairwise-calibration.ts` (#7443).