### PR TITLE
fix(queue): record gate_check_run in failedOutputs on double failure

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -10807,6 +10807,17 @@ async function maybePublishPrPublicSurface(
               });
             }
           }
+          // #8686: when both the primary publish and its fallback fail (or there was no pending id to fall
+          // back on), record the same failedOutputs entry check_run/comment/label already push — otherwise a
+          // gate-only repo silently leaves publishedOutputs+failedOutputs empty and finishPublicSurfacePublication
+          // skips pr_public_surface_failed / PostHog escalation / transient retry entirely.
+          if (!gateFinalized) {
+            failedOutputs.push({
+              output: "gate_check_run",
+              error: gateCheckResult.warning,
+              transient: false,
+            });
+          }
         }
       } catch (checkError) {
         if (isGitHubRateLimitedError(checkError)) throw checkError;
@@ -10848,6 +10859,16 @@ async function maybePublishPrPublicSurface(
               );
             });
           }
+        }
+        // #8686: final failure after fallback also failed (or was unavailable) — same failedOutputs contract
+        // as check_run so gate-only repos get operator-visible failure + transient retry when applicable.
+        if (!gateFinalized) {
+          const message = errorMessage(checkError);
+          failedOutputs.push({
+            output: "gate_check_run",
+            error: message,
+            transient: isGitHubTransientPublishError(checkError),
+          });
         }
         await recordAuditEvent(env, {
           eventType: "github_app.gate_check_failed_nonfatal",

--- a/test/unit/queue-4.test.ts
+++ b/test/unit/queue-4.test.ts
@@ -1496,16 +1496,10 @@ describe("queue processors", () => {
     });
   });
 
