### PR TITLE
fix(ui): use the info tone for unrecognized skip reasons in the audit feed

### DIFF
--- a/apps/loopover-ui/src/components/site/audit-feed-model.ts
+++ b/apps/loopover-ui/src/components/site/audit-feed-model.ts
@@ -125,5 +125,8 @@ export function skipReasonTone(reason: string): "ready" | "info" | "warn" | "deg
   if (reason === "bot_author" || reason === "not_official_gittensor_miner") return "info";
   if (reason === "surface_off" || reason === "maintainer_author") return "warn";
   if (reason === "miner_detection_unavailable" || reason === "missing_author") return "degraded";
-  return "ready";
+  // `reason` is a plain string at the API boundary (same widening as contributor-quality-table-model's
+  // `band: string`), so an unrecognized/legacy value can reach here. Degrade it to the neutral "info"
+  // pill — never "ready", which would render an unclassified skip as green/healthy.
+  return "info";
 }

--- a/apps/loopover-ui/src/components/site/audit-feed.test.tsx
+++ b/apps/loopover-ui/src/components/site/audit-feed.test.tsx
@@ -11,6 +11,7 @@ import {
   normalizeSinceInput,
   normalizeSkippedPrAuditExport,
   pullRequestHref,
+  skipReasonTone,
 } from "@/components/site/audit-feed-model";
 import { AuditFeed } from "@/components/site/audit-feed";
 
@@ -70,6 +71,21 @@ describe("audit feed helpers", () => {
     );
   });
 
