### PR TITLE
test(ui): cover miner-commands redaction and action branches

### DIFF
--- a/apps/loopover-ui/src/lib/miner-commands.test.ts
+++ b/apps/loopover-ui/src/lib/miner-commands.test.ts
@@ -33,24 +33,43 @@ describe("sanitizeMinerCommand (#8677)", () => {
 
   it("does not corrupt a legitimate login/repo token that merely contains a forbidden word as a name", () => {
     // Contract: assignment form is required. A repo named wallet-adapter must not be mangled.
-    const cmd = "loopover-mcp preflight --login trust-score --repo wallet-adapter/sdk --base origin/main --json";
+    const cmd =
+      "loopover-mcp preflight --login trust-score --repo wallet-adapter/sdk --base origin/main --json";
     expect(sanitizeMinerCommand(cmd)).toBe(cmd);
   });
 
   it("redacts POSIX home, absolute, and Windows absolute local paths", () => {
     expect(sanitizeMinerCommand("run --cwd /home/user/project --json")).toContain("<local-path>");
     expect(sanitizeMinerCommand("run --cwd ~/code/repo --json")).toContain("<local-path>");
-    expect(sanitizeMinerCommand("run --cwd C:\\Users\\admin\\proj --json")).toContain("<local-path>");
+    expect(sanitizeMinerCommand("run --cwd C:\\Users\\admin\\proj --json")).toContain(
+      "<local-path>",
+    );
   });
 });
 
 describe("buildMinerCommandActions (#8677)", () => {
   it("returns setup/ready actions when login and repo are absent (fallback placeholders)", () => {
     const actions = buildMinerCommandActions({});
-    expect(actions.map((a) => a.id)).toEqual(["install", "status", "doctor", "plan", "preflight", "packet"]);
-    expect(actions.find((a) => a.id === "install")).toMatchObject({ state: "setup", copyable: true });
-    expect(actions.find((a) => a.id === "status")).toMatchObject({ state: "ready", copyable: true });
-    expect(actions.find((a) => a.id === "doctor")).toMatchObject({ state: "ready", copyable: true });
+    expect(actions.map((a) => a.id)).toEqual([
+      "install",
+      "status",
+      "doctor",
+      "plan",
+      "preflight",
+      "packet",
+    ]);
+    expect(actions.find((a) => a.id === "install")).toMatchObject({
+      state: "setup",
+      copyable: true,
+    });
+    expect(actions.find((a) => a.id === "status")).toMatchObject({
+      state: "ready",
+      copyable: true,
+    });
+    expect(actions.find((a) => a.id === "doctor")).toMatchObject({
+      state: "ready",
+      copyable: true,
+    });
     expect(actions.find((a) => a.id === "plan")).toMatchObject({
       state: "needs_login",
       copyable: false,
@@ -61,7 +80,10 @@ describe("buildMinerCommandActions (#8677)", () => {
       copyable: false,
       command: expect.stringContaining("owner/repo"),
     });
-    expect(actions.find((a) => a.id === "packet")).toMatchObject({ state: "needs_login", copyable: false });
+    expect(actions.find((a) => a.id === "packet")).toMatchObject({
+      state: "needs_login",
+      copyable: false,
+    });
   });
 
   it("marks plan ready and preflight/packet needs_repo when only login is present", () => {
@@ -71,8 +93,14 @@ describe("buildMinerCommandActions (#8677)", () => {
       copyable: true,
       command: expect.stringContaining("--login alice"),
     });
-    expect(actions.find((a) => a.id === "preflight")).toMatchObject({ state: "needs_repo", copyable: false });
-    expect(actions.find((a) => a.id === "packet")).toMatchObject({ state: "needs_repo", copyable: false });
+    expect(actions.find((a) => a.id === "preflight")).toMatchObject({
+      state: "needs_repo",
+      copyable: false,
+    });
+    expect(actions.find((a) => a.id === "packet")).toMatchObject({
+      state: "needs_repo",
+      copyable: false,
+    });
   });
 
   it("marks preflight and packet ready when both login and repo are present", () => {
@@ -85,7 +113,8 @@ describe("buildMinerCommandActions (#8677)", () => {
     expect(actions.find((a) => a.id === "packet")).toMatchObject({
       state: "ready",
       copyable: true,
-      command: "loopover-mcp agent packet --login alice --repo acme/widgets --base origin/main --json",
+      command:
+        "loopover-mcp agent packet --login alice --repo acme/widgets --base origin/main --json",
     });
   });
 

--- a/apps/loopover-ui/src/lib/miner-commands.test.ts
+++ b/apps/loopover-ui/src/lib/miner-commands.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import { buildMinerCommandActions, sanitizeMinerCommand } from "@/lib/miner-commands";
+
+// (#8677) Direct coverage for miner-commands.ts: sensitive-term redaction and every
+// buildMinerCommandActions branch. Previously only exercised indirectly via miner-panel.test.tsx.
+
+describe("sanitizeMinerCommand (#8677)", () => {
+  it("redacts each forbidden term=value / term: value category", () => {
+    const cases = [
+      { leak: "wallet=abc123", banned: /abc123/ },
+      { leak: "hotkey: 'hk-secret'", banned: /hk-secret/ },
+      { leak: 'coldkey="ck-secret"', banned: /ck-secret/ },
+      { leak: "mnemonic = word1-word2-word3", banned: /word1-word2-word3/ },
+      { leak: "trust-score: 0.99", banned: /0\.99/ },
+      { leak: "trust_score=0.5", banned: /0\.5/ },
+      { leak: "raw-trust: 1", banned: /:\s*1\b/ },
+      { leak: "raw_trust=1", banned: /=\s*1\b/ },
+      { leak: "private-reviewability: high", banned: /high/ },
+      { leak: "private_reviewability=low", banned: /low/ },
+    ];
+    for (const { leak, banned } of cases) {
+      const out = sanitizeMinerCommand(`loopover-mcp status --json ${leak}`);
+      expect(out).toContain("[redacted]");
+      expect(out).not.toMatch(banned);
+    }
+  });
+
+  it("passes through a command with none of the forbidden assignment patterns", () => {
+    const cmd = "loopover-mcp agent plan --login alice --json";
+    expect(sanitizeMinerCommand(cmd)).toBe(cmd);
+  });
+
+  it("does not corrupt a legitimate login/repo token that merely contains a forbidden word as a name", () => {
+    // Contract: assignment form is required. A repo named wallet-adapter must not be mangled.
+    const cmd = "loopover-mcp preflight --login trust-score --repo wallet-adapter/sdk --base origin/main --json";
+    expect(sanitizeMinerCommand(cmd)).toBe(cmd);
+  });
+
+  it("redacts POSIX home, absolute, and Windows absolute local paths", () => {
+    expect(sanitizeMinerCommand("run --cwd /home/user/project --json")).toContain("<local-path>");
+    expect(sanitizeMinerCommand("run --cwd ~/code/repo --json")).toContain("<local-path>");
+    expect(sanitizeMinerCommand("run --cwd C:\\Users\\admin\\proj --json")).toContain("<local-path>");
+  });
+});
+
+describe("buildMinerCommandActions (#8677)", () => {
+  it("returns setup/ready actions when login and repo are absent (fallback placeholders)", () => {
+    const actions = buildMinerCommandActions({});
+    expect(actions.map((a) => a.id)).toEqual(["install", "status", "doctor", "plan", "preflight", "packet"]);
+    expect(actions.find((a) => a.id === "install")).toMatchObject({ state: "setup", copyable: true });
+    expect(actions.find((a) => a.id === "status")).toMatchObject({ state: "ready", copyable: true });
+    expect(actions.find((a) => a.id === "doctor")).toMatchObject({ state: "ready", copyable: true });
+    expect(actions.find((a) => a.id === "plan")).toMatchObject({
+      state: "needs_login",
+      copyable: false,
+      command: expect.stringContaining("your-login"),
+    });
+    expect(actions.find((a) => a.id === "preflight")).toMatchObject({
+      state: "needs_login",
+      copyable: false,
+      command: expect.stringContaining("owner/repo"),
+    });
+    expect(actions.find((a) => a.id === "packet")).toMatchObject({ state: "needs_login", copyable: false });
+  });
+
+  it("marks plan ready and preflight/packet needs_repo when only login is present", () => {
+    const actions = buildMinerCommandActions({ login: "alice" });
+    expect(actions.find((a) => a.id === "plan")).toMatchObject({
+      state: "ready",
+      copyable: true,
+      command: expect.stringContaining("--login alice"),
+    });
+    expect(actions.find((a) => a.id === "preflight")).toMatchObject({ state: "needs_repo", copyable: false });
+    expect(actions.find((a) => a.id === "packet")).toMatchObject({ state: "needs_repo", copyable: false });
+  });
+
+  it("marks preflight and packet ready when both login and repo are present", () => {
+    const actions = buildMinerCommandActions({ login: "alice", repoFullName: "acme/widgets" });
+    expect(actions.find((a) => a.id === "preflight")).toMatchObject({
+      state: "ready",
+      copyable: true,
+      command: "loopover-mcp preflight --login alice --repo acme/widgets --base origin/main --json",
+    });
+    expect(actions.find((a) => a.id === "packet")).toMatchObject({
+      state: "ready",
+      copyable: true,
+      command: "loopover-mcp agent packet --login alice --repo acme/widgets --base origin/main --json",
+    });
+  });
+
+  it("treats invalid login/repo shapes as missing (falls back to placeholders)", () => {
+    const actions = buildMinerCommandActions({ login: "bad login!", repoFullName: "not-a-repo" });
+    expect(actions.find((a) => a.id === "plan")?.state).toBe("needs_login");
+    expect(actions.find((a) => a.id === "preflight")?.command).toContain("your-login");
+    expect(actions.find((a) => a.id === "preflight")?.command).toContain("owner/repo");
+  });
+
+  it("runs every built command through sanitizeMinerCommand", () => {
+    const actions = buildMinerCommandActions({ login: "alice", repoFullName: "acme/widgets" });
+    for (const action of actions) {
+      expect(action.command).toBe(sanitizeMinerCommand(action.command));
+    }
+  });
+});

--- a/apps/loopover-ui/src/lib/miner-commands.ts
+++ b/apps/loopover-ui/src/lib/miner-commands.ts
@@ -84,7 +84,7 @@ function safeRepoFullName(value: string | null | undefined): string | null {
   return /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(text) ? text : null;
 }
 
-function sanitizeMinerCommand(command: string): string {
+export function sanitizeMinerCommand(command: string): string {
   return command
     .replace(/(?:~\/|[A-Za-z]:\\)[^\s"'`,;)]+/g, "<local-path>")
     .replace(


### PR DESCRIPTION
## Summary

- Add dedicated `apps/loopover-ui/src/lib/miner-commands.test.ts` covering `sanitizeMinerCommand` (each forbidden `term=value` / `term: value` category, passthrough, name-token non-corruption, and local-path redaction) and every `buildMinerCommandActions` state branch.
- Export `sanitizeMinerCommand` so the redaction contract can be unit-tested directly (it was previously private and only reached indirectly via `miner-panel.test.tsx`).

Closes #8677

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm --workspace @loopover/ui run test -- src/lib/miner-commands.test.ts` (9 passed)
- [ ] `npm run actionlint` — not applicable
- [ ] `npm run typecheck` — not applicable (UI test/export only)
- [ ] `npm run test:coverage` — not applicable (`apps/**` excluded from `codecov/patch`; UI vitest coverage exercised above)
- [ ] `npm run test:workers` — not applicable
- [ ] `npm run build:mcp` — not applicable
- [ ] `npm run test:mcp-pack` — not applicable
- [ ] `npm run ui:openapi:check` — not applicable
- [ ] `npm run ui:lint` — skipped locally; no formatting-sensitive UI component changes beyond a one-line export
- [ ] `npm run ui:typecheck` — skipped locally; export is a visibility change only
- [ ] `npm run ui:build` — not applicable for this test-only PR
- [ ] `npm audit --audit-level=moderate` — not applicable
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Test-only / one-line export PR. Local UI vitest covers the new file; full UI lint/typecheck/build left to CI.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — no visible UI change (test coverage + export only).

## Notes

- Duplicate-checked open PRs for #8677 before opening.
- Second of two open PRs for this account (2-PR threshold).