-  it("does not stamp a gate-only surface when the incomplete-surface audit write fails", async () => {
-    const originalRecordAuditEvent = repositoriesModule.recordAuditEvent;
-    let incompleteAuditWrites = 0;
-    const auditSpy = vi.spyOn(repositoriesModule, "recordAuditEvent").mockImplementation(async (auditEnv, event) => {
-      if (event.eventType === "github_app.pr_public_surface_incomplete") {
-        incompleteAuditWrites += 1;
-        throw new Error("audit failed");
-      }
-      await originalRecordAuditEvent(auditEnv, event);
-    });
+  it("does not stamp a gate-only surface when gate publish fails transiently (#8686)", async () => {
+    // Gate-only repo: pending POST succeeds, completed PATCH + errored fallback both 500 → failedOutputs
+    // gets a transient gate_check_run entry and finishPublicSurfacePublication retries (no surface stamp).
+    // Pre-#8686 this path left failedOutputs empty and only wrote pr_public_surface_incomplete.
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await persistRegistrySnapshot(
       asCloudEnv(env),
@@ -1531,23 +1525,36 @@ describe("queue processors", () => {
       if (url.includes("/check-runs/973") && method === "PATCH") return new Response("check update failed", { status: 500 });
       return new Response("not found", { status: 404 });
     });
+    const captureSpy = vi.spyOn(posthogModule, "capturePostHogReviewFailure");
 
-    await processJob(env, {
-      type: "github-webhook",
-      deliveryId: "gate-missing-zero-output",
-      eventName: "pull_request",
-      payload: {
-        action: "opened",
-        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
-        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
-        pull_request: { number: 83, title: "Gate only missing", state: "open", user: { login: "contributor" }, head: { sha: "gate-zero-missing" }, labels: [], body: "No issue link." },
-      },
-    });
+    await expect(
+      processJob(env, {
+        type: "github-webhook",
+        deliveryId: "gate-missing-zero-output",
+        eventName: "pull_request",
+        payload: {
+          action: "opened",
+          installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+          repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+          pull_request: { number: 83, title: "Gate only missing", state: "open", user: { login: "contributor" }, head: { sha: "gate-zero-missing" }, labels: [], body: "No issue link." },
+        },
+      }),
+    ).rejects.toMatchObject({ retryKind: "public_surface_publish_transient" });
 
-    expect(incompleteAuditWrites).toBe(1);
+    const aggregate = await env.DB.prepare("select detail, metadata_json from audit_events where event_type = ?")
+      .bind("github_app.pr_public_surface_failed")
+      .first<{ detail: string; metadata_json: string }>();
+    expect(aggregate).toMatchObject({ detail: "gate_check_run" });
+    expect(aggregate?.metadata_json).toContain('"output":"gate_check_run"');
+    expect(aggregate?.metadata_json).toContain('"transient":true');
+    expect(captureSpy).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ kind: "publish", repo: "JSONbored/gittensory", failedOutputs: ["gate_check_run"] }),
+      "pr_public_surface_publish_failed",
+    );
     const stored = await getPullRequest(env, "JSONbored/gittensory", 83);
     expect(stored?.lastPublishedSurfaceSha ?? null).toBeNull();
-    auditSpy.mockRestore();
+    captureSpy.mockRestore();
   });
 
   it("does not stamp a comment surface when the incomplete-surface audit write fails", async () => {
@@ -1749,6 +1756,142 @@ describe("queue processors", () => {
       outcome: "error",
     });
     expect(audit?.detail).toMatch(/Checks: write permission is missing/i);
+  });
+
+  it("records gate_check_run in failedOutputs when primary and fallback both fail with permission_missing (#8686)", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await persistRegistrySnapshot(
+      asCloudEnv(env),
+      normalizeRegistryPayload(
+        { "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } },
+        { kind: "raw-github", url: "https://example.test" },
+        "2026-05-23T00:00:00.000Z",
+      ),
+    );
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      autoLabelEnabled: false,
+      requireLinkedIssue: true,
+    });
+    // Gate-only surface: no comment/label/check_run sibling can mask an empty failedOutputs.
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/commits/gateDoubleFail/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/check-runs") && method === "POST") {
+        const body = JSON.parse(String(init?.body ?? "{}")) as { status?: string };
+        // Pending in_progress succeeds so the permission_missing finalize path has a check id to fall back on.
+        if (body.status === "in_progress") {
+          return Response.json({ id: 501, html_url: "https://example.test/check/501" }, { status: 201 });
+        }
+        // Primary completed publish → permission_missing (createOrUpdateGateCheckRun).
+        return new Response(JSON.stringify({ message: "Resource not accessible by integration" }), { status: 403 });
+      }
+      // Fallback createOrUpdateErroredGateCheckRun PATCHes the pending id — also permission_missing.
+      if (url.includes("/check-runs/") && method === "PATCH") {
+        return new Response(JSON.stringify({ message: "Resource not accessible by integration" }), { status: 403 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+    const captureSpy = vi.spyOn(posthogModule, "capturePostHogReviewFailure");
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "gate-double-fail-permission",
+      eventName: "pull_request",
+      payload: {
+        action: "opened",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        pull_request: { number: 86, title: "Gate without issue", state: "open", user: { login: "contributor" }, head: { sha: "gateDoubleFail" }, labels: [], body: "No issue link." },
+      },
+    });
+
+    const permissionAudit = await env.DB.prepare("select event_type from audit_events where event_type = ?")
+      .bind("github_app.gate_check_permission_missing")
+      .first<{ event_type: string }>();
+    expect(permissionAudit?.event_type).toBe("github_app.gate_check_permission_missing");
+
+    const aggregate = await env.DB.prepare("select detail, metadata_json from audit_events where event_type = ?")
+      .bind("github_app.pr_public_surface_failed")
+      .first<{ detail: string; metadata_json: string }>();
+    expect(aggregate).toMatchObject({ detail: "gate_check_run" });
+    expect(aggregate?.metadata_json).toContain('"output":"gate_check_run"');
+    expect(aggregate?.metadata_json).toContain('"transient":false');
+    expect(captureSpy).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ kind: "publish", repo: "JSONbored/gittensory", failedOutputs: ["gate_check_run"] }),
+      "pr_public_surface_publish_failed",
+    );
+    captureSpy.mockRestore();
+  });
+
+  it("retries when gate_check_run primary throw and fallback both fail transiently (#8686)", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await persistRegistrySnapshot(
+      asCloudEnv(env),
+      normalizeRegistryPayload(
+        { "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } },
+        { kind: "raw-github", url: "https://example.test" },
+        "2026-05-23T00:00:00.000Z",
+      ),
+    );
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      autoLabelEnabled: false,
+      requireLinkedIssue: true,
+    });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", commentMode: "off", publicSurface: "off", checkRunMode: "off" } });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/commits/gateTransientFail/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/check-runs") && method === "POST") {
+        const body = JSON.parse(String(init?.body ?? "{}")) as { status?: string };
+        if (body.status === "in_progress") {
+          return Response.json({ id: 502, html_url: "https://example.test/check/502" }, { status: 201 });
+        }
+        // Primary completed publish throws (octokit path) → catch + fallback.
+        return new Response("GitHub gate check API failed", { status: 500 });
+      }
+      if (url.includes("/check-runs/") && method === "PATCH") {
+        return new Response("GitHub gate check fallback failed", { status: 500 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+    const captureSpy = vi.spyOn(posthogModule, "capturePostHogReviewFailure");
+
+    await expect(
+      processJob(env, {
+        type: "github-webhook",
+        deliveryId: "gate-double-fail-transient",
+        eventName: "pull_request",
+        payload: {
+          action: "opened",
+          installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+          repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+          pull_request: { number: 87, title: "Gate without issue", state: "open", user: { login: "contributor" }, head: { sha: "gateTransientFail" }, labels: [], body: "No issue link." },
+        },
+      }),
+    ).rejects.toMatchObject({ retryKind: "public_surface_publish_transient" });
+
+    const aggregate = await env.DB.prepare("select detail, metadata_json from audit_events where event_type = ?")
+      .bind("github_app.pr_public_surface_failed")
+      .first<{ detail: string; metadata_json: string }>();
+    expect(aggregate).toMatchObject({ detail: "gate_check_run" });
+    expect(aggregate?.metadata_json).toContain('"output":"gate_check_run"');
+    expect(aggregate?.metadata_json).toContain('"transient":true');
+    expect(captureSpy).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ kind: "publish", repo: "JSONbored/gittensory", failedOutputs: ["gate_check_run"] }),
+      "pr_public_surface_publish_failed",
+    );
+    captureSpy.mockRestore();
   });
 
   it("marks closed PR gates skipped without creating late first comments", async () => {


### PR DESCRIPTION
## Summary

- When a `gate_check_run` primary publish and its `createOrUpdateErroredGateCheckRun` fallback both fail, push `gate_check_run` onto `failedOutputs` (same contract as `check_run` / `comment` / `label`).
- Gate-only repos now correctly fire `pr_public_surface_failed`, PostHog escalation, and `RetryablePublicSurfacePublishFailedError` on transient double-failure.
- Updates the prior gate-only incomplete-surface test that assumed empty `failedOutputs` (that was the bug #8686 fixes) so validate-tests stays green - the failure mode that closed #8734.

Closes #8686

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) - a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ?99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Local Node is v24; repo engines pin Node 22. New/updated coverage is in `test/unit/queue-4.test.ts` and will run under CI. #8734 failed validate-tests on the outdated incomplete-surface expectation - fixed here.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A - no visible UI changes.

## Notes

- Replaces closed #8734. Fallback publish behavior unchanged; only final double-failure recording into `failedOutputs` is added.