### PR TITLE
fix(ui): resolve the slop/duplicate trend legends' latest week per series

### DIFF
--- a/apps/loopover-ui/src/components/site/app-panels/slop-duplicate-trend-card-model.ts
+++ b/apps/loopover-ui/src/components/site/app-panels/slop-duplicate-trend-card-model.ts
@@ -45,13 +45,18 @@ export function trendHasAnySignal(weeks: SlopDuplicateTrendWeek[]): boolean {
   return seriesHasSignal(weeks, "slop") || seriesHasSignal(weeks, "duplicate");
 }
 
+/** Latest week bearing a signal for ONE series. The two rates are independently nullable, so each
+ *  legend must resolve its own latest week — a single shared "any signal" lookup would let one
+ *  series' null in the newest signal-bearing week hide an older real value for the other (#8667). */
 export function latestWeekWithSignal(
   weeks: SlopDuplicateTrendWeek[],
+  series: "slop" | "duplicate",
 ): SlopDuplicateTrendWeek | null {
   for (let index = weeks.length - 1; index >= 0; index -= 1) {
     const week = weeks[index];
     if (!week) continue;
-    if (week.slopFlagRatePct !== null || week.duplicateFlagRatePct !== null) return week;
+    const value = series === "slop" ? week.slopFlagRatePct : week.duplicateFlagRatePct;
+    if (value !== null) return week;
   }
   return null;
 }

