### PR TITLE
fix(discovery-index): populate assignees on hosted candidates

### DIFF
--- a/packages/discovery-index/src/discovery-query.ts
+++ b/packages/discovery-index/src/discovery-query.ts
@@ -52,6 +52,22 @@ function labelNames(labels: unknown): string[] {
     .filter((name) => name.length > 0);
 }
 
+/** Extract assignee logins from a GitHub issue payload (#8655). Returns `undefined` when the field is
+ *  absent or yields no usable logins, so `buildCandidate` can omit `assignees` entirely (contract:
+ *  absent ≠ empty array). */
+function assigneeLogins(assignees: unknown): string[] | undefined {
+  if (!Array.isArray(assignees)) return undefined;
+  const logins = assignees
+    .map((assignee) => {
+      if (assignee && typeof assignee === "object" && typeof (assignee as { login?: unknown }).login === "string") {
+        return (assignee as { login: string }).login.trim();
+      }
+      return "";
+    })
+    .filter((login) => login.length > 0);
+  return logins.length > 0 ? logins : undefined;
+}
+
 /** `https://api.github.com/repos/{owner}/{repo}` (present on `/search/issues` items) → `owner/repo`, or null
  *  if the field is absent/malformed. */
 function extractRepoFullNameFromIssue(issue: GitHubIssue): string | null {
@@ -74,6 +90,7 @@ function buildCandidate(repoFullName: string, issue: GitHubIssue, verdict: AiPol
   // from extractRepoFullNameFromIssue's regex, which requires a non-empty segment on each side) — the split
   // below can never produce an empty half.
   const slashIndex = repoFullName.indexOf("/");
+  const assignees = assigneeLogins(issue.assignees);
   return {
     owner: repoFullName.slice(0, slashIndex),
     repo: repoFullName.slice(slashIndex + 1),
@@ -81,6 +98,7 @@ function buildCandidate(repoFullName: string, issue: GitHubIssue, verdict: AiPol
     issueNumber,
     title,
     labels: labelNames(issue.labels),
+    ...(assignees ? { assignees } : {}),
     commentsCount: typeof issue.comments === "number" && Number.isFinite(issue.comments) ? issue.comments : 0,
     createdAt: typeof issue.created_at === "string" ? issue.created_at : null,
     updatedAt: typeof issue.updated_at === "string" ? issue.updated_at : null,

--- a/packages/discovery-index/src/github-client.ts
+++ b/packages/discovery-index/src/github-client.ts
@@ -19,6 +19,8 @@ export interface GitHubIssue {
   number?: unknown;
   title?: unknown;
   labels?: unknown;
+  /** GitHub issue assignees (`login` of each), present on issues-list and search-issues payloads. */
+  assignees?: unknown;
   comments?: unknown;
   created_at?: unknown;
   updated_at?: unknown;

--- a/test/unit/discovery-index/discovery-query.test.ts
+++ b/test/unit/discovery-index/discovery-query.test.ts
@@ -109,6 +109,41 @@ describe("discovery-index runDiscoveryQuery (#7164)", () => {
     expect(calls.filter((c) => c.method === "fetchRepoFile")).toHaveLength(1);
   });
 
+  it("forwards real assignee logins onto the candidate (#8655)", async () => {
+    const { github } = makeStubGitHub({
+      issuesByRepo: {
+        "acme/widgets": [
+          {
+            number: 10,
+            title: "Owned issue",
+            assignees: [{ login: "acme-owner" }, { login: "  helper  " }, { login: "" }, { name: "no-login" }, "skip"],
+          },
+        ],
+      },
+      filesByRepo: { "acme/widgets": { "AI-USAGE.md": ALLOWED_AI_USAGE } },
+    });
+    const response = await runDiscoveryQuery(query({ repos: ["acme/widgets"] }), makeDeps(github));
+    expect(response.candidates).toHaveLength(1);
+    expect(response.candidates[0]?.assignees).toEqual(["acme-owner", "helper"]);
+  });
+
+  it("omits assignees when the GitHub issue has none (#8655)", async () => {
+    const { github } = makeStubGitHub({
+      issuesByRepo: {
+        "acme/widgets": [
+          { number: 11, title: "Unassigned issue" },
+          { number: 12, title: "Empty assignees array", assignees: [] },
+        ],
+      },
+      filesByRepo: { "acme/widgets": { "AI-USAGE.md": ALLOWED_AI_USAGE } },
+    });
+    const response = await runDiscoveryQuery(query({ repos: ["acme/widgets"] }), makeDeps(github));
+    expect(response.candidates).toHaveLength(2);
+    for (const candidate of response.candidates) {
+      expect(Object.prototype.hasOwnProperty.call(candidate, "assignees")).toBe(false);
+    }
+  });
+
   it("skips a repo entirely when its AI policy disallows contributions", async () => {
     const { github, calls } = makeStubGitHub({
       issuesByRepo: { "acme/banned": [{ number: 1, title: "Should never appear" }] },


### PR DESCRIPTION
## Summary

- Add `assignees` to the discovery-index `GitHubIssue` type (already present on GitHub issues/search payloads).
- Forward real assignee logins from `buildCandidate` onto hosted candidates; omit the field when absent/empty so clients can distinguish "never served" from "served empty" per the contract.
- Unit tests cover present assignees and omitted-when-absent paths.

Closes #8655

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) - a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ?99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Local Node is v24; repo engines pin Node 22. New coverage is in `test/unit/discovery-index/discovery-query.test.ts` and will run under CI. No UI/MCP surface in this change.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A - no visible UI changes.

## Notes

- Client `discover-cli.ts` already consumes `assignees`; this only populates the hosted server side.