### PR TITLE
test(ui): cover all three formatReversalEventType branches

### DIFF
--- a/apps/loopover-ui/src/components/site/app-panels/reversal-health-card.test.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/reversal-health-card.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import { ReversalHealthCard } from "@/components/site/app-panels/reversal-health-card";
 import {
   formatRatePct,
+  formatReversalEventType,
   reversalHealthStatus,
   type ReversalHealth,
 } from "@/components/site/app-panels/reversal-health-card-model";
@@ -85,5 +86,20 @@ describe("ReversalHealthCard", () => {
     expect(screen.getByText("no auto-actions in window")).toBeTruthy();
     expect(screen.getAllByText("0%").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("No reversals in window")).toBeTruthy();
+  });
+});
+
+describe("formatReversalEventType (#8665)", () => {
+  it("names a bot-merge revert (the reversal_reverted branch, the headline event this card surfaces)", () => {
+    expect(formatReversalEventType("reversal_reverted")).toBe("merge reverted");
+  });
+
+  it("names a close reopen (the reversal_reopened branch)", () => {
+    expect(formatReversalEventType("reversal_reopened")).toBe("close reopened");
+  });
+
+  it("humanizes any other event type by replacing underscores (the fallback branch)", () => {
+    expect(formatReversalEventType("some_other_event")).toBe("some other event");
+    expect(formatReversalEventType("plain")).toBe("plain");
   });
 });


### PR DESCRIPTION
Fixes #8665

## Context

`formatReversalEventType` (`apps/loopover-ui/src/components/site/app-panels/reversal-health-card-model.ts`) has three branches, but only `reversal_reopened` was exercised — indirectly, via the card's render test. The `reversal_reverted` branch (the bot-merge-revert headline this whole card exists to surface) and the underscore-humanizing fallback had zero direct coverage, so a typo/refactor regression in either string would go undetected.

## Change

Added a `formatReversalEventType` `describe` block to the existing `reversal-health-card.test.tsx` with a direct assertion for **all three** branches: `reversal_reverted → "merge reverted"`, `reversal_reopened → "close reopened"`, and the fallback (`some_other_event → "some other event"`, plus a no-underscore input). Test-only — no source change.

## Validation

- `@loopover/ui` test: **9 passed** (6 existing + 3 new), rebased onto current `main`
- `prettier --check` clean; `npm --workspace @loopover/ui run typecheck` clean; committed as LF
- `apps/**` is outside Codecov's `coverage.include`, so no patch percentage applies; `git diff --check` clean
