### PR TITLE
test(ui): cover all formatReversalEventType branches

### DIFF
--- a/apps/loopover-ui/src/components/site/app-panels/reversal-health-card-model.test.ts
+++ b/apps/loopover-ui/src/components/site/app-panels/reversal-health-card-model.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { formatReversalEventType } from "@/components/site/app-panels/reversal-health-card-model";
+
+// (#8665) Direct unit coverage for all three formatReversalEventType branches. Previously only
+// "reversal_reopened" was reached indirectly via reversal-health-card.test.tsx's card render.
+
+describe("formatReversalEventType (#8665)", () => {
+  it('maps reversal_reverted to "merge reverted"', () => {
+    expect(formatReversalEventType("reversal_reverted")).toBe("merge reverted");
+  });
+
+  it('maps reversal_reopened to "close reopened"', () => {
+    expect(formatReversalEventType("reversal_reopened")).toBe("close reopened");
+  });
+
+  it("falls back to replacing underscores with spaces for unknown event types", () => {
+    expect(formatReversalEventType("some_new_event")).toBe("some new event");
+  });
+});


### PR DESCRIPTION
## Summary

- Add `reversal-health-card-model.test.ts` with direct unit assertions for all three `formatReversalEventType` branches: `reversal_reverted` → `merge reverted`, `reversal_reopened` → `close reopened`, and the underscore-fallback arm.

Closes #8665

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npx eslint src/components/site/app-panels/reversal-health-card-model.test.ts` (exit 0, Prettier/LF clean)
- [x] `npx vitest run src/components/site/app-panels/reversal-health-card-model.test.ts` (3 passed)
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Test-only PR (`apps/**` excluded from `codecov/patch`). Sibling model test file keeps coverage on the pure helper without pulling the card/ui-kit graph.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — test-only; no visible UI change.

## Notes

- Duplicate-checked open PRs for #8665 before opening.