+  it("maps the enumerated skip reasons to their tones and degrades an unrecognized reason to the neutral info tone, never ready", () => {
+    // The four enumerated reasons keep their existing tones.
+    expect(skipReasonTone("bot_author")).toBe("info");
+    expect(skipReasonTone("not_official_gittensor_miner")).toBe("info");
+    expect(skipReasonTone("surface_off")).toBe("warn");
+    expect(skipReasonTone("maintainer_author")).toBe("warn");
+    expect(skipReasonTone("miner_detection_unavailable")).toBe("degraded");
+    expect(skipReasonTone("missing_author")).toBe("degraded");
+    // An unrecognized/legacy reason string must degrade to the neutral pill (the
+    // contributor-quality-table-model `band: string` convention), not the green "ready" tone.
+    expect(skipReasonTone("legacy_skip_reason")).toBe("info");
+    expect(skipReasonTone("legacy_skip_reason")).not.toBe("ready");
+    expect(skipReasonTone("")).toBe("info");
+  });
+
   it("normalizes since input without throwing on invalid dates", () => {
     expect(normalizeSinceInput("")).toBe("");
     expect(normalizeSinceInput("   ")).toBe("");
@@ -119,6 +135,29 @@ describe("AuditFeed", () => {
       "https://api.test/v1/app/skipped-pr-audit?limit=50&offset=0",
       expect.objectContaining({ credentials: "include" }),
     );
+  });
+
+  it("renders an unrecognized skip reason as a neutral info pill, not the green ready tone", async () => {
+    apiFetch.mockResolvedValue({
+      ok: true,
+      data: {
+        ...SAMPLE,
+        items: [
+          {
+            repoFullName: "repo-owner/owned-repo",
+            pullNumber: 6,
+            reason: "legacy_skip_reason",
+            timestamp: "2026-05-28T00:00:04.000Z",
+            remediation: "Contact support to reclassify this legacy skip.",
+          },
+        ],
+      },
+    });
+    render(<AuditFeed />);
+    const pill = await screen.findByText("legacy skip reason");
+    // "info" tone (text-mint), never the "ready" tone (text-success) that implies a healthy state.
+    expect(pill.className).toContain("text-mint");
+    expect(pill.className).not.toContain("text-success");
   });
 
   it("wraps the audit table in a keyboard-focusable, labelled scroll region with a caption and column-scoped headers (#794 a11y pattern)", async () => {


### PR DESCRIPTION
Closes #8666

## Problem

`skipReasonTone` (`apps/loopover-ui/src/components/site/audit-feed-model.ts`) falls back to `"ready"` — the green, healthy-looking tone — for any reason string outside the four enumerated skip reasons. `SkippedPrAuditItem.reason` is a plain `string` at the API boundary (the same intentional widening as `contributor-quality-table-model.ts`'s `band: string`), so a new or legacy backend skip reason silently rendered in the audit feed as a green "ready" pill, implying a positive state for something actually unclassified — contrary to the sibling model's explicit "an unrecognized value degrades to a neutral pill" convention.

## Fix

The fallback branch now returns the neutral `"info"` tone, mirroring `contributor-quality-table-model.ts`'s established convention. None of the four enumerated reasons map to `"ready"`, so **no enumerated reason's behavior changes** — only the unrecognized-value fallback.

## Tests (new coverage for a branch that had none)

Added to `apps/loopover-ui/src/components/site/audit-feed.test.tsx`, both red on `main` before the fix:

| Deliverable | Test | Before (main) | After |
|---|---|---|---|
| Fallback returns `"info"`, not `"ready"` | direct `skipReasonTone("legacy_skip_reason")` assertion (plus `""`), exercising the previously zero-coverage fallback branch | **failed**: `expected 'ready' to be 'info'` | passes |
| Rendered pill is not the ready tone | renders `<AuditFeed />` with an unmapped `reason: "legacy_skip_reason"` item and asserts the pill's classes contain the info tone (`text-mint`) and **not** the ready tone (`text-success`) | **failed**: pill rendered `border-success/40 bg-success/10 text-success` | passes |
| Enumerated reasons unchanged | asserts all six enumerated values keep their exact current tones (`info`/`warn`/`degraded`); existing `surface_off` render tests untouched | passes | passes |

Full file run: 17/17 passing; `tsc --noEmit` clean; prettier/eslint clean on both changed files; `git diff --check` clean.

## UI Evidence

The `/app/audit` skipped-PR audit feed, served locally (`vite` dev, preview session per the contributor skill) with the audit export API answered at the network boundary by a fixture that includes one **unrecognized** reason (`legacy_skip_reason`) alongside enumerated ones — the only way to exercise this fallback, since it is unreachable while the backend only emits the enumerated reasons. Look at the **`LEGACY SKIP REASON` pill on PR #38**: before, it renders in the green "ready" tone (identical to a healthy state); after, it renders in the neutral "info" (mint) tone like `BOT AUTHOR`. Enumerated pills (`SURFACE OFF`, `BOT AUTHOR`, `MISSING AUTHOR`) are identical in both columns. The UI is a dark-mode-only build, so the Light and Dark rows (captured under emulated `prefers-color-scheme`) render identically by design.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | <a href="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8666-v2/lo8666-desktop-light-before.png"><img src="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8666-v2/lo8666-desktop-light-before.png" alt="Desktop light before — legacy reason pill in green ready tone" width="240"></a> | <a href="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8666-v2/lo8666-desktop-light-after.png"><img src="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8666-v2/lo8666-desktop-light-after.png" alt="Desktop light after — legacy reason pill in neutral info tone" width="240"></a> |
| Desktop · Dark | <a href="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8666-v2/lo8666-desktop-dark-before.png"><img src="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8666-v2/lo8666-desktop-dark-before.png" alt="Desktop dark before — legacy reason pill in green ready tone" width="240"></a> | <a href="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8666-v2/lo8666-desktop-dark-after.png"><img src="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8666-v2/lo8666-desktop-dark-after.png" alt="Desktop dark after — legacy reason pill in neutral info tone" width="240"></a> |
| Tablet · Light | <a href="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8666-v2/lo8666-tablet-light-before.png"><img src="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8666-v2/lo8666-tablet-light-before.png" alt="Tablet light before — legacy reason pill in green ready tone" width="240"></a> | <a href="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8666-v2/lo8666-tablet-light-after.png"><img src="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8666-v2/lo8666-tablet-light-after.png" alt="Tablet light after — legacy reason pill in neutral info tone" width="240"></a> |
| Tablet · Dark | <a href="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8666-v2/lo8666-tablet-dark-before.png"><img src="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8666-v2/lo8666-tablet-dark-before.png" alt="Tablet dark before — legacy reason pill in green ready tone" width="240"></a> | <a href="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8666-v2/lo8666-tablet-dark-after.png"><img src="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8666-v2/lo8666-tablet-dark-after.png" alt="Tablet dark after — legacy reason pill in neutral info tone" width="240"></a> |
| Mobile · Light | <a href="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8666-v2/lo8666-mobile-light-before.png"><img src="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8666-v2/lo8666-mobile-light-before.png" alt="Mobile light before — legacy reason pill in green ready tone" width="240"></a> | <a href="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8666-v2/lo8666-mobile-light-after.png"><img src="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8666-v2/lo8666-mobile-light-after.png" alt="Mobile light after — legacy reason pill in neutral info tone" width="240"></a> |
| Mobile · Dark | <a href="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8666-v2/lo8666-mobile-dark-before.png"><img src="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8666-v2/lo8666-mobile-dark-before.png" alt="Mobile dark before — legacy reason pill in green ready tone" width="240"></a> | <a href="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8666-v2/lo8666-mobile-dark-after.png"><img src="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8666-v2/lo8666-mobile-dark-after.png" alt="Mobile dark after — legacy reason pill in neutral info tone" width="240"></a> |
