### PR TITLE
test(ui): cover app.runs.tsx mapping helpers and SavedViews flow

### DIFF
--- a/apps/loopover-ui/src/routes/app.runs.test.tsx
+++ b/apps/loopover-ui/src/routes/app.runs.test.tsx
@@ -2,10 +2,26 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock the toast layer so the copy handlers' user-facing signal can be asserted directly.
-const { success, error } = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }));
-vi.mock("sonner", () => ({ toast: { success, error } }));
+// `toast` itself is called bare (SavedViews' remove flow, AgentRuns' rerun handler) as well as via
+// `.success`/`.error` (the drawer's copy handlers) -- `base` backs the bare-call form so both shapes
+// work against the same mock, while `success`/`error` stay the exact references existing assertions
+// in this file already check.
+const { success, error, base } = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
+  base: vi.fn(),
+}));
+vi.mock("sonner", () => ({ toast: Object.assign(base, { success, error }) }));
 
-import { DrawerSurface, RunsFilterBar } from "./app.runs";
+import {
+  DrawerSurface,
+  RunsFilterBar,
+  SavedViews,
+  mapAgentRunBundle,
+  mapAgentRunKind,
+  mapSignalFidelity,
+  type AgentRunBundle,
+} from "./app.runs";
 
 const run = {
   id: "run_1",
@@ -165,5 +181,263 @@ describe("Agent Runs filter bar persistent reset (#6818)", () => {
     renderBar({ hasActiveFilters: true, status: "ready", onReset });
     fireEvent.click(screen.getByRole("button", { name: "Reset filters" }));
     expect(onReset).toHaveBeenCalledTimes(1);
+  });
+});
+
+// #8701: mapSignalFidelity/mapAgentRunKind/mapAgentRunBundle/SavedViews previously had zero direct
+// test coverage -- these lock in every branch so a future refactor can't silently regress them.
+describe("mapSignalFidelity (#8701)", () => {
+  it("maps complete to ready", () => {
+    expect(mapSignalFidelity("complete")).toBe("ready");
+  });
+
+  it("maps degraded to degraded", () => {
+    expect(mapSignalFidelity("degraded")).toBe("degraded");
+  });
+
+  it("maps blocked to blocked", () => {
+    expect(mapSignalFidelity("blocked")).toBe("blocked");
+  });
+
+  it("falls through any other value to stale", () => {
+    expect(mapSignalFidelity("unknown")).toBe("stale");
+  });
+});
+
+describe("mapAgentRunKind (#8701)", () => {
+  it("maps preflight_branch to preflight-branch", () => {
+    expect(mapAgentRunKind("preflight_branch")).toBe("preflight-branch");
+  });
+
+  it("maps prepare_pr_packet to prepare-pr-packet", () => {
+    expect(mapAgentRunKind("prepare_pr_packet")).toBe("prepare-pr-packet");
+  });
+
+  it("maps explain_blockers to explain-blockers", () => {
+    expect(mapAgentRunKind("explain_blockers")).toBe("explain-blockers");
+  });
+
+  it("maps explain_branch_blockers to explain-blockers (the other half of the || branch)", () => {
+    expect(mapAgentRunKind("explain_branch_blockers")).toBe("explain-blockers");
+  });
+
+  it("falls through null or any unrecognized kind to plan-next-work", () => {
+    expect(mapAgentRunKind(null)).toBe("plan-next-work");
+    expect(mapAgentRunKind("something_else")).toBe("plan-next-work");
+  });
+});
+
+describe("mapAgentRunBundle (#8701)", () => {
+  function buildBundle(overrides: Partial<AgentRunBundle> = {}): AgentRunBundle {
+    return {
+      run: {
+        id: "run_1",
+        objective: "test",
+        actorLogin: "acme-bot",
+        surface: "mcp",
+        status: "completed",
+        dataQualityStatus: "complete",
+      },
+      actions: [],
+      contextSnapshots: [],
+      summary: "did a thing",
+      ...overrides,
+    };
+  }
+
+  describe("repo fallback chain", () => {
+    it("prefers actions[0].targetRepoFullName when present", () => {
+      const bundle = buildBundle({
+        actions: [{ actionType: "x", targetRepoFullName: "acme/from-action" }],
+        run: { ...buildBundle().run, payload: { repoFullName: "acme/from-payload" } },
+      });
+      expect(mapAgentRunBundle(bundle).repo).toBe("acme/from-action");
+    });
+
+    it("falls back to payload.repoFullName when the action has none", () => {
+      const bundle = buildBundle({
+        actions: [{ actionType: "x" }],
+        run: { ...buildBundle().run, payload: { repoFullName: "acme/from-payload" } },
+      });
+      expect(mapAgentRunBundle(bundle).repo).toBe("acme/from-payload");
+    });
+
+    it("falls back to payload.input.repoFullName when the action and payload both lack it", () => {
+      const bundle = buildBundle({
+        actions: [{ actionType: "x" }],
+        run: { ...buildBundle().run, payload: { input: { repoFullName: "acme/from-input" } } },
+      });
+      expect(mapAgentRunBundle(bundle).repo).toBe("acme/from-input");
+    });
+
+    it('falls back to "unknown" when every referent is absent', () => {
+      const bundle = buildBundle({ actions: [{ actionType: "x" }] });
+      expect(mapAgentRunBundle(bundle).repo).toBe("unknown");
+    });
+  });
+
+  describe("surface -> source/boundary mapping", () => {
+    it("maps github_comment to the github-command source and public boundary", () => {
+      const bundle = buildBundle({ run: { ...buildBundle().run, surface: "github_comment" } });
+      const mapped = mapAgentRunBundle(bundle);
+      expect(mapped.source).toBe("github-command");
+      expect(mapped.boundary).toBe("public");
+    });
+
+    it("maps mcp to the private-mcp boundary", () => {
+      const bundle = buildBundle({ run: { ...buildBundle().run, surface: "mcp" } });
+      const mapped = mapAgentRunBundle(bundle);
+      expect(mapped.source).toBe("mcp");
+      expect(mapped.boundary).toBe("private-mcp");
+    });
+
+    it("maps api to the private-api boundary", () => {
+      const bundle = buildBundle({ run: { ...buildBundle().run, surface: "api" } });
+      const mapped = mapAgentRunBundle(bundle);
+      expect(mapped.source).toBe("api");
+      expect(mapped.boundary).toBe("private-api");
+    });
+  });
+
+  describe("ruleset_snapshot fallback", () => {
+    it("prefers scoringModelId when present", () => {
+      const bundle = buildBundle({
+        contextSnapshots: [{ scoringModelId: "model-x", decisionPackVersion: "v2" }],
+      });
+      expect(mapAgentRunBundle(bundle).ruleset_snapshot).toBe("model-x");
+    });
+
+    it("falls back to decisionPackVersion when scoringModelId is absent", () => {
+      const bundle = buildBundle({ contextSnapshots: [{ decisionPackVersion: "v2" }] });
+      expect(mapAgentRunBundle(bundle).ruleset_snapshot).toBe("v2");
+    });
+
+    it('falls back to "live" when no context snapshot carries either', () => {
+      expect(mapAgentRunBundle(buildBundle()).ruleset_snapshot).toBe("live");
+      expect(mapAgentRunBundle(buildBundle({ contextSnapshots: [{}] })).ruleset_snapshot).toBe(
+        "live",
+      );
+    });
+  });
+
+  describe("snapshot replay construction", () => {
+    it("pools counterfactuals across snapshots and builds both viewer perspectives per action", () => {
+      const bundle = buildBundle({
+        contextSnapshots: [{ payload: { counterfactualReasons: ["budget"] } }],
+        actions: [
+          {
+            actionType: "x",
+            payload: { recommendationSnapshot: { snapshotId: "snap_1" } },
+          },
+        ],
+      });
+      const { snapshotReplays } = mapAgentRunBundle(bundle);
+      expect(snapshotReplays).toHaveLength(1);
+      // buildSnapshotReplayView embeds the requested viewer directly into its result, so this proves
+      // it was actually invoked once per viewer rather than one call result reused for both.
+      expect(snapshotReplays[0].authenticated.viewer).toBe("authenticated");
+      expect(snapshotReplays[0].publicSafe.viewer).toBe("public");
+    });
+
+    it("excludes an action whose recommendationSnapshot is not a plain object", () => {
+      const arrayBundle = buildBundle({
+        actions: [{ actionType: "x", payload: { recommendationSnapshot: [1, 2, 3] } }],
+      });
+      const missingBundle = buildBundle({ actions: [{ actionType: "x" }] });
+      expect(mapAgentRunBundle(arrayBundle).snapshotReplays).toEqual([]);
+      expect(mapAgentRunBundle(missingBundle).snapshotReplays).toEqual([]);
+    });
+  });
+});
+
+describe("SavedViews save/apply/remove (#8701)", () => {
+  const defaultCurrent = { status: "all" as const, kind: "all" as const, q: "" };
+  const activeCurrent = { status: "ready" as const, kind: "all" as const, q: "" };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.localStorage.clear();
+  });
+
+  function renderSavedViews(
+    current: Parameters<typeof SavedViews>[0]["current"] = activeCurrent,
+    onApply = vi.fn(),
+  ) {
+    render(<SavedViews current={current} onApply={onApply} />);
+    return { onApply };
+  }
+
+  it("disables Save view while every filter is still at its default", async () => {
+    renderSavedViews(defaultCurrent);
+    await waitFor(() => expect(screen.getByRole("button", { name: /save view/i })).toBeTruthy());
+    expect((screen.getByRole("button", { name: /save view/i }) as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+  });
+
+  it("saves a view under a name, lists it, and confirms via toast", async () => {
+    renderSavedViews();
+    await waitFor(() => screen.getByRole("button", { name: /save view/i }));
+
+    fireEvent.click(screen.getByRole("button", { name: /save view/i }));
+    fireEvent.change(screen.getByPlaceholderText("View name"), {
+      target: { value: "My triage view" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(screen.getByRole("button", { name: "My triage view" })).toBeTruthy();
+    expect(success).toHaveBeenCalledWith(
+      "View saved",
+      expect.objectContaining({ description: expect.stringContaining("My triage view") }),
+    );
+  });
+
+  it("applies a saved view with its saved filter values", async () => {
+    const { onApply } = renderSavedViews();
+    await waitFor(() => screen.getByRole("button", { name: /save view/i }));
+
+    fireEvent.click(screen.getByRole("button", { name: /save view/i }));
+    fireEvent.change(screen.getByPlaceholderText("View name"), {
+      target: { value: "My triage view" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "My triage view" }));
+    expect(onApply).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "ready", kind: "all", q: "" }),
+    );
+  });
+
+  it("removes a saved view and confirms via toast", async () => {
+    renderSavedViews();
+    await waitFor(() => screen.getByRole("button", { name: /save view/i }));
+
+    fireEvent.click(screen.getByRole("button", { name: /save view/i }));
+    fireEvent.change(screen.getByPlaceholderText("View name"), {
+      target: { value: "My triage view" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(screen.getByRole("button", { name: "My triage view" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove My triage view" }));
+
+    expect(screen.queryByRole("button", { name: "My triage view" })).toBeNull();
+    expect(base).toHaveBeenCalledWith(expect.stringContaining("My triage view"));
+  });
+
+  it("persists saved views across remounts via localStorage", async () => {
+    const { unmount } = render(<SavedViews current={activeCurrent} onApply={vi.fn()} />);
+    await waitFor(() => screen.getByRole("button", { name: /save view/i }));
+    fireEvent.click(screen.getByRole("button", { name: /save view/i }));
+    fireEvent.change(screen.getByPlaceholderText("View name"), {
+      target: { value: "Persisted view" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    unmount();
+
+    render(<SavedViews current={activeCurrent} onApply={vi.fn()} />);
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Persisted view" })).toBeTruthy(),
+    );
   });
 });

--- a/apps/loopover-ui/src/routes/app.runs.tsx
+++ b/apps/loopover-ui/src/routes/app.runs.tsx
@@ -53,7 +53,7 @@ const KIND_FILTERS = [
 type StatusFilter = (typeof STATUS_FILTERS)[number];
 type KindFilter = (typeof KIND_FILTERS)[number];
 
-interface AgentRun {
+export interface AgentRun {
   id: string;
   source: "mcp" | "api" | "github-command";
   kind: "plan-next-work" | "preflight-branch" | "prepare-pr-packet" | "explain-blockers";
@@ -72,7 +72,7 @@ type AgentRunBundleResponse = {
   runs: AgentRunBundle[];
 };
 
-type AgentRunBundle = {
+export type AgentRunBundle = {
   run: {
     id: string;
     objective: string;
@@ -455,7 +455,7 @@ function AgentRuns() {
   );
 }
 
-function mapAgentRunBundle(bundle: AgentRunBundle): AgentRun {
+export function mapAgentRunBundle(bundle: AgentRunBundle): AgentRun {
   const payload = bundle.run.payload ?? {};
   const input = recordValue(payload.input);
   const repo =
@@ -506,14 +506,14 @@ function mapAgentRunBundle(bundle: AgentRunBundle): AgentRun {
   };
 }
 
-function mapAgentRunKind(kind: string | null): AgentRun["kind"] {
+export function mapAgentRunKind(kind: string | null): AgentRun["kind"] {
   if (kind === "preflight_branch") return "preflight-branch";
   if (kind === "prepare_pr_packet") return "prepare-pr-packet";
   if (kind === "explain_blockers" || kind === "explain_branch_blockers") return "explain-blockers";
   return "plan-next-work";
 }
 
-function mapSignalFidelity(
+export function mapSignalFidelity(
   status: AgentRunBundle["run"]["dataQualityStatus"],
 ): AgentRun["signal_fidelity"] {
   if (status === "complete") return "ready";
@@ -569,7 +569,7 @@ type SavedView = {
   q: string;
 };
 
-function SavedViews({
+export function SavedViews({
   current,
   onApply,
 }: {


### PR DESCRIPTION
## Summary

- Adds direct unit test coverage for `app.runs.tsx`'s previously-untested pure mapping helpers (`mapSignalFidelity`, `mapAgentRunKind`, `mapAgentRunBundle`) and the `SavedViews` save/apply/remove flow. No production behavior changes — the only non-test edit is adding the `export` keyword to four already-existing functions/types so the test file can import them directly.
- Resubmit of #8748, which was auto-closed by a screenshot-evidence check despite the platform's own prior automated review (on the identical commit) already confirming zero visual diff with its own captured before/after images — see `## UI Evidence` below, which republishes that same platform-captured evidence in the requested row format rather than manually re-shooting screenshots of a page that doesn't render differently.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` — skipped, no `.github/workflows`/composite-action changes in this diff.
- [x] `npm run typecheck` (via `npm run ui:typecheck`, which builds `@loopover/ui-kit` then typechecks `@loopover/ui` + `@loopover/ui-miner` — clean)
- [ ] `npm run test:coverage` locally — this repo's own `codecov/patch` gate only measures `src/**`; `apps/**` (this change) is explicitly excluded (confirmed directly against `vitest.config.ts`/`codecov.yml`, and issue #8701's own body states the same). Ran the applicable local equivalent instead: `npx vitest run src/routes/app.runs.test.tsx` (35/35 passed) and the full `npm run ui:test` (683/683 passed across `@loopover/ui` + `@loopover/ui-miner`).
- [ ] `npm run test:workers` — skipped, no Workers/backend code touched.
- [ ] `npm run build:mcp` — ran for local diagnostics only (unrelated package, not part of this diff).
- [ ] `npm run test:mcp-pack` — skipped, no MCP package changes in this diff.
- [ ] `npm run ui:openapi:check` — skipped, no API/OpenAPI schema changes.
- [x] `npm run ui:lint` — 0 errors (89 pre-existing `react-refresh/only-export-components` warnings across the codebase, same pre-existing pattern already present on ~20 other route files in this repo).
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate` — 5 pre-existing high-severity advisories in the `eslint`/`minimatch`/`brace-expansion` dev-dependency chain, unrelated to this change (zero new dependencies added).
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — see Summary; this PR *is* the test addition.

If any required check was skipped, explain why:

- `test:workers`/`test:mcp-pack`/`ui:openapi:check`/`actionlint` all skipped as not applicable — this diff touches exactly two files under `apps/loopover-ui/src/routes/`, nothing else.
- Full `npm run test:ci` was attempted; it fails at the unsharded `test:coverage` step, but every failing test file is in `packages/loopover-mcp`/`packages/loopover-miner`'s CLI test suites (stale/missing `dist/` build artifacts for those two unrelated packages in a fresh clone — confirmed zero diff between this branch and `upstream/main` for every failing file, and confirmed zero failures anywhere under `apps/loopover-ui`). Ran `ui:lint`/`ui:typecheck`/`ui:test`/`ui:build` directly instead, all green, per the boxes above.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no such changes.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no such changes.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no production UI behavior changed (test-only + additive exports).
- [x] Visible UI changes include a `UI Evidence` section below with screenshots. — see below.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — N/A.

## UI Evidence

This PR has **no visual or behavioral UI change** — the only production edit is adding the `export` keyword to four already-existing functions/types (`mapAgentRunBundle`, `mapAgentRunKind`, `mapSignalFidelity`, `SavedViews`); everything else is test code. Also note: `apps/loopover-ui` is a **dark-mode-only build** (the theme toggle was removed — see `apps/loopover-ui/src/components/site/theme-toggle.tsx`), so there is no Light theme to capture.

The table below republishes this platform's **own automated before/after capture** from the identical commit on the prior submission (#8748, auto-closed by a conflicting check moments after its own review comment reported this same evidence and recommended merge). Every row shows an empty **Diff** column, confirming no rendering difference:

| Route | Viewport | Before | After | Diff |
| --- | --- | --- | --- | --- |
| `/app/runs` | Desktop · Dark | <a href="https://pub-2c7b5868f2ca43d6be1dca8a4996fba0.r2.dev/loopover/shots/c623b59495e1f0c4fa98827f4ad5cee959d989f1.png"><img src="https://pub-2c7b5868f2ca43d6be1dca8a4996fba0.r2.dev/loopover/shots/c623b59495e1f0c4fa98827f4ad5cee959d989f1.png" alt="before desktop" width="240"></a> | <a href="https://pub-2c7b5868f2ca43d6be1dca8a4996fba0.r2.dev/loopover/shots/6b964d746c3356da0e72eccabaa7d88e0b8e6f30.png"><img src="https://pub-2c7b5868f2ca43d6be1dca8a4996fba0.r2.dev/loopover/shots/6b964d746c3356da0e72eccabaa7d88e0b8e6f30.png" alt="after desktop" width="240"></a> | none |
| `/app/runs` | Mobile · Dark | <a href="https://pub-2c7b5868f2ca43d6be1dca8a4996fba0.r2.dev/loopover/shots/b59b5810923f8a515f97ac962387a5299c29d930.png"><img src="https://pub-2c7b5868f2ca43d6be1dca8a4996fba0.r2.dev/loopover/shots/b59b5810923f8a515f97ac962387a5299c29d930.png" alt="before mobile" width="240"></a> | <a href="https://pub-2c7b5868f2ca43d6be1dca8a4996fba0.r2.dev/loopover/shots/ce0bc22e1c68a4b20a72cd8735461a48f57acd3a.png"><img src="https://pub-2c7b5868f2ca43d6be1dca8a4996fba0.r2.dev/loopover/shots/ce0bc22e1c68a4b20a72cd8735461a48f57acd3a.png" alt="after mobile" width="240"></a> | none |
| `/app/runs/test` | Desktop · Dark | <a href="https://pub-2c7b5868f2ca43d6be1dca8a4996fba0.r2.dev/loopover/shots/79fb1e4b18410d2d2f06ec36288a45a122a66e22.png"><img src="https://pub-2c7b5868f2ca43d6be1dca8a4996fba0.r2.dev/loopover/shots/79fb1e4b18410d2d2f06ec36288a45a122a66e22.png" alt="before desktop test route" width="240"></a> | <a href="https://pub-2c7b5868f2ca43d6be1dca8a4996fba0.r2.dev/loopover/shots/a79b6d941e4ec3562f8d300b919dec2060f156f8.png"><img src="https://pub-2c7b5868f2ca43d6be1dca8a4996fba0.r2.dev/loopover/shots/a79b6d941e4ec3562f8d300b919dec2060f156f8.png" alt="after desktop test route" width="240"></a> | none |
| `/app/runs/test` | Mobile · Dark | <a href="https://pub-2c7b5868f2ca43d6be1dca8a4996fba0.r2.dev/loopover/shots/26f8ebee45617b939d3ab7bfabbef14e2c908623.png"><img src="https://pub-2c7b5868f2ca43d6be1dca8a4996fba0.r2.dev/loopover/shots/26f8ebee45617b939d3ab7bfabbef14e2c908623.png" alt="before mobile test route" width="240"></a> | <a href="https://pub-2c7b5868f2ca43d6be1dca8a4996fba0.r2.dev/loopover/shots/4bfb3fd4ce85f1681713ac8f8e3ced538954886d.png"><img src="https://pub-2c7b5868f2ca43d6be1dca8a4996fba0.r2.dev/loopover/shots/4bfb3fd4ce85f1681713ac8f8e3ced538954886d.png" alt="after mobile test route" width="240"></a> | none |

_No Tablet capture is included above (none was produced by the platform's own automated capture on #8748 either); a Tablet viewport is unaffected by this diff for the same reason the other four rows show no diff — no rendering-relevant code changed._

## Notes

- Closes #8701.
- All four Deliverables from the issue are covered in this single PR: `mapSignalFidelity` (all 4 branches), `mapAgentRunKind` (all 4 branches, including both inputs that feed the shared `explain-blockers` branch), `mapAgentRunBundle` (the full repo-fallback chain, surface→source/boundary mapping, scoring-snapshot fallback, and counterfactual-pooling/snapshot-replay construction), and `SavedViews` (save/apply/remove render test, plus the disabled-while-default-filters case and localStorage persistence across remounts).
- This is a resubmission of #8748 (closed) rebased onto current `main`; no code changed between the two, only this PR body's UI Evidence section.
