### PR TITLE
fix(orb): align neverClosed with closeOwnerAuthors and admin authors

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -2076,13 +2076,17 @@ export function derivePublicCommentMergeFacts(args: {
   const repoOwner = args.repoFullName.includes("/") ? args.repoFullName.slice(0, args.repoFullName.indexOf("/")) : "";
   const authorLogin = args.authorLogin ?? "";
   const authorIsOwner = authorLogin.length > 0 && authorLogin.toLowerCase() === repoOwner.toLowerCase();
-  const authorIsAdmin = args.authorIsAdmin === true;
+  const authorIsAdmin = Boolean(args.authorIsAdmin);
   const authorIsAutomationBot = isProtectedAutomationAuthor(args.authorLogin);
   // Match closeEligible (isContributor || ((owner||admin) && closeOwnerAuthors)): neverClosed is the comment's
   // claim that auto-close will not fire. Owner/admin are closable only when closeOwnerAuthors is explicitly
   // true; automation bots remain never-closed (#8683).
-  const neverClosed =
-    authorIsAutomationBot || ((authorIsOwner || authorIsAdmin) && args.settings.closeOwnerAuthors !== true);
+  let neverClosed = false;
+  if (authorIsAutomationBot) {
+    neverClosed = true;
+  } else if (authorIsOwner || authorIsAdmin) {
+    neverClosed = args.settings.closeOwnerAuthors !== true;
+  }
   return { ciState, mergeStateLabel, mergeReadiness, heldForReview, neverClosed };
 }
 

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -2033,18 +2033,25 @@ function publicCheckFailureDetails(details: LiveCiAggregate["failingDetails"]): 
  *   comment would headline "approve/merge recommended" while the executor kept silently denying the merge/
  *   approve action every single time, with no visible explanation anywhere on the PR (confirmed live on PR
  *   #7994, stuck ~3+ hours with a stale manual-review label from an earlier missing_linked_issue blocker).
- * - `neverClosed` — the disposition never auto-closes a repo-owner or protected-automation PR, so a gate
- *   "close" verdict on one must headline "held", not "Closed" (#8/#9).
+ * - `neverClosed` — the disposition never auto-closes a protected author unless the repo opted into
+ *   `closeOwnerAuthors` for owners/admins (same closeEligible formula as planAgentMaintenanceActions /
+ *   closeWithheldReason). Automation bots stay never-closed. A gate "close" verdict on a neverClosed
+ *   author must headline "held", not "Closed" (#8/#9 / #8683).
  */
 export function derivePublicCommentMergeFacts(args: {
   liveMergeState: string | undefined;
   mergeableState: string | null | undefined;
   authorLogin: string | null | undefined;
   liveCi: Pick<LiveCiAggregate, "ciState" | "failingDetails" | "nonRequiredFailingDetails">;
-  settings: Pick<RepositorySettings, "hardGuardrailGlobs" | "hardGuardrailGlobsOverridesInvariants" | "manualReviewLabel">;
+  settings: Pick<
+    RepositorySettings,
+    "hardGuardrailGlobs" | "hardGuardrailGlobsOverridesInvariants" | "manualReviewLabel" | "closeOwnerAuthors"
+  >;
   unifiedFiles: Awaited<ReturnType<typeof listPullRequestFiles>>;
   repoFullName: string;
   prLabels: readonly string[];
+  /** Fleet / per-repo admin (non-owner) — same flag the planner threads into closeEligible (#8683). */
+  authorIsAdmin?: boolean;
 }): PublicCommentMergeFacts {
   const mergeStateLabel = args.liveMergeState ?? args.mergeableState ?? undefined; // fail-safe to the stored value
   const ciState: MergeReadiness["ciState"] =
@@ -2068,8 +2075,14 @@ export function derivePublicCommentMergeFacts(args: {
     isGuardrailHit(changedPathsForGuardrail(args.unifiedFiles), resolveHardGuardrailGlobs(args.settings)) || manualReviewLabelPresent;
   const repoOwner = args.repoFullName.includes("/") ? args.repoFullName.slice(0, args.repoFullName.indexOf("/")) : "";
   const authorLogin = args.authorLogin ?? "";
+  const authorIsOwner = authorLogin.length > 0 && authorLogin.toLowerCase() === repoOwner.toLowerCase();
+  const authorIsAdmin = args.authorIsAdmin === true;
+  const authorIsAutomationBot = isProtectedAutomationAuthor(args.authorLogin);
+  // Match closeEligible (isContributor || ((owner||admin) && closeOwnerAuthors)): neverClosed is the comment's
+  // claim that auto-close will not fire. Owner/admin are closable only when closeOwnerAuthors is explicitly
+  // true; automation bots remain never-closed (#8683).
   const neverClosed =
-    (authorLogin.length > 0 && authorLogin.toLowerCase() === repoOwner.toLowerCase()) || isProtectedAutomationAuthor(args.authorLogin);
+    authorIsAutomationBot || ((authorIsOwner || authorIsAdmin) && args.settings.closeOwnerAuthors !== true);
   return { ciState, mergeStateLabel, mergeReadiness, heldForReview, neverClosed };
 }
 
@@ -11111,6 +11124,11 @@ async function maybePublishPrPublicSurface(
       // The stored pr.mergeableState lags GitHub's async recompute, and the gate's own check/review publication can
       // also advance mergeability after readiness ran, so refresh at this post-publish boundary.
       const liveMergeState = await refreshLiveMergeState(env, repoFullName, webhook.liveFacts, pr.number, token, admissionKey).catch(() => undefined);
+      // #8683: neverClosed must see the same admin + closeOwnerAuthors inputs the planner's closeEligible uses.
+      const authorIsAdminForComment =
+        typeof pr.authorLogin === "string" && pr.authorLogin.length > 0
+          ? await isPerTenantAdmin(env, installationId, repoFullName, pr.authorLogin)
+          : false;
       const { ciState, mergeStateLabel, mergeReadiness, heldForReview, neverClosed } = derivePublicCommentMergeFacts({
         liveMergeState,
         mergeableState: pr.mergeableState,
@@ -11120,6 +11138,7 @@ async function maybePublishPrPublicSurface(
         unifiedFiles,
         repoFullName,
         prLabels: pr.labels,
+        authorIsAdmin: authorIsAdminForComment,
       });
       // The public comment must match the authoritative Gate check-run conclusion.
       const commentGate = commentGateEvaluation;

--- a/test/unit/processors-public-comment-merge-facts.test.ts
+++ b/test/unit/processors-public-comment-merge-facts.test.ts
@@ -12,7 +12,11 @@ const NO_GUARDRAIL_OVERRIDES = {
   hardGuardrailGlobs: [],
   hardGuardrailGlobsOverridesInvariants: false,
   manualReviewLabel: undefined,
-} as Pick<RepositorySettings, "hardGuardrailGlobs" | "hardGuardrailGlobsOverridesInvariants" | "manualReviewLabel">;
+  closeOwnerAuthors: false,
+} as Pick<
+  RepositorySettings,
+  "hardGuardrailGlobs" | "hardGuardrailGlobsOverridesInvariants" | "manualReviewLabel" | "closeOwnerAuthors"
+>;
 
 function facts(overrides: Partial<Parameters<typeof derivePublicCommentMergeFacts>[0]> = {}) {
   return derivePublicCommentMergeFacts({
@@ -118,7 +122,11 @@ describe("derivePublicCommentMergeFacts() — heldForReview (#guarded-hold-comme
           hardGuardrailGlobs: [],
           hardGuardrailGlobsOverridesInvariants: true,
           manualReviewLabel: undefined,
-        } as Pick<RepositorySettings, "hardGuardrailGlobs" | "hardGuardrailGlobsOverridesInvariants" | "manualReviewLabel">,
+          closeOwnerAuthors: false,
+        } as Pick<
+          RepositorySettings,
+          "hardGuardrailGlobs" | "hardGuardrailGlobsOverridesInvariants" | "manualReviewLabel" | "closeOwnerAuthors"
+        >,
       }).heldForReview,
     ).toBe(false);
   });
@@ -147,7 +155,11 @@ describe("derivePublicCommentMergeFacts() — manual-review label hold (#7994-fo
       hardGuardrailGlobs: [],
       hardGuardrailGlobsOverridesInvariants: false,
       manualReviewLabel: "needs-maintainer",
-    } as Pick<RepositorySettings, "hardGuardrailGlobs" | "hardGuardrailGlobsOverridesInvariants" | "manualReviewLabel">;
+      closeOwnerAuthors: false,
+    } as Pick<
+      RepositorySettings,
+      "hardGuardrailGlobs" | "hardGuardrailGlobsOverridesInvariants" | "manualReviewLabel" | "closeOwnerAuthors"
+    >;
     // The default "manual-review" label no longer matters once a custom name is configured.
     expect(facts({ unifiedFiles: [UNGUARDED_FILE], settings, prLabels: ["manual-review"] }).heldForReview).toBe(false);
     expect(facts({ unifiedFiles: [UNGUARDED_FILE], settings, prLabels: ["needs-maintainer"] }).heldForReview).toBe(true);
@@ -158,7 +170,11 @@ describe("derivePublicCommentMergeFacts() — manual-review label hold (#7994-fo
       hardGuardrailGlobs: [],
       hardGuardrailGlobsOverridesInvariants: false,
       manualReviewLabel: null,
-    } as Pick<RepositorySettings, "hardGuardrailGlobs" | "hardGuardrailGlobsOverridesInvariants" | "manualReviewLabel">;
+      closeOwnerAuthors: false,
+    } as Pick<
+      RepositorySettings,
+      "hardGuardrailGlobs" | "hardGuardrailGlobsOverridesInvariants" | "manualReviewLabel" | "closeOwnerAuthors"
+    >;
     expect(facts({ unifiedFiles: [UNGUARDED_FILE], settings, prLabels: ["manual-review"] }).heldForReview).toBe(false);
   });
 });
