### PR TITLE
fix(ui): migrate the pre-rebrand analytics window preference forward

### DIFF
--- a/apps/loopover-ui/src/routes/app.analytics.test.tsx
+++ b/apps/loopover-ui/src/routes/app.analytics.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 // #6817: app.analytics.tsx's StateBoundary had no loadingSkeleton, falling through to the generic spinner
 // -- the same gap #6816 fixed for app.operator.tsx.
@@ -40,5 +40,62 @@ describe("ProductAnalytics loading skeleton (#6817)", () => {
     const { container } = render(<ProductAnalytics />);
     expect(screen.getByText("Usage & value analytics")).toBeTruthy();
     expect(container.querySelectorAll(".animate-pulse").length).toBe(0);
+  });
+});
+
+// #8699: the analytics window preference was renamed from "gittensory.analytics.windowDays" to
+// "loopover.analytics.windowDays" in the rebrand (75450f1d5) without the one-time legacyKey fallback
+// app.runs.tsx / app.workbench.tsx got, silently resetting returning users to the 7-day default.
+describe("ProductAnalytics window preference rebrand migration (#8699)", () => {
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("migrates a pre-rebrand gittensory window preference forward instead of resetting to 7d", async () => {
+    window.localStorage.setItem("gittensory.analytics.windowDays", "30");
+    useApiResource.mockReturnValue({
+      status: "ready",
+      data: { metrics: [{ label: "Active repos", value: "12", delta: "+2" }], noiseReduction: [] },
+      error: null,
+      loadedAt: "2026-07-17T00:00:00.000Z",
+      reload: () => {},
+    });
+
+    render(<ProductAnalytics />);
+
+    // The toggle group renders once the preference has hydrated -- with the legacy value carried
+    // over, 30d is the selected window (not the 7-day default the user never chose).
+    const thirtyDay = await screen.findByRole("radio", { name: "30 day window" });
+    await waitFor(() => expect(thirtyDay.getAttribute("data-state")).toBe("on"));
+    expect(screen.getByRole("radio", { name: "7 day window" }).getAttribute("data-state")).toBe(
+      "off",
+    );
+    // The dashboard is fetched for the migrated window, not the default.
+    await waitFor(() =>
+      expect(useApiResource).toHaveBeenLastCalledWith(
+        "/v1/app/operator-dashboard?days=30",
+        "Product analytics",
+      ),
+    );
+    // Backfilled: the new key now holds the value directly (the hook migrates it forward on first read).
+    expect(window.localStorage.getItem("loopover.analytics.windowDays")).toBe("30");
+  });
+
+  it("still uses the 7-day default when neither the new nor the legacy key is present", async () => {
+    useApiResource.mockReturnValue({
+      status: "ready",
+      data: { metrics: [{ label: "Active repos", value: "12", delta: "+2" }], noiseReduction: [] },
+      error: null,
+      loadedAt: "2026-07-17T00:00:00.000Z",
+      reload: () => {},
+    });
+
+    render(<ProductAnalytics />);
+
+    const sevenDay = await screen.findByRole("radio", { name: "7 day window" });
+    await waitFor(() => expect(sevenDay.getAttribute("data-state")).toBe("on"));
+    // Nothing to migrate: no value is invented under either key.
+    expect(window.localStorage.getItem("loopover.analytics.windowDays")).toBeNull();
+    expect(window.localStorage.getItem("gittensory.analytics.windowDays")).toBeNull();
   });
 });

