### PR TITLE
fix(miner): drop stale ProcessEnv casts on resolveReplaySnapshotDbPath

### DIFF
--- a/packages/loopover-miner/lib/migrate-cli.ts
+++ b/packages/loopover-miner/lib/migrate-cli.ts
@@ -60,14 +60,7 @@ const STORES: MigrateStoreDescriptor[] = [
   { name: "plan-store", resolveDbPath: resolvePlanStoreDbPath, open: openPlanStore },
   { name: "governor-state", resolveDbPath: resolveGovernorStateDbPath, open: openGovernorState },
   { name: "attempt-log", resolveDbPath: resolveAttemptLogDbPath, open: initAttemptLog },
-  {
-    name: "replay-snapshot",
-    // resolveReplaySnapshotDbPath's own (not-yet-converted) .d.ts types `env` as `NodeJS.ProcessEnv`, unlike
-    // every sibling resolver here (`Record<string, string | undefined>`) -- a pre-existing inconsistency, not
-    // introduced by this batch. process.env genuinely satisfies both shapes at runtime, so this cast is safe.
-    resolveDbPath: resolveReplaySnapshotDbPath as (env?: Record<string, string | undefined>) => string,
-    open: openReplaySnapshotStore,
-  },
+  { name: "replay-snapshot", resolveDbPath: resolveReplaySnapshotDbPath, open: openReplaySnapshotStore },
   {
     name: "worktree-allocator",
     resolveDbPath: resolveWorktreeAllocatorDbPath,

--- a/packages/loopover-miner/lib/status.ts
+++ b/packages/loopover-miner/lib/status.ts
@@ -399,8 +399,7 @@ function storeIntegrityChecks(env: Record<string, string | undefined>): DoctorCh
     ["plan-store", resolvePlanStoreDbPath(env)],
     ["governor-state", resolveGovernorStateDbPath(env)],
     ["attempt-log", resolveAttemptLogDbPath(env)],
-    // replay-snapshot's .d.ts still types env as ProcessEnv (not yet migrated); cast is lossless.
-    ["replay-snapshot", resolveReplaySnapshotDbPath(env as NodeJS.ProcessEnv)],
+    ["replay-snapshot", resolveReplaySnapshotDbPath(env)],
     ["worktree-allocator", resolveWorktreeAllocatorDbPath(env)],
     ["contribution-profile", resolveContributionProfileCacheDbPath(env)],
     ["policy-verdict-cache", resolvePolicyVerdictCacheDbPath(env)],


### PR DESCRIPTION
## Summary

- Remove stale `not yet migrated` comments and `NodeJS.ProcessEnv` casts around `resolveReplaySnapshotDbPath` in `migrate-cli.ts` and `status.ts`.
- Call the resolver directly — its real type is already `Record<string, string | undefined>`, matching sibling store resolvers.

Closes #8642

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npx tsc -p packages/loopover-miner/tsconfig.json --noEmit` (exit 0 after cast removal)
- [ ] `npm run actionlint` — not applicable
- [ ] `npm run typecheck` — covered by focused miner `tsc` above
- [ ] `npm run test:coverage` — not required (type/comment-only; no new runtime branch per issue)
- [ ] `npm run test:workers` — not applicable
- [ ] `npm run build:mcp` — not applicable
- [ ] `npm run test:mcp-pack` — not applicable
- [ ] `npm run ui:openapi:check` — not applicable
- [ ] `npm run ui:lint` — not applicable
- [ ] `npm run ui:typecheck` — not applicable
- [ ] `npm run ui:build` — not applicable
- [ ] `npm audit --audit-level=moderate` — not applicable
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Issue Test Coverage Requirements: type-level/comment fix with no behavioral change; verification is `tsc` passing with casts removed.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — miner type/comment cleanup only.

## Notes

- Duplicate-checked open PRs for #8642 before opening.