--- a/apps/loopover-ui/src/components/site/app-panels/slop-duplicate-trend-card.test.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/slop-duplicate-trend-card.test.tsx
@@ -2,7 +2,11 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { SlopDuplicateTrendCard } from "@/components/site/app-panels/slop-duplicate-trend-card";
-import type { MaintainerSlopDuplicateTrend } from "@/components/site/app-panels/slop-duplicate-trend-card-model";
+import {
+  latestWeekWithSignal,
+  type MaintainerSlopDuplicateTrend,
+  type SlopDuplicateTrendWeek,
+} from "@/components/site/app-panels/slop-duplicate-trend-card-model";
 
 function trend(
   overrides: Partial<MaintainerSlopDuplicateTrend> = {},
@@ -85,5 +89,107 @@ describe("SlopDuplicateTrendCard", () => {
   it("surfaces the stale snapshot pill when data is old", () => {
     render(<SlopDuplicateTrendCard trend={trend({ stale: true })} />);
     expect(screen.getByText(/stale snapshot/i)).toBeTruthy();
+  });
+
+  // The two series are independently nullable (#8667): each legend must resolve its OWN latest
+  // signal-bearing week, not share the single most-recent week that has *any* signal.
+  it("keeps the slop legend on its own latest signal week when the newest signal week only has duplicate data", () => {
+    render(
+      <SlopDuplicateTrendCard
+        trend={trend({
+          weeks: [
+            {
+              weekStart: "2026-06-02",
+              slopFlagRatePct: 40,
+              slopBandLabel: "elevated",
+              duplicateFlagRatePct: null,
+            },
+            {
+              weekStart: "2026-06-09",
+              slopFlagRatePct: null,
+              slopBandLabel: null,
+              duplicateFlagRatePct: 12.5,
+            },
+          ],
+        })}
+      />,
+    );
+    // Slop legend reflects the EARLIER week's real band — not "latest: —" from the newest week's null.
+    expect(screen.getByText(/latest band: elevated/i)).toBeTruthy();
+    expect(screen.queryByText("latest: —")).toBeNull();
+    // Duplicate legend independently reflects the newest week's own value.
+    expect(screen.getByText(/latest: 12\.5%/i)).toBeTruthy();
+  });
+
+  it("keeps the duplicate legend on its own latest signal week when the newest signal week only has slop data", () => {
+    render(
+      <SlopDuplicateTrendCard
+        trend={trend({
+          weeks: [
+            {
+              weekStart: "2026-06-02",
+              slopFlagRatePct: null,
+              slopBandLabel: null,
+              duplicateFlagRatePct: 25,
+            },
+            {
+              weekStart: "2026-06-09",
+              slopFlagRatePct: 10,
+              slopBandLabel: "low",
+              duplicateFlagRatePct: null,
+            },
+          ],
+        })}
+      />,
+    );
+    // Duplicate legend reflects the EARLIER week's real value — not the newest week's null.
+    expect(screen.getByText(/latest: 25%/i)).toBeTruthy();
+    expect(screen.queryByText("latest: —")).toBeNull();
+    // Slop legend independently reflects the newest week's own band.
+    expect(screen.getByText(/latest band: low/i)).toBeTruthy();
+  });
+});
+
+describe("latestWeekWithSignal", () => {
+  const week = (
+    weekStart: string,
+    slopFlagRatePct: number | null,
+    duplicateFlagRatePct: number | null,
+  ): SlopDuplicateTrendWeek => ({
+    weekStart,
+    slopFlagRatePct,
+    slopBandLabel: slopFlagRatePct === null ? null : "low",
+    duplicateFlagRatePct,
+  });
+
+  it("resolves a different latest week per series when the two series' nulls diverge", () => {
+    const weeks = [week("2026-06-02", 40, null), week("2026-06-09", null, 12.5)];
+    expect(latestWeekWithSignal(weeks, "slop")?.weekStart).toBe("2026-06-02");
+    expect(latestWeekWithSignal(weeks, "duplicate")?.weekStart).toBe("2026-06-09");
+  });
+
+  it("returns the same (newest) week for both series when null-ness stays in lockstep", () => {
+    const weeks = [
+      week("2026-06-02", 30, 20),
+      week("2026-06-09", null, null),
+      week("2026-06-16", 10, 5),
+    ];
+    expect(latestWeekWithSignal(weeks, "slop")?.weekStart).toBe("2026-06-16");
+    expect(latestWeekWithSignal(weeks, "duplicate")?.weekStart).toBe("2026-06-16");
+  });
+
+  it("returns null for a series with no signal in any week, independently of the other series", () => {
+    const weeks = [week("2026-06-02", 40, null), week("2026-06-09", 10, null)];
+    expect(latestWeekWithSignal(weeks, "slop")?.weekStart).toBe("2026-06-09");
+    expect(latestWeekWithSignal(weeks, "duplicate")).toBeNull();
+    expect(latestWeekWithSignal([], "slop")).toBeNull();
+  });
+
+  it("skips sparse holes while scanning backwards", () => {
+    const weeks: SlopDuplicateTrendWeek[] = [];
+    weeks[0] = week("2026-06-02", 40, 25);
+    weeks.length = 2; // trailing hole — scanned first, must be skipped, not crashed on
+    expect(latestWeekWithSignal(weeks, "slop")?.weekStart).toBe("2026-06-02");
+    expect(latestWeekWithSignal(weeks, "duplicate")?.weekStart).toBe("2026-06-02");
   });
 });

--- a/apps/loopover-ui/src/components/site/app-panels/slop-duplicate-trend-card.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/slop-duplicate-trend-card.tsx
@@ -26,7 +26,10 @@ export function SlopDuplicateTrendCard({ trend }: { trend: MaintainerSlopDuplica
   const hasSignal = trendHasAnySignal(trend.weeks);
   const hasSlop = seriesHasSignal(trend.weeks, "slop");
   const hasDuplicate = seriesHasSignal(trend.weeks, "duplicate");
-  const latest = latestWeekWithSignal(trend.weeks);
+  // Each legend resolves its own latest signal-bearing week — the two series are independently
+  // nullable, so a shared lookup could surface one series' null over the other's real data (#8667).
+  const latestSlop = latestWeekWithSignal(trend.weeks, "slop");
+  const latestDuplicate = latestWeekWithSignal(trend.weeks, "duplicate");
 
   return (
     <AnalyticsCardShell
@@ -51,20 +54,20 @@ export function SlopDuplicateTrendCard({ trend }: { trend: MaintainerSlopDuplica
           color="var(--mint)"
           label="Slop flag rate"
           detail={
-            latest?.slopBandLabel
-              ? `latest band: ${latest.slopBandLabel}`
+            latestSlop?.slopBandLabel
+              ? `latest band: ${latestSlop.slopBandLabel}`
               : hasSlop
-                ? `latest: ${formatTrendRatePct(latest?.slopFlagRatePct)}`
+                ? `latest: ${formatTrendRatePct(latestSlop?.slopFlagRatePct)}`
                 : "no slop samples"
           }
-          bandLabel={latest?.slopBandLabel}
+          bandLabel={latestSlop?.slopBandLabel}
         />
         <LegendItem
           color="var(--warning)"
           label="Duplicate flag rate"
           detail={
             hasDuplicate
-              ? `latest: ${formatTrendRatePct(latest?.duplicateFlagRatePct)}`
+              ? `latest: ${formatTrendRatePct(latestDuplicate?.duplicateFlagRatePct)}`
               : "no duplicate samples"
           }
         />


### PR DESCRIPTION
Closes #8667

## Problem

`latestWeekWithSignal` (`apps/loopover-ui/src/components/site/app-panels/slop-duplicate-trend-card-model.ts`) finds the single most recent week with *either* signal present, and `slop-duplicate-trend-card.tsx` reuses that one shared `latest` week for BOTH legends — `latest?.slopBandLabel` / `latest?.slopFlagRatePct` on the slop side and `latest?.duplicateFlagRatePct` on the duplicate side. `SlopDuplicateTrendWeek` types the two rates as independently nullable, so if the most recent signal-bearing week has one series populated and the other `null`, the null series' legend silently renders `latest: —` / no band even when an earlier week holds real data for it. Latent today (the backend generator's shared `openPullRequests` denominator gate keeps both series' null-ness in lockstep), but the helper is written generically and its own type signature permits divergence — a waiting defect for any backend change or new caller.

## Fix

`latestWeekWithSignal` is now parameterized by series (`"slop" | "duplicate"`) and scans for that series' own most recent non-null week. The card resolves `latestSlop` and `latestDuplicate` independently and each legend reads only its own result. For lockstep-null data (today's production shape) both lookups return the same week the old code returned, so rendered output is unchanged — only the divergent-null case is corrected.

## Tests (new coverage for a branch that had none)

Added to `apps/loopover-ui/src/components/site/app-panels/slop-duplicate-trend-card.test.tsx`, red on `main` before the fix:

| Deliverable | Test | Before (main) | After |
|---|---|---|---|
| Slop legend uses its own latest week | renders the card with the newest signal week slop-`null`/duplicate-populated and an earlier week at 40%/band `elevated`; asserts the slop legend shows `latest band: elevated`, not `latest: —` | **failed**: legend rendered `latest: —` | passes |
| Duplicate legend uses its own latest week (reverse divergence) | newest signal week duplicate-`null`/slop-populated, earlier week duplicate 25%; asserts `latest: 25%` renders | **failed**: legend rendered `latest: —` | passes |
| Per-series model lookup | direct `latestWeekWithSignal(weeks, series)` assertions: divergent weeks resolve to different weeks per series | **failed**: `expected '2026-06-09' to be '2026-06-02'` | passes |
| Series-independent null | a series with no signal anywhere returns `null` even when the other series has data; `[]` returns `null` | **failed**: returned the other series' week | passes |
| Lockstep unchanged | lockstep-null weeks resolve to the same (newest) week for both series; all 4 pre-existing card tests (including the lockstep one-series-empty and all-null cases) untouched and passing | passes | passes |

Full file run: 10/10 passing; whole `apps/loopover-ui` suite: 88 files / 623 tests passing; `tsc --noEmit` clean; eslint/prettier clean on all changed files; `git diff --check` clean. `apps/**` is codecov-excluded; the new tests exercise the previously zero-coverage divergent-null-per-series branch directly per the issue's coverage requirement.

## UI Evidence

The `/app/maintainer` console's "Slop + duplicate trend" card, served locally (`vite` dev, preview session per the contributor skill) with `GET /v1/app/maintainer-dashboard` answered at the network boundary by a fixture in the issue's divergent-null shape — the only way to exercise this branch, since it is unreachable with today's lockstep backend data: the newest signal-bearing week has a real duplicate rate (12.5%) but a `null` slop rate, while the latest week with real slop data (40%, band `elevated`) is two weeks older. Look at the **slop legend**: before, it renders `latest: —` (the shared week's null) as if there were no recent slop signal; after, it renders `latest band: elevated` in the warning tone from its own latest signal week. The duplicate legend (`latest: 12.5%`) and both chart panels are identical in both columns. The UI is a dark-mode-only build, so the Light and Dark rows (captured under emulated `prefers-color-scheme`) render identically by design.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | <a href="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8667/lo8667-desktop-light-before.png"><img src="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8667/lo8667-desktop-light-before.png" alt="Desktop light before — slop legend shows latest: — despite real earlier data" width="240"></a> | <a href="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8667/lo8667-desktop-light-after.png"><img src="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8667/lo8667-desktop-light-after.png" alt="Desktop light after — slop legend shows latest band: elevated from its own week" width="240"></a> |
| Desktop · Dark | <a href="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8667/lo8667-desktop-dark-before.png"><img src="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8667/lo8667-desktop-dark-before.png" alt="Desktop dark before — slop legend shows latest: — despite real earlier data" width="240"></a> | <a href="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8667/lo8667-desktop-dark-after.png"><img src="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8667/lo8667-desktop-dark-after.png" alt="Desktop dark after — slop legend shows latest band: elevated from its own week" width="240"></a> |
| Tablet · Light | <a href="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8667/lo8667-tablet-light-before.png"><img src="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8667/lo8667-tablet-light-before.png" alt="Tablet light before — slop legend shows latest: — despite real earlier data" width="240"></a> | <a href="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8667/lo8667-tablet-light-after.png"><img src="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8667/lo8667-tablet-light-after.png" alt="Tablet light after — slop legend shows latest band: elevated from its own week" width="240"></a> |
| Tablet · Dark | <a href="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8667/lo8667-tablet-dark-before.png"><img src="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8667/lo8667-tablet-dark-before.png" alt="Tablet dark before — slop legend shows latest: — despite real earlier data" width="240"></a> | <a href="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8667/lo8667-tablet-dark-after.png"><img src="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8667/lo8667-tablet-dark-after.png" alt="Tablet dark after — slop legend shows latest band: elevated from its own week" width="240"></a> |
| Mobile · Light | <a href="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8667/lo8667-mobile-light-before.png"><img src="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8667/lo8667-mobile-light-before.png" alt="Mobile light before — slop legend shows latest: — despite real earlier data" width="240"></a> | <a href="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8667/lo8667-mobile-light-after.png"><img src="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8667/lo8667-mobile-light-after.png" alt="Mobile light after — slop legend shows latest band: elevated from its own week" width="240"></a> |
| Mobile · Dark | <a href="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8667/lo8667-mobile-dark-before.png"><img src="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8667/lo8667-mobile-dark-before.png" alt="Mobile dark before — slop legend shows latest: — despite real earlier data" width="240"></a> | <a href="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8667/lo8667-mobile-dark-after.png"><img src="https://raw.githubusercontent.com/rsnetworkinginc/loopover/pr-assets-8667/lo8667-mobile-dark-after.png" alt="Mobile dark after — slop legend shows latest band: elevated from its own week" width="240"></a> |
