### PR TITLE
test(ui): cover app.runs mapping helpers and SavedViews

### DIFF
--- a/apps/loopover-ui/src/routes/app.runs.test.tsx
+++ b/apps/loopover-ui/src/routes/app.runs.test.tsx
@@ -1,11 +1,24 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-// Mock the toast layer so the copy handlers' user-facing signal can be asserted directly.
-const { success, error } = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }));
-vi.mock("sonner", () => ({ toast: { success, error } }));
+// Mock the toast layer so the copy handlers' user-facing signal can be asserted directly. The base
+// export is itself callable (SavedViews' remove flow uses bare toast(...)) while keeping the
+// success/error channels the existing copy-button tests assert on.
+const { toastBase, success, error } = vi.hoisted(() => {
+  const success = vi.fn();
+  const error = vi.fn();
+  return { toastBase: Object.assign(vi.fn(), { success, error }), success, error };
+});
+vi.mock("sonner", () => ({ toast: toastBase }));
 
-import { DrawerSurface, RunsFilterBar } from "./app.runs";
+import {
+  DrawerSurface,
+  mapAgentRunBundle,
+  mapAgentRunKind,
+  mapSignalFidelity,
+  RunsFilterBar,
+  SavedViews,
+} from "./app.runs";
 
 const run = {
   id: "run_1",
@@ -165,5 +178,249 @@ describe("Agent Runs filter bar persistent reset (#6818)", () => {
     renderBar({ hasActiveFilters: true, status: "ready", onReset });
     fireEvent.click(screen.getByRole("button", { name: "Reset filters" }));
     expect(onReset).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------------------------------
+// #8701: app.runs.tsx's pure mapping helpers (mapSignalFidelity, mapAgentRunKind, mapAgentRunBundle)
+// and the SavedViews save/apply/remove flow previously had zero direct test coverage.
+// ---------------------------------------------------------------------------------------------------
+
+describe("mapSignalFidelity (#8701)", () => {
+  it("maps every data-quality status, including the unknown fallthrough", () => {
+    expect(mapSignalFidelity("complete")).toBe("ready");
+    expect(mapSignalFidelity("degraded")).toBe("degraded");
+    expect(mapSignalFidelity("blocked")).toBe("blocked");
+    expect(mapSignalFidelity("unknown")).toBe("stale");
+  });
+});
+
+describe("mapAgentRunKind (#8701)", () => {
+  it("maps each backend kind to its UI kind", () => {
+    expect(mapAgentRunKind("preflight_branch")).toBe("preflight-branch");
+    expect(mapAgentRunKind("prepare_pr_packet")).toBe("prepare-pr-packet");
+    expect(mapAgentRunKind("explain_blockers")).toBe("explain-blockers");
+    expect(mapAgentRunKind("explain_branch_blockers")).toBe("explain-blockers");
+  });
+
+  it("defaults everything else — including null — to plan-next-work", () => {
+    expect(mapAgentRunKind(null)).toBe("plan-next-work");
+    expect(mapAgentRunKind("something_new")).toBe("plan-next-work");
+  });
+});
+
+type Bundle = Parameters<typeof mapAgentRunBundle>[0];
+
+function buildBundle(overrides?: {
+  run?: Partial<Bundle["run"]>;
+  actions?: Bundle["actions"];
+  contextSnapshots?: Bundle["contextSnapshots"];
+}): Bundle {
+  return {
+    run: {
+      id: "run_9",
+      objective: "triage",
+      actorLogin: "octocat",
+      surface: "mcp",
+      status: "completed",
+      dataQualityStatus: "complete",
+      payload: {
+        kind: "preflight_branch",
+        repoFullName: "payload/repo",
+        input: { repoFullName: "input/repo" },
+      },
+      createdAt: "2026-07-20T00:00:00.000Z",
+      updatedAt: "2026-07-21T00:00:00.000Z",
+      ...overrides?.run,
+    },
+    actions: overrides?.actions ?? [
+      {
+        actionType: "recommend",
+        targetRepoFullName: "target/repo",
+        recommendation: "Open the preflight branch",
+        payload: { recommendationSnapshot: { decision: "approve" } },
+      },
+    ],
+    contextSnapshots: overrides?.contextSnapshots ?? [
+      {
+        scoringModelId: "model-1",
+        decisionPackVersion: "dp-2",
+        payload: { counterfactualReasons: [] },
+      },
+    ],
+    summary: "one ranked action",
+  };
+}
+
+describe("mapAgentRunBundle (#8701)", () => {
+  it("prefers the first action's targetRepoFullName for the repo", () => {
+    expect(mapAgentRunBundle(buildBundle()).repo).toBe("target/repo");
+  });
+
+  it("falls back to payload.repoFullName when the action repo is absent or blank", () => {
+    const bundle = buildBundle({
+      actions: [{ actionType: "recommend", targetRepoFullName: "   " }],
+    });
+    expect(mapAgentRunBundle(bundle).repo).toBe("payload/repo");
+  });
+
+  it("falls back to payload.input.repoFullName when the payload repo is also absent", () => {
+    const bundle = buildBundle({
+      run: { payload: { input: { repoFullName: "input/repo" } } },
+      actions: [{ actionType: "recommend" }],
+    });
+    expect(mapAgentRunBundle(bundle).repo).toBe("input/repo");
+  });
+
+  it('resolves "unknown" when every level of the repo fallback chain is absent', () => {
+    const bundle = buildBundle({
+      run: { payload: { input: "not-a-record" } },
+      actions: [],
+    });
+    expect(mapAgentRunBundle(bundle).repo).toBe("unknown");
+  });
+
+  it("maps surface to source and boundary for each surface", () => {
+    expect(mapAgentRunBundle(buildBundle())).toMatchObject({
+      source: "mcp",
+      boundary: "private-mcp",
+    });
+    expect(mapAgentRunBundle(buildBundle({ run: { surface: "github_comment" } }))).toMatchObject({
+      source: "github-command",
+      boundary: "public",
+    });
+    expect(mapAgentRunBundle(buildBundle({ run: { surface: "api" } }))).toMatchObject({
+      source: "api",
+      boundary: "private-api",
+    });
+  });
+
+  it("routes kind and data quality through the mapping helpers", () => {
+    const mapped = mapAgentRunBundle(buildBundle({ run: { dataQualityStatus: "degraded" } }));
+    expect(mapped.kind).toBe("preflight-branch");
+    expect(mapped.signal_fidelity).toBe("degraded");
+  });
+
+  it("resolves the ruleset snapshot from scoringModelId, then decisionPackVersion, then live", () => {
+    expect(mapAgentRunBundle(buildBundle()).ruleset_snapshot).toBe("model-1");
+    expect(
+      mapAgentRunBundle(
+        buildBundle({
+          contextSnapshots: [{ scoringModelId: null, decisionPackVersion: "dp-2" }],
+        }),
+      ).ruleset_snapshot,
+    ).toBe("dp-2");
+    expect(mapAgentRunBundle(buildBundle({ contextSnapshots: [] })).ruleset_snapshot).toBe("live");
+  });
+
+  it("falls back from createdAt to updatedAt to a fresh timestamp for created_at", () => {
+    expect(mapAgentRunBundle(buildBundle()).created_at).toBe("2026-07-20T00:00:00.000Z");
+    expect(mapAgentRunBundle(buildBundle({ run: { createdAt: null } })).created_at).toBe(
+      "2026-07-21T00:00:00.000Z",
+    );
+    const nowIso = mapAgentRunBundle(
+      buildBundle({ run: { createdAt: null, updatedAt: null } }),
+    ).created_at;
+    expect(Number.isNaN(Date.parse(nowIso))).toBe(false);
+  });
+
+  it("keeps only string recommendations and counts ranked actions", () => {
+    const bundle = buildBundle({
+      actions: [
+        { actionType: "recommend", targetRepoFullName: "target/repo", recommendation: "Do X" },
+        { actionType: "recommend", recommendation: null },
+        { actionType: "recommend", recommendation: "   " },
+      ],
+    });
+    const mapped = mapAgentRunBundle(bundle);
+    expect(mapped.ranked_actions).toBe(3);
+    expect(mapped.recommendations).toEqual(["Do X"]);
+  });
+
+  it("builds an authenticated and public-safe replay pair per object recommendationSnapshot only", () => {
+    const bundle = buildBundle({
+      actions: [
+        {
+          actionType: "recommend",
+          targetRepoFullName: "target/repo",
+          payload: { recommendationSnapshot: { decision: "approve" } },
+        },
+        { actionType: "recommend", payload: { recommendationSnapshot: "not-an-object" } },
+        { actionType: "recommend", payload: { recommendationSnapshot: ["array"] } },
+        { actionType: "recommend", payload: {} },
+      ],
+      contextSnapshots: [
+        // A non-array counterfactualReasons payload is ignored rather than crashing the pooling.
+        { scoringModelId: "model-1", payload: { counterfactualReasons: "not-an-array" } },
+      ],
+    });
+    const mapped = mapAgentRunBundle(bundle);
+    expect(mapped.snapshotReplays).toHaveLength(1);
+    expect(mapped.snapshotReplays[0]?.authenticated).toBeTruthy();
+    expect(mapped.snapshotReplays[0]?.publicSafe).toBeTruthy();
+  });
+});
+
+describe("SavedViews save/apply/remove flow (#8701)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.localStorage.clear();
+  });
+
+  const current = { status: "ready" as const, kind: "all" as const, q: "" };
+
+  it("saves the current filters as a named view, lists it, applies it, and removes it", async () => {
+    const onApply = vi.fn();
+    render(<SavedViews current={current} onApply={onApply} />);
+
+    // Empty state first: no saved views yet.
+    expect(screen.getByText("Save current filters as a named view.")).toBeTruthy();
+
+    // Save: open the naming form, type a name, submit.
+    fireEvent.click(screen.getByRole("button", { name: /save view/i }));
+    fireEvent.change(screen.getByPlaceholderText("View name"), {
+      target: { value: "Ready runs" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    // The view chip appears, the empty state is gone, and the save is announced + persisted.
+    const viewButton = await screen.findByRole("button", { name: "Ready runs" });
+    expect(screen.queryByText("Save current filters as a named view.")).toBeNull();
+    expect(success).toHaveBeenCalledWith("View saved", {
+      description: "“Ready runs” pinned to your filters.",
+    });
+    const stored = JSON.parse(window.localStorage.getItem("loopover.runs.views") ?? "[]");
+    expect(stored).toHaveLength(1);
+    expect(stored[0]).toMatchObject({ name: "Ready runs", status: "ready", kind: "all", q: "" });
+
+    // Apply: clicking the chip hands the saved filters back to the parent.
+    fireEvent.click(viewButton);
+    expect(onApply).toHaveBeenCalledTimes(1);
+    expect(onApply.mock.calls[0]?.[0]).toMatchObject({ status: "ready", kind: "all", q: "" });
+
+    // Remove: the chip disappears, the removal is announced, and storage is emptied.
+    fireEvent.click(screen.getByRole("button", { name: "Remove Ready runs" }));
+    expect(screen.queryByRole("button", { name: "Ready runs" })).toBeNull();
+    expect(toastBase).toHaveBeenCalledWith("Removed “Ready runs”");
+    expect(JSON.parse(window.localStorage.getItem("loopover.runs.views") ?? "[]")).toEqual([]);
+  });
+
+  it("ignores a whitespace-only name and disables saving when no filter is active", () => {
+    render(
+      <SavedViews current={{ status: "all", kind: "all", q: "" }} onApply={() => undefined} />,
+    );
+    // No active filters — the save affordance is disabled.
+    expect((screen.getByRole("button", { name: /save view/i }) as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+  });
+
+  it("does not save a blank name", () => {
+    render(<SavedViews current={current} onApply={() => undefined} />);
+    fireEvent.click(screen.getByRole("button", { name: /save view/i }));
+    fireEvent.change(screen.getByPlaceholderText("View name"), { target: { value: "   " } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(success).not.toHaveBeenCalled();
+    expect(window.localStorage.getItem("loopover.runs.views")).toBeNull();
   });
 });

--- a/apps/loopover-ui/src/routes/app.runs.tsx
+++ b/apps/loopover-ui/src/routes/app.runs.tsx
@@ -455,7 +455,7 @@ function AgentRuns() {
   );
 }
 
-function mapAgentRunBundle(bundle: AgentRunBundle): AgentRun {
+export function mapAgentRunBundle(bundle: AgentRunBundle): AgentRun {
   const payload = bundle.run.payload ?? {};
   const input = recordValue(payload.input);
   const repo =
@@ -506,14 +506,14 @@ function mapAgentRunBundle(bundle: AgentRunBundle): AgentRun {
   };
 }
 
-function mapAgentRunKind(kind: string | null): AgentRun["kind"] {
+export function mapAgentRunKind(kind: string | null): AgentRun["kind"] {
   if (kind === "preflight_branch") return "preflight-branch";
   if (kind === "prepare_pr_packet") return "prepare-pr-packet";
   if (kind === "explain_blockers" || kind === "explain_branch_blockers") return "explain-blockers";
   return "plan-next-work";
 }
 
-function mapSignalFidelity(
+export function mapSignalFidelity(
   status: AgentRunBundle["run"]["dataQualityStatus"],
 ): AgentRun["signal_fidelity"] {
   if (status === "complete") return "ready";
@@ -569,7 +569,7 @@ type SavedView = {
   q: string;
 };
 
-function SavedViews({
+export function SavedViews({
   current,
   onApply,
 }: {


### PR DESCRIPTION
Closes #8701

## What

`apps/loopover-ui/src/routes/app.runs.tsx`'s pure mapping helpers — `mapSignalFidelity`, `mapAgentRunKind`, `mapAgentRunBundle` (including its four-level repo fallback chain and the counterfactuals-pooling / snapshot-replay construction) — and the `SavedViews` save/apply/remove flow had zero direct test coverage: `app.runs.test.tsx` only covered the drawer's copy buttons and the filter-bar reset control.

## How

The three helpers and the `SavedViews` component gain an `export` keyword — no behavior change, no signature change — so the test file can exercise them directly. The file's sonner mock becomes a callable base (`Object.assign(vi.fn(), { success, error })`) because `SavedViews`' remove flow announces through bare `toast(...)`, which the previous `{ success, error }`-only mock could not represent; the existing copy-button assertions are untouched. `app.runs.test.tsx` grows four suites (25 tests in the file total, all passing):

- **`mapSignalFidelity`** — all 4 branches: `complete` → ready, `degraded` → degraded, `blocked` → blocked, and the `unknown` default → stale.
- **`mapAgentRunKind`** — all 4 branches: `preflight_branch`, `prepare_pr_packet`, both `explain_blockers` and `explain_branch_blockers` → `explain-blockers`, and the default (`null` and unrecognized strings) → `plan-next-work`.
- **`mapAgentRunBundle`** — each level of the repo fallback chain (`targetRepoFullName` present; blank/absent → `payload.repoFullName`; absent → `payload.input.repoFullName`; `input` not even a record → `"unknown"`), plus: surface → source/boundary mapping for all three surfaces (`github_comment` → `github-command`/public, `mcp` → private-mcp, `api` → private-api), kind and data-quality routing through the two helpers above, the `scoringModelId` → `decisionPackVersion` → `"live"` ruleset-snapshot fallback, the `createdAt` → `updatedAt` → fresh-timestamp fallback, string-only recommendation filtering with `ranked_actions` counting, and snapshot-replay construction that keeps only object-shaped `recommendationSnapshot`s (string/array/absent are dropped) while a non-array `counterfactualReasons` payload is ignored rather than crashing the pooling.
- **`SavedViews`** — a full render flow: save a named view (open the naming form, type, submit), assert the chip appears, the empty state clears, `toast.success` announces it, and it persists to `localStorage["loopover.runs.views"]`; apply it and assert `onApply` receives the saved `{status, kind, q}`; remove it and assert the chip disappears, the bare-`toast` announcement fires, and storage empties. Companion tests pin the disabled save affordance when no filter is active and the blank-name no-op.

## Deliverables (all in this one PR)

- [x] `mapSignalFidelity` tested for all 4 branches, including the default/fallthrough case.
- [x] `mapAgentRunKind` tested for all 4 branches.
- [x] `mapAgentRunBundle` tested exercising each level of the repo-fallback chain (`targetRepoFullName` present, absent-falls-to-`payload.repoFullName`, absent-falls-to-`input?.repoFullName`, all absent-falls-to-`"unknown"`).
- [x] `SavedViews` render test: save a view, confirm it appears in the list, apply it, remove it.

## Validation

- `app.runs.test.tsx`: **25 tests, all passing** (10 pre-existing + 15 new).
- Full `@loopover/ui` suite: **88 test files, 600 tests, all passing**; `@loopover/ui-miner` suite (37 files, 393 tests) also green (`npm run ui:test`).
- `npm run ui:typecheck` green.
- `prettier --check` and `eslint` clean on both changed files (0 errors).
- Every branch named in #8701 now has a direct, explicit assertion. (`apps/**` is excluded from `codecov/patch`; the app's own vitest suite gates locally.)

## UI Evidence

This PR is test-only plus an `export` keyword on four existing symbols — it intentionally changes **no rendered pixels**, so each row's Before and After captures are identical, taken from the same build. Captured on `/app/runs` served locally (`vite dev`, local preview session per the contributor skill), with `/v1/auth/session` and `/v1/agent/runs` answered at the network boundary by fixtures shaped like the new tests' bundles (other private endpoints answer 500). The rendered list is `mapAgentRunBundle`'s output end-to-end: the READY `preflight-branch` run from an `mcp` surface resolving `JSONbored/loopover` through `targetRepoFullName`, the DEGRADED `plan-next-work` run whose `github_comment` surface renders as `github-command`, and a BLOCKED `explain-blockers` run falling back through the repo chain — with the `SavedViews` "Views" row above the list. The UI is a dark-mode-only build, so the Light and Dark rows (captured under emulated `prefers-color-scheme`) render identically by design. Viewports: 1280×800 / 768×1024 / 375×812.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | <a href="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8701/lo8701-desktop-light-before.png"><img src="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8701/lo8701-desktop-light-before.png" alt="Desktop light before — agent runs list rendered from mapped bundles" width="240"></a> | <a href="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8701/lo8701-desktop-light-after.png"><img src="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8701/lo8701-desktop-light-after.png" alt="Desktop light after — identical, test-only change" width="240"></a> |
| Desktop · Dark | <a href="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8701/lo8701-desktop-dark-before.png"><img src="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8701/lo8701-desktop-dark-before.png" alt="Desktop dark before — agent runs list rendered from mapped bundles" width="240"></a> | <a href="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8701/lo8701-desktop-dark-after.png"><img src="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8701/lo8701-desktop-dark-after.png" alt="Desktop dark after — identical, test-only change" width="240"></a> |
| Tablet · Light | <a href="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8701/lo8701-tablet-light-before.png"><img src="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8701/lo8701-tablet-light-before.png" alt="Tablet light before — agent runs list" width="240"></a> | <a href="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8701/lo8701-tablet-light-after.png"><img src="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8701/lo8701-tablet-light-after.png" alt="Tablet light after — identical, test-only change" width="240"></a> |
| Tablet · Dark | <a href="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8701/lo8701-tablet-dark-before.png"><img src="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8701/lo8701-tablet-dark-before.png" alt="Tablet dark before — agent runs list" width="240"></a> | <a href="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8701/lo8701-tablet-dark-after.png"><img src="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8701/lo8701-tablet-dark-after.png" alt="Tablet dark after — identical, test-only change" width="240"></a> |
| Mobile · Light | <a href="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8701/lo8701-mobile-light-before.png"><img src="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8701/lo8701-mobile-light-before.png" alt="Mobile light before — agent runs list" width="240"></a> | <a href="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8701/lo8701-mobile-light-after.png"><img src="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8701/lo8701-mobile-light-after.png" alt="Mobile light after — identical, test-only change" width="240"></a> |
| Mobile · Dark | <a href="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8701/lo8701-mobile-dark-before.png"><img src="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8701/lo8701-mobile-dark-before.png" alt="Mobile dark before — agent runs list" width="240"></a> | <a href="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8701/lo8701-mobile-dark-after.png"><img src="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8701/lo8701-mobile-dark-after.png" alt="Mobile dark after — identical, test-only change" width="240"></a> |
