### PR TITLE
test(miner-ui): cover bare-integer portfolio-queue identifier parsing

### DIFF
--- a/apps/loopover-miner-ui/src/lib/chat-portfolio-queue-resolve.test.ts
+++ b/apps/loopover-miner-ui/src/lib/chat-portfolio-queue-resolve.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PORTFOLIO_QUEUE_CHAT_RELEASE_ACTION,
+  PORTFOLIO_QUEUE_CHAT_REQUEUE_ACTION,
+  resolvePortfolioQueueChatAction,
+} from "./chat-portfolio-queue-resolve";
+
+// (#8671) Bare positive integer after the repo (IDENTIFIER_RE's third arm) was never covered —
+// existing chat-portfolio-queue-actions cases only used `#7` / `issue:12`.
+
+describe("resolvePortfolioQueueChatAction bare-integer identifier (#8671)", () => {
+  it('resolves "release acme/widgets 12" to identifier issue:12', () => {
+    expect(resolvePortfolioQueueChatAction("release acme/widgets 12")).toEqual({
+      ok: true,
+      action: PORTFOLIO_QUEUE_CHAT_RELEASE_ACTION,
+      target: { repoFullName: "acme/widgets", identifier: "issue:12" },
+    });
+  });
+
+  it('resolves "requeue acme/widgets 12" to identifier issue:12', () => {
+    expect(resolvePortfolioQueueChatAction("requeue acme/widgets 12")).toEqual({
+      ok: true,
+      action: PORTFOLIO_QUEUE_CHAT_REQUEUE_ACTION,
+      target: { repoFullName: "acme/widgets", identifier: "issue:12" },
+    });
+  });
+
+  it("does not treat a digit glued to a letter (e.g. v2) as a bare-integer identifier", () => {
+    // Lookbehind/lookahead require the digit not be adjacent to alphanumerics — "v2" must not become issue:2.
+    expect(resolvePortfolioQueueChatAction("release acme/widgets for sprint v2")).toEqual({
+      ok: true,
+      action: PORTFOLIO_QUEUE_CHAT_RELEASE_ACTION,
+      target: { repoFullName: "acme/widgets" },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `chat-portfolio-queue-resolve.test.ts` covering the bare-integer `IDENTIFIER_RE` arm: `release acme/widgets 12` and `requeue acme/widgets 12` both resolve `identifier: "issue:12"`.
- Negative case: `release acme/widgets for sprint v2` does not treat `v2` as an identifier (lookbehind/lookahead).

Closes #8671

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npx eslint src/lib/chat-portfolio-queue-resolve.test.ts` (exit 0, Prettier/LF clean)
- [x] `npx vitest run src/lib/chat-portfolio-queue-resolve.test.ts` (3 passed)
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Test-only PR (`apps/**` excluded from `codecov/patch`). Dedicated resolve test file exercises the pure parser without the actions suite's ui-kit import graph.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — test-only; no visible UI change.

## Notes

- Duplicate-checked open PRs for #8671 before opening.