--- a/apps/loopover-ui/src/routes/app.analytics.tsx
+++ b/apps/loopover-ui/src/routes/app.analytics.tsx
@@ -172,6 +172,9 @@ export function ProductAnalytics() {
   const [windowDays, setWindowDays, windowHydrated] = useLocalStorage<AnalyticsWindowDays>(
     ANALYTICS_WINDOW_STORAGE_KEY,
     DEFAULT_ANALYTICS_WINDOW_DAYS,
+    // Pre-rebrand key (#8699): read once as a fallback and migrate forward, mirroring
+    // app.runs.tsx / app.workbench.tsx, so a returning user's window choice survives the rename.
+    "gittensory.analytics.windowDays",
   );
   const selectedWindow = parseAnalyticsWindowDays(windowDays);
   const dashboard = useApiResource<OperatorDashboard>(

--- a/scripts/branding-drift-baseline.json
+++ b/scripts/branding-drift-baseline.json
@@ -1,5 +1,6 @@
 {
   "apps/loopover-ui/src/components/site/api/try-it.tsx": 1,
+  "apps/loopover-ui/src/routes/app.analytics.tsx": 1,
   "apps/loopover-ui/src/routes/app.index.tsx": 1,
   "apps/loopover-ui/src/routes/app.runs.tsx": 1,
   "apps/loopover-ui/src/routes/app.workbench.tsx": 1,


### PR DESCRIPTION
Closes #8699

## What

`app.analytics.tsx` called `useLocalStorage<AnalyticsWindowDays>(ANALYTICS_WINDOW_STORAGE_KEY, DEFAULT_ANALYTICS_WINDOW_DAYS)` with no third `legacyKey` argument. The key was renamed from `"gittensory.analytics.windowDays"` to `"loopover.analytics.windowDays"` in the rebrand commit (`75450f1d5`) that gave `app.runs.tsx` and `app.workbench.tsx` their one-time `legacyKey` migration — this file was missed. Any returning user who had picked a 30d/90d analytics window before the cutover silently reverted to the 7-day default.

## How

`apps/loopover-ui/src/routes/app.analytics.tsx` now passes `"gittensory.analytics.windowDays"` as the third `useLocalStorage` argument, matching the `app.runs.tsx` / `app.workbench.tsx` pattern exactly. The hook already implements the one-time fallback: if the new key is absent it reads the legacy key, adopts the value, and writes it forward to the new key (leaving the legacy key in place).

Because the fix intentionally introduces one new `"gittensory"` string into `app.analytics.tsx` (the pre-rebrand storage key itself — the same intentional historical reference `app.runs.tsx`/`app.workbench.tsx` already carry), `scripts/branding-drift-baseline.json` is regenerated via `npm run branding-drift:update` in this same commit, exactly as the branding-drift checker's own guidance instructs for a legitimate legacy-key reference. Without it, `branding-drift:check` fails on the 0 → 1 count increase for this file.

## Deliverables

- [x] The `useLocalStorage` call for the analytics window preference includes the `"gittensory.analytics.windowDays"` legacy key.
- [x] New test in `apps/loopover-ui/src/routes/app.analytics.test.tsx`: seeds `localStorage["gittensory.analytics.windowDays"] = "30"`, mounts `ProductAnalytics`, and asserts the toggle group shows 30d selected (`data-state="on"`, 7d `"off"`), the dashboard is fetched for `?days=30`, and `localStorage["loopover.analytics.windowDays"]` is backfilled with `"30"` — mirroring the migration tests used for the runs/workbench keys in `use-local-storage.test.ts`. A companion test pins the no-keys case: 7d default, and no value invented under either key.
- [x] `scripts/branding-drift-baseline.json` regenerated (`npm run branding-drift:update`) for the intentional legacy-key reference; `npm run branding-drift:check` green.

## Before / after

On unfixed `main` (fix stashed), the new migration test fails exactly as the issue describes — the seeded 30d preference is ignored and the default wins:

```
× migrates a pre-rebrand gittensory window preference forward instead of resetting to 7d
  AssertionError: expected 'off' to be 'on'   // 7d is "on", 30d is "off"
```

With the fix:

```
✓ src/routes/app.analytics.test.tsx (4 tests)
✓ src/lib/use-local-storage.test.ts (11 tests)
```

`ui:typecheck`, `ui:lint` (eslint + prettier) on the changed files, `branding-drift:check`, and `git diff --check` all green.

## UI Evidence

`/app/analytics`, served locally (`vite` dev, preview session per the contributor skill) with `localStorage` seeded the way a returning pre-rebrand user's browser looks: `gittensory.analytics.windowDays = "30"` and no `loopover.*` key. The operator-dashboard API is answered at the network boundary by a fixture so the page renders its loaded state. Look at the **window toggle group**: before, the stored 30d preference is ignored and **7d** is active (the bug); after, the legacy value is migrated forward and **30d** is active, with the dashboard fetched for `?days=30`. The UI is a dark-mode-only build, so the Light and Dark rows (captured under emulated `prefers-color-scheme`) render identically by design.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | <a href="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8699-v2/lo8699-desktop-light-before.png"><img src="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8699-v2/lo8699-desktop-light-before.png" alt="Desktop light before — stored 30d ignored, 7d active" width="240"></a> | <a href="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8699-v2/lo8699-desktop-light-after.png"><img src="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8699-v2/lo8699-desktop-light-after.png" alt="Desktop light after — legacy 30d migrated, 30d active" width="240"></a> |
| Desktop · Dark | <a href="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8699-v2/lo8699-desktop-dark-before.png"><img src="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8699-v2/lo8699-desktop-dark-before.png" alt="Desktop dark before — stored 30d ignored, 7d active" width="240"></a> | <a href="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8699-v2/lo8699-desktop-dark-after.png"><img src="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8699-v2/lo8699-desktop-dark-after.png" alt="Desktop dark after — legacy 30d migrated, 30d active" width="240"></a> |
| Tablet · Light | <a href="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8699-v2/lo8699-tablet-light-before.png"><img src="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8699-v2/lo8699-tablet-light-before.png" alt="Tablet light before — stored 30d ignored, 7d active" width="240"></a> | <a href="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8699-v2/lo8699-tablet-light-after.png"><img src="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8699-v2/lo8699-tablet-light-after.png" alt="Tablet light after — legacy 30d migrated, 30d active" width="240"></a> |
| Tablet · Dark | <a href="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8699-v2/lo8699-tablet-dark-before.png"><img src="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8699-v2/lo8699-tablet-dark-before.png" alt="Tablet dark before — stored 30d ignored, 7d active" width="240"></a> | <a href="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8699-v2/lo8699-tablet-dark-after.png"><img src="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8699-v2/lo8699-tablet-dark-after.png" alt="Tablet dark after — legacy 30d migrated, 30d active" width="240"></a> |
| Mobile · Light | <a href="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8699-v2/lo8699-mobile-light-before.png"><img src="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8699-v2/lo8699-mobile-light-before.png" alt="Mobile light before — stored 30d ignored, 7d active" width="240"></a> | <a href="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8699-v2/lo8699-mobile-light-after.png"><img src="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8699-v2/lo8699-mobile-light-after.png" alt="Mobile light after — legacy 30d migrated, 30d active" width="240"></a> |
| Mobile · Dark | <a href="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8699-v2/lo8699-mobile-dark-before.png"><img src="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8699-v2/lo8699-mobile-dark-before.png" alt="Mobile dark before — stored 30d ignored, 7d active" width="240"></a> | <a href="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8699-v2/lo8699-mobile-dark-after.png"><img src="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8699-v2/lo8699-mobile-dark-after.png" alt="Mobile dark after — legacy 30d migrated, 30d active" width="240"></a> |
