### PR TITLE
test(ui): add direct branch coverage for formatReversalEventType

### DIFF
--- a/apps/loopover-ui/src/components/site/app-panels/reversal-health-card-model.test.ts
+++ b/apps/loopover-ui/src/components/site/app-panels/reversal-health-card-model.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { formatReversalEventType } from "@/components/site/app-panels/reversal-health-card-model";
+
+// #8665: formatReversalEventType has three branches, but only the "reversal_reopened" case was ever
+// exercised — indirectly, through reversal-health-card.test.tsx's render. The headline
+// "reversal_reverted" (bot-merge revert) branch and the generic fallback were untested, so a typo in
+// either string comparison would go undetected. These are direct unit assertions on the function
+// itself (a .ts test file, deliberately not .tsx), one per branch.
+describe("formatReversalEventType (#8665)", () => {
+  it('maps "reversal_reverted" to the "merge reverted" headline label', () => {
+    expect(formatReversalEventType("reversal_reverted")).toBe("merge reverted");
+  });
+
+  it('maps "reversal_reopened" to "close reopened"', () => {
+    expect(formatReversalEventType("reversal_reopened")).toBe("close reopened");
+  });
+
+  it("falls back to underscore-to-space humanization for any other event type", () => {
+    expect(formatReversalEventType("some_new_event")).toBe("some new event");
+    // Multiple underscores are all replaced (replaceAll, not replace).
+    expect(formatReversalEventType("a_b_c")).toBe("a b c");
+  });
+});


### PR DESCRIPTION
## Summary

`formatReversalEventType` (`reversal-health-card-model.ts`) has three branches but only the
`"reversal_reopened"` case was exercised — and only indirectly, through `reversal-health-card.test.tsx`'s
render. The headline `"reversal_reverted"` (bot-merge revert) branch and the generic underscore-to-space
fallback had zero direct coverage, so a typo/refactor regression in either string comparison would go
undetected by the suite.

Adds a dedicated **`.ts`** unit test (`reversal-health-card-model.test.ts`) asserting all three branches
directly on the function itself, not inferred from a component render.

## Test plan

- [x] `formatReversalEventType("reversal_reverted") === "merge reverted"`
- [x] `formatReversalEventType("reversal_reopened") === "close reopened"`
- [x] fallback: `formatReversalEventType("some_new_event") === "some new event"` (and multi-underscore)
- [x] `npm --workspace @loopover/ui run test` — 3/3 pass; prettier `--check` clean; UI typecheck clean

Closes #8665