### PR TITLE
fix(ui): migrate the pre-rebrand analytics window preference forward

### DIFF
--- a/apps/loopover-ui/src/routes/app.analytics.test.tsx
+++ b/apps/loopover-ui/src/routes/app.analytics.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 // #6817: app.analytics.tsx's StateBoundary had no loadingSkeleton, falling through to the generic spinner
 // -- the same gap #6816 fixed for app.operator.tsx.
@@ -40,5 +40,62 @@ describe("ProductAnalytics loading skeleton (#6817)", () => {
     const { container } = render(<ProductAnalytics />);
     expect(screen.getByText("Usage & value analytics")).toBeTruthy();
     expect(container.querySelectorAll(".animate-pulse").length).toBe(0);
+  });
+});
+
+// #8699: the analytics window preference was renamed from "gittensory.analytics.windowDays" to
+// "loopover.analytics.windowDays" in the rebrand (75450f1d5) without the one-time legacyKey fallback
+// app.runs.tsx / app.workbench.tsx got, silently resetting returning users to the 7-day default.
+describe("ProductAnalytics window preference rebrand migration (#8699)", () => {
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("migrates a pre-rebrand gittensory window preference forward instead of resetting to 7d", async () => {
+    window.localStorage.setItem("gittensory.analytics.windowDays", "30");
+    useApiResource.mockReturnValue({
+      status: "ready",
+      data: { metrics: [{ label: "Active repos", value: "12", delta: "+2" }], noiseReduction: [] },
+      error: null,
+      loadedAt: "2026-07-17T00:00:00.000Z",
+      reload: () => {},
+    });
+
+    render(<ProductAnalytics />);
+
+    // The toggle group renders once the preference has hydrated -- with the legacy value carried
+    // over, 30d is the selected window (not the 7-day default the user never chose).
+    const thirtyDay = await screen.findByRole("radio", { name: "30 day window" });
+    await waitFor(() => expect(thirtyDay.getAttribute("data-state")).toBe("on"));
+    expect(screen.getByRole("radio", { name: "7 day window" }).getAttribute("data-state")).toBe(
+      "off",
+    );
+    // The dashboard is fetched for the migrated window, not the default.
+    await waitFor(() =>
+      expect(useApiResource).toHaveBeenLastCalledWith(
+        "/v1/app/operator-dashboard?days=30",
+        "Product analytics",
+      ),
+    );
+    // Backfilled: the new key now holds the value directly (the hook migrates it forward on first read).
+    expect(window.localStorage.getItem("loopover.analytics.windowDays")).toBe("30");
+  });
+
+  it("still uses the 7-day default when neither the new nor the legacy key is present", async () => {
+    useApiResource.mockReturnValue({
+      status: "ready",
+      data: { metrics: [{ label: "Active repos", value: "12", delta: "+2" }], noiseReduction: [] },
+      error: null,
+      loadedAt: "2026-07-17T00:00:00.000Z",
+      reload: () => {},
+    });
+
+    render(<ProductAnalytics />);
+
+    const sevenDay = await screen.findByRole("radio", { name: "7 day window" });
+    await waitFor(() => expect(sevenDay.getAttribute("data-state")).toBe("on"));
+    // Nothing to migrate: no value is invented under either key.
+    expect(window.localStorage.getItem("loopover.analytics.windowDays")).toBeNull();
+    expect(window.localStorage.getItem("gittensory.analytics.windowDays")).toBeNull();
   });
 });

--- a/apps/loopover-ui/src/routes/app.analytics.tsx
+++ b/apps/loopover-ui/src/routes/app.analytics.tsx
@@ -172,6 +172,9 @@ export function ProductAnalytics() {
   const [windowDays, setWindowDays, windowHydrated] = useLocalStorage<AnalyticsWindowDays>(
     ANALYTICS_WINDOW_STORAGE_KEY,
     DEFAULT_ANALYTICS_WINDOW_DAYS,
+    // Pre-rebrand key (#8699): read once as a fallback and migrate forward, mirroring
+    // app.runs.tsx / app.workbench.tsx, so a returning user's window choice survives the rename.
+    "gittensory.analytics.windowDays",
   );
   const selectedWindow = parseAnalyticsWindowDays(windowDays);
   const dashboard = useApiResource<OperatorDashboard>(


### PR DESCRIPTION
Closes #8699

## What

`app.analytics.tsx` called `useLocalStorage<AnalyticsWindowDays>(ANALYTICS_WINDOW_STORAGE_KEY, DEFAULT_ANALYTICS_WINDOW_DAYS)` with no third `legacyKey` argument. The key was renamed from `"gittensory.analytics.windowDays"` to `"loopover.analytics.windowDays"` in the rebrand commit (`75450f1d5`) that gave `app.runs.tsx` and `app.workbench.tsx` their one-time `legacyKey` migration — this file was missed. Any returning user who had picked a 30d/90d analytics window before the cutover silently reverted to the 7-day default.

## How

`apps/loopover-ui/src/routes/app.analytics.tsx` now passes `"gittensory.analytics.windowDays"` as the third `useLocalStorage` argument, matching the `app.runs.tsx` / `app.workbench.tsx` pattern exactly. The hook already implements the one-time fallback: if the new key is absent it reads the legacy key, adopts the value, and writes it forward to the new key (leaving the legacy key in place).

## Deliverables

- [x] The `useLocalStorage` call for the analytics window preference includes the `"gittensory.analytics.windowDays"` legacy key.
- [x] New test in `apps/loopover-ui/src/routes/app.analytics.test.tsx`: seeds `localStorage["gittensory.analytics.windowDays"] = "30"`, mounts `ProductAnalytics`, and asserts the toggle group shows 30d selected (`data-state="on"`, 7d `"off"`), the dashboard is fetched for `?days=30`, and `localStorage["loopover.analytics.windowDays"]` is backfilled with `"30"` — mirroring the migration tests used for the runs/workbench keys in `use-local-storage.test.ts`. A companion test pins the no-keys case: 7d default, and no value invented under either key.

## Before / after

On unfixed `main` (fix stashed), the new migration test fails exactly as the issue describes — the seeded 30d preference is ignored and the default wins:

```
× migrates a pre-rebrand gittensory window preference forward instead of resetting to 7d
  AssertionError: expected 'off' to be 'on'   // 7d is "on", 30d is "off"
```

With the fix:

```
✓ src/routes/app.analytics.test.tsx (4 tests)
✓ src/lib/use-local-storage.test.ts (11 tests)
```
