### PR TITLE
fix(miner): drop stale ProcessEnv casts on resolveReplaySnapshotDbPath

### DIFF
--- a/packages/loopover-miner/lib/migrate-cli.ts
+++ b/packages/loopover-miner/lib/migrate-cli.ts
@@ -60,14 +60,7 @@ const STORES: MigrateStoreDescriptor[] = [
   { name: "plan-store", resolveDbPath: resolvePlanStoreDbPath, open: openPlanStore },
   { name: "governor-state", resolveDbPath: resolveGovernorStateDbPath, open: openGovernorState },
   { name: "attempt-log", resolveDbPath: resolveAttemptLogDbPath, open: initAttemptLog },
-  {
-    name: "replay-snapshot",
-    // resolveReplaySnapshotDbPath's own (not-yet-converted) .d.ts types `env` as `NodeJS.ProcessEnv`, unlike
-    // every sibling resolver here (`Record<string, string | undefined>`) -- a pre-existing inconsistency, not
-    // introduced by this batch. process.env genuinely satisfies both shapes at runtime, so this cast is safe.
-    resolveDbPath: resolveReplaySnapshotDbPath as (env?: Record<string, string | undefined>) => string,
-    open: openReplaySnapshotStore,
-  },
+  { name: "replay-snapshot", resolveDbPath: resolveReplaySnapshotDbPath, open: openReplaySnapshotStore },
   {
     name: "worktree-allocator",
     resolveDbPath: resolveWorktreeAllocatorDbPath,

--- a/packages/loopover-miner/lib/status.ts
+++ b/packages/loopover-miner/lib/status.ts
@@ -399,8 +399,7 @@ function storeIntegrityChecks(env: Record<string, string | undefined>): DoctorCh
     ["plan-store", resolvePlanStoreDbPath(env)],
     ["governor-state", resolveGovernorStateDbPath(env)],
     ["attempt-log", resolveAttemptLogDbPath(env)],
-    // replay-snapshot's .d.ts still types env as ProcessEnv (not yet migrated); cast is lossless.
-    ["replay-snapshot", resolveReplaySnapshotDbPath(env as NodeJS.ProcessEnv)],
+    ["replay-snapshot", resolveReplaySnapshotDbPath(env)],
     ["worktree-allocator", resolveWorktreeAllocatorDbPath(env)],
     ["contribution-profile", resolveContributionProfileCacheDbPath(env)],
     ["policy-verdict-cache", resolvePolicyVerdictCacheDbPath(env)],

--- a/test/unit/miner-migrate-cli.test.ts
+++ b/test/unit/miner-migrate-cli.test.ts
@@ -9,6 +9,7 @@ import { resolveEventLedgerDbPath } from "../../packages/loopover-miner/lib/even
 import { applySchemaMigrations, BASELINE_SCHEMA_VERSION } from "../../packages/loopover-miner/lib/schema-version.js";
 import { openWorktreeAllocator, resolveWorktreeAllocatorDbPath } from "../../packages/loopover-miner/lib/worktree-allocator.js";
 import { openLaptopStateStore, resolveLaptopStateDbPath } from "../../packages/loopover-miner/lib/laptop-init.js";
+import { openReplaySnapshotStore, resolveReplaySnapshotDbPath } from "../../packages/loopover-miner/lib/replay-snapshot.js";
 
 const roots: string[] = [];
 
@@ -117,6 +118,18 @@ describe("loopover-miner migrate (#4871)", () => {
     openLaptopStateStore(dbPath).close();
     const again = runMigrateChecks(env).find((result) => result.name === "laptop-state");
     expect(again).toMatchObject({ ok: true, status: "up-to-date", versionBefore: BASELINE_SCHEMA_VERSION });
+  });
+
+  // REGRESSION (#8642): migrate/status used to cast resolveReplaySnapshotDbPath's env as NodeJS.ProcessEnv
+  // behind a stale "not yet migrated" comment. The resolver already accepts Record<string, string | undefined>
+  // like every sibling — calling it without a cast must still open + report up-to-date for a fresh store.
+  it("REGRESSION (#8642): replay-snapshot migrate open adapter resolves env without a ProcessEnv cast", () => {
+    const env = tempEnv();
+    openReplaySnapshotStore(resolveReplaySnapshotDbPath(env)).close();
+    const row = runMigrateChecks(env).find((result) => result.name === "replay-snapshot");
+    expect(row).toMatchObject({ ok: true, status: "up-to-date" });
+    expect(row?.versionBefore).toBe(row?.versionAfter);
+    expect(row?.versionBefore).toEqual(expect.any(Number));
   });
 
   it("actually migrates a pre-existing older-schema portfolio-queue file, bumping its stamped version and adding the missing column", () => {


### PR DESCRIPTION
## Summary

- Remove stale `not yet migrated` comments and `NodeJS.ProcessEnv` casts around `resolveReplaySnapshotDbPath` in `migrate-cli.ts` and `status.ts`.
- Call the resolver directly — its real type is already `Record<string, string | undefined>`.
- Add a migrate open-adapter regression (`test/unit/miner-migrate-cli.test.ts`) so CI's `backend` path filter runs `Build engine` before typecheck (miner-lib-only PRs otherwise skip that step and fail `tsc`).

Closes #8642

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npx tsc -p packages/loopover-miner/tsconfig.json --noEmit` (exit 0)
- [x] `npx vitest run test/unit/miner-migrate-cli.test.ts -t "#8642"` (1 passed)
- [ ] Full suite left to CI
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Type/comment fix + focused migrate regression. Resubmit of #8755 (auto-closed): prior miner-lib-only diff skipped `Build engine package` while still running typecheck.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable.

## Notes

- Replaces closed #8755. Duplicate-checked open PRs for #8642.