### PR TITLE
fix(ui): resolve slop/duplicate legend latest week per series

### DIFF
--- a/apps/loopover-ui/src/components/site/app-panels/slop-duplicate-trend-card-model.ts
+++ b/apps/loopover-ui/src/components/site/app-panels/slop-duplicate-trend-card-model.ts
@@ -45,13 +45,16 @@ export function trendHasAnySignal(weeks: SlopDuplicateTrendWeek[]): boolean {
   return seriesHasSignal(weeks, "slop") || seriesHasSignal(weeks, "duplicate");
 }
 
+/** Most recent week with a non-null value for the given series (independent per series). */
 export function latestWeekWithSignal(
   weeks: SlopDuplicateTrendWeek[],
+  series: "slop" | "duplicate",
 ): SlopDuplicateTrendWeek | null {
   for (let index = weeks.length - 1; index >= 0; index -= 1) {
     const week = weeks[index];
     if (!week) continue;
-    if (week.slopFlagRatePct !== null || week.duplicateFlagRatePct !== null) return week;
+    const value = series === "slop" ? week.slopFlagRatePct : week.duplicateFlagRatePct;
+    if (value !== null) return week;
   }
   return null;
 }

--- a/apps/loopover-ui/src/components/site/app-panels/slop-duplicate-trend-card.test.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/slop-duplicate-trend-card.test.tsx
@@ -2,7 +2,10 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { SlopDuplicateTrendCard } from "@/components/site/app-panels/slop-duplicate-trend-card";
-import type { MaintainerSlopDuplicateTrend } from "@/components/site/app-panels/slop-duplicate-trend-card-model";
+import {
+  latestWeekWithSignal,
+  type MaintainerSlopDuplicateTrend,
+} from "@/components/site/app-panels/slop-duplicate-trend-card-model";
 
 function trend(
   overrides: Partial<MaintainerSlopDuplicateTrend> = {},
@@ -85,5 +88,31 @@ describe("SlopDuplicateTrendCard", () => {
   it("surfaces the stale snapshot pill when data is old", () => {
     render(<SlopDuplicateTrendCard trend={trend({ stale: true })} />);
     expect(screen.getByText(/stale snapshot/i)).toBeTruthy();
+  });
+
+  it("resolves each series' legend from its own latest signal-bearing week", () => {
+    // Most recent week has only duplicate signal; earlier week has slop (and band).
+    // Shared "latest any signal" would hide the slop band behind the null series.
+    const weeks = [
+      {
+        weekStart: "2026-06-02",
+        slopFlagRatePct: 18.5,
+        slopBandLabel: "elevated" as const,
+        duplicateFlagRatePct: null,
+      },
+      {
+        weekStart: "2026-06-09",
+        slopFlagRatePct: null,
+        slopBandLabel: null,
+        duplicateFlagRatePct: 40,
+      },
+    ];
+
+    expect(latestWeekWithSignal(weeks, "slop")?.weekStart).toBe("2026-06-02");
+    expect(latestWeekWithSignal(weeks, "duplicate")?.weekStart).toBe("2026-06-09");
+
+    render(<SlopDuplicateTrendCard trend={trend({ weeks })} />);
+    expect(screen.getByText(/latest band: elevated/i)).toBeTruthy();
+    expect(screen.getByText(/latest: 40%/i)).toBeTruthy();
   });
 });

--- a/apps/loopover-ui/src/components/site/app-panels/slop-duplicate-trend-card.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/slop-duplicate-trend-card.tsx
@@ -26,7 +26,8 @@ export function SlopDuplicateTrendCard({ trend }: { trend: MaintainerSlopDuplica
   const hasSignal = trendHasAnySignal(trend.weeks);
   const hasSlop = seriesHasSignal(trend.weeks, "slop");
   const hasDuplicate = seriesHasSignal(trend.weeks, "duplicate");
-  const latest = latestWeekWithSignal(trend.weeks);
+  const latestSlop = latestWeekWithSignal(trend.weeks, "slop");
+  const latestDuplicate = latestWeekWithSignal(trend.weeks, "duplicate");
 
   return (
     <AnalyticsCardShell
@@ -51,20 +52,20 @@ export function SlopDuplicateTrendCard({ trend }: { trend: MaintainerSlopDuplica
           color="var(--mint)"
           label="Slop flag rate"
           detail={
-            latest?.slopBandLabel
-              ? `latest band: ${latest.slopBandLabel}`
+            latestSlop?.slopBandLabel
+              ? `latest band: ${latestSlop.slopBandLabel}`
               : hasSlop
-                ? `latest: ${formatTrendRatePct(latest?.slopFlagRatePct)}`
+                ? `latest: ${formatTrendRatePct(latestSlop?.slopFlagRatePct)}`
                 : "no slop samples"
           }
-          bandLabel={latest?.slopBandLabel}
+          bandLabel={latestSlop?.slopBandLabel}
         />
         <LegendItem
           color="var(--warning)"
           label="Duplicate flag rate"
           detail={
             hasDuplicate
-              ? `latest: ${formatTrendRatePct(latest?.duplicateFlagRatePct)}`
+              ? `latest: ${formatTrendRatePct(latestDuplicate?.duplicateFlagRatePct)}`
               : "no duplicate samples"
           }
         />


### PR DESCRIPTION
## Summary

- Parameterize `latestWeekWithSignal(weeks, series)` so each series finds its own most recent non-null week instead of sharing one "any signal" week.
- Wire `SlopDuplicateTrendCard` legends to `latestSlop` / `latestDuplicate` independently.
- Add a divergent-null regression test (newest week has only duplicate signal; earlier week has elevated slop band) asserting the slop legend still shows `latest band: elevated`.

Closes #8667

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npx prettier --write --end-of-line lf` on the three changed files (LF blobs, prettier/prettier clean)
- [x] `npm --workspace @loopover/ui exec -- eslint` on the three changed files (exit 0)
- [x] `npm --workspace @loopover/ui run test -- src/components/site/app-panels/slop-duplicate-trend-card.test.tsx` (5 passed)
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Root `npm run typecheck` / `test:coverage` / `ui:build` not re-run locally for this narrowly scoped UI model fix; workspace eslint + vitest cover the changed surface. `apps/**` is excluded from `codecov/patch`.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Behavior-preserving for today's production lockstep-null data shape (both series null together). Visible legend change only appears in the divergent-null case covered by the new unit/RTL test; no production screenshot delta for the lockstep path.

| State / title | Evidence |
| --- | --- |
| Lockstep (production shape) | Unchanged vs main — existing card tests still assert `latest band: low` / `latest: 25%` |
| Divergent-null (fixed) | New test asserts `latest band: elevated` + `latest: 40%` when series peak on different weeks |

## Notes

- Mirrors the focused UI model+test pattern from recent merges (#8752 tone fallback, #8769/#8772 dedicated coverage).