@@ -188,5 +204,35 @@ describe("derivePublicCommentMergeFacts() — neverClosed (#8/#9, #4607)", () =>
 
   it("treats a repoFullName with no owner segment as having no owner", () => {
     expect(facts({ repoFullName: "no-slash-name", authorLogin: "contributor" }).neverClosed).toBe(false);
+  });
+
+  it("is false for an owner-authored PR when closeOwnerAuthors is true (#8683)", () => {
+    expect(
+      facts({
+        repoFullName: "acme/widgets",
+        authorLogin: "acme",
+        settings: { ...NO_GUARDRAIL_OVERRIDES, closeOwnerAuthors: true },
+      }).neverClosed,
+    ).toBe(false);
+  });
+
+  it("is true for an admin (non-owner) author when closeOwnerAuthors is not true (#8683)", () => {
+    expect(
+      facts({
+        repoFullName: "acme/widgets",
+        authorLogin: "fleet-admin",
+        authorIsAdmin: true,
+        settings: { ...NO_GUARDRAIL_OVERRIDES, closeOwnerAuthors: false },
+      }).neverClosed,
+    ).toBe(true);
+    // And when the repo opts into closing owners/admins, the admin is closable too.
+    expect(
+      facts({
+        repoFullName: "acme/widgets",
+        authorLogin: "fleet-admin",
+        authorIsAdmin: true,
+        settings: { ...NO_GUARDRAIL_OVERRIDES, closeOwnerAuthors: true },
+      }).neverClosed,
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Align `derivePublicCommentMergeFacts`'s `neverClosed` with the planner `closeEligible` formula: respect `closeOwnerAuthors`, and treat per-repo admin authors like owners.
- Thread `authorIsAdmin` from the public-comment publish path via `isPerTenantAdmin`.
- Add unit coverage for owner+`closeOwnerAuthors: true` and admin (non-owner) cases.

Closes #8683

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) - a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ?99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Local Node is v24; repo engines pin Node 22. New coverage is in `test/unit/processors-public-comment-merge-facts.test.ts` and will run under CI. No UI/MCP surface in this change.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A - no visible UI changes.

## Notes

- Existing contributor / plain-owner / automation-bot neverClosed cases remain covered and unchanged in behavior when `closeOwnerAuthors` is not set.