### PR TITLE
fix(miner-ui): resolve governor pause/resume chat intents to the registered actions

### DIFF
--- a/apps/loopover-miner-ui/src/chat-conversation.test.tsx
+++ b/apps/loopover-miner-ui/src/chat-conversation.test.tsx
@@ -1,8 +1,11 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
+import { createChatActionRegistry } from "../../../packages/loopover-miner/lib/chat-action-registry.js";
 import { ChatConversation } from "./components/chat/conversation";
+import { GOVERNOR_CHAT_ACTION_PENDING_MESSAGE } from "./lib/chat-governor-action-copy";
 import type { ChatWireMessage } from "./lib/chat-stream";
+import type { GovernorPauseState } from "./lib/governor";
 
 const sendButton = () => screen.getByRole("button", { name: "Send" }) as HTMLButtonElement;
 
@@ -192,5 +195,146 @@ describe("ChatConversation (#6518)", () => {
     await waitFor(() => expect(screen.getByText("grounded answer")).toBeTruthy());
     expect(handlePortfolioQueueChatCommandImpl).not.toHaveBeenCalled();
     expect(seen[0]).toEqual([{ role: "user", content: "what is stuck?" }]);
+  });
+});
+
+describe("ChatConversation governor pause/resume chat actions (#8670)", () => {
+  const pausedAt = "2026-07-16T10:00:00.000Z";
+  const pausedState: GovernorPauseState = { paused: true, reason: null, pausedAt };
+  const notPausedState: GovernorPauseState = { paused: false, reason: null, pausedAt: null };
+
+  /** Real registry + real registration/dispatch wire; only the two HTTP clients are injected. */
+  function governorHarness(overrides: { pauseState?: GovernorPauseState } = {}) {
+    const registry = createChatActionRegistry();
+    const pauseGovernorFn = vi.fn(async () => ({ ok: true as const, pauseState: overrides.pauseState ?? pausedState }));
+    const resumeGovernorFn = vi.fn(async () => ({ ok: true as const, pauseState: notPausedState }));
+    let streamCalls = 0;
+    const streamChatImpl = async function* (_messages: ChatWireMessage[]): AsyncGenerator<string> {
+      streamCalls += 1;
+      yield "should not stream";
+    };
+    return {
+      pauseGovernorFn,
+      resumeGovernorFn,
+      streamChatImpl,
+      streamCalls: () => streamCalls,
+      deps: { registry, pauseGovernorFn, resumeGovernorFn },
+    };
+  }
+
+  it('END-TO-END: typing "pause the governor" fires the pause action and renders GovernorChatActionResult copy', async () => {
+    const harness = governorHarness();
+    render(<ChatConversation streamChatImpl={harness.streamChatImpl} governorChatDeps={harness.deps} />);
+    ask("pause the governor");
+
+    // The pause client actually fires — through registration + flag-gated dispatch, not a direct call…
+    await waitFor(() => expect(harness.pauseGovernorFn).toHaveBeenCalledTimes(1));
+    // …and the resolved result lands in the message list with GovernorChatActionResult's Ledgers-verbatim copy.
+    await waitFor(() => expect(screen.getByText(`Paused since ${pausedAt}`)).toBeTruthy());
+    expect(screen.getByText("pause the governor")).toBeTruthy();
+    expect(harness.resumeGovernorFn).not.toHaveBeenCalled();
+    expect(harness.streamCalls()).toBe(0);
+    expect(sendButton().disabled).toBe(false);
+  });
+
+  it("passes a because-clause through to pauseGovernor as the structured reason param", async () => {
+    const harness = governorHarness({
+      pauseState: { paused: true, reason: "release traffic spiked", pausedAt },
+    });
+    render(<ChatConversation streamChatImpl={harness.streamChatImpl} governorChatDeps={harness.deps} />);
+    ask("pause the governor because release traffic spiked");
+
+    await waitFor(() => expect(harness.pauseGovernorFn).toHaveBeenCalledWith("release traffic spiked"));
+    await waitFor(() => expect(screen.getByText(`Paused since ${pausedAt} (release traffic spiked)`)).toBeTruthy());
+    expect(harness.streamCalls()).toBe(0);
+  });
+
+  it('typing "resume the governor" fires the resume action and renders the not-paused copy', async () => {
+    const harness = governorHarness();
+    render(<ChatConversation streamChatImpl={harness.streamChatImpl} governorChatDeps={harness.deps} />);
+    ask("resume the governor");
+
+    await waitFor(() => expect(harness.resumeGovernorFn).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.getByText("Not paused")).toBeTruthy());
+    expect(harness.pauseGovernorFn).not.toHaveBeenCalled();
+    expect(harness.streamCalls()).toBe(0);
+  });
+
+  it("shows the pending governor copy (and locks the composer) while the round-trip is outstanding", async () => {
+    const registry = createChatActionRegistry();
+    let resolvePause!: (value: { ok: true; pauseState: GovernorPauseState }) => void;
+    const pauseGovernorFn = vi.fn(
+      () => new Promise<{ ok: true; pauseState: GovernorPauseState }>((resolve) => (resolvePause = resolve)),
+    );
+    const resumeGovernorFn = vi.fn(async () => ({ ok: true as const, pauseState: notPausedState }));
+    render(
+      <ChatConversation
+        streamChatImpl={async function* () {
+          /* never used */
+        }}
+        governorChatDeps={{ registry, pauseGovernorFn, resumeGovernorFn }}
+      />,
+    );
+    ask("pause the governor");
+
+    await waitFor(() => expect(screen.getByText(GOVERNOR_CHAT_ACTION_PENDING_MESSAGE)).toBeTruthy());
+    expect(sendButton().disabled).toBe(true);
+
+    resolvePause({ ok: true, pauseState: pausedState });
+
+    await waitFor(() => expect(screen.getByText(`Paused since ${pausedAt}`)).toBeTruthy());
+    expect(screen.queryByText(GOVERNOR_CHAT_ACTION_PENDING_MESSAGE)).toBeNull();
+    expect(sendButton().disabled).toBe(false);
+  });
+
+  it("surfaces a non-executed dispatch (flag off / gated) as a system note instead of an empty turn", async () => {
+    const runGovernorChatActionImpl = vi.fn(async () => ({ ok: false, status: "disabled", action: null }));
+    render(
+      <ChatConversation
+        streamChatImpl={async function* () {
+          /* never used */
+        }}
+        runGovernorChatActionImpl={runGovernorChatActionImpl}
+      />,
+    );
+    ask("pause the governor");
+
+    await waitFor(() => expect(screen.getByText("Couldn't run the governor action: disabled.")).toBeTruthy());
+    expect(runGovernorChatActionImpl).toHaveBeenCalledTimes(1);
+    expect(sendButton().disabled).toBe(false);
+  });
+
+  it("surfaces a thrown dispatch as the inline turn-failed note and re-enables the composer", async () => {
+    const runGovernorChatActionImpl = vi.fn(async () => {
+      throw new Error("connection refused");
+    });
+    render(
+      <ChatConversation
+        streamChatImpl={async function* () {
+          /* never used */
+        }}
+        runGovernorChatActionImpl={runGovernorChatActionImpl}
+      />,
+    );
+    ask("pause the governor");
+
+    await waitFor(() => expect(screen.getByText(/latest response failed to complete/i)).toBeTruthy());
+    expect(sendButton().disabled).toBe(false);
+  });
+
+  it("an ordinary governor QUESTION still streams through the read-only assistant, never a dispatch", async () => {
+    const harness = governorHarness();
+    const seen: ChatWireMessage[][] = [];
+    const streamChatImpl = async function* (messages: ChatWireMessage[]) {
+      seen.push(messages);
+      yield "governor overview";
+    };
+    render(<ChatConversation streamChatImpl={streamChatImpl} governorChatDeps={harness.deps} />);
+    ask("what is the governor status?");
+
+    await waitFor(() => expect(screen.getByText("governor overview")).toBeTruthy());
+    expect(harness.pauseGovernorFn).not.toHaveBeenCalled();
+    expect(harness.resumeGovernorFn).not.toHaveBeenCalled();
+    expect(seen[0]).toEqual([{ role: "user", content: "what is the governor status?" }]);
   });
 });

--- a/apps/loopover-miner-ui/src/components/chat/conversation.tsx
+++ b/apps/loopover-miner-ui/src/components/chat/conversation.tsx
@@ -15,6 +15,16 @@ import {
   type HandlePortfolioQueueChatCommandResult,
 } from "@/lib/chat-portfolio-queue-actions";
 import { fetchPortfolioQueueItems } from "@/lib/portfolio-queue-actions";
+import {
+  enabledChatActionsEnv,
+  registerGovernorChatActions,
+  runGovernorChatAction,
+  unwrapGovernorPauseChatResult,
+  type RegisterGovernorChatActionsOptions,
+} from "@/lib/chat-governor-actions";
+import { formatGovernorPauseChatMessage } from "@/lib/chat-governor-action-copy";
+import { resolveGovernorChatAction } from "@/lib/chat-governor-resolve";
+import { GovernorChatActionResult } from "@/components/chat/governor-action-result";
 
 // The chat-rail's content integration (#6518): the first point the persistent rail (#6513) holds a live
 // conversation. Pure wiring — it composes the standalone composer (#6514), message list (#6515), and streaming
@@ -23,6 +33,11 @@ import { fetchPortfolioQueueItems } from "@/lib/portfolio-queue-actions";
 // #7075: portfolio release/requeue is resolved first via resolvePortfolioQueueChatAction; only unresolved
 // text falls through to streamChat. Action dispatch reuses the already-built handlePortfolioQueueChatCommand
 // pipeline (no new routes / fetches).
+//
+// #8670: governor pause/resume is resolved the same way via resolveGovernorChatAction; a matched intent
+// dispatches through the already-built runGovernorChatAction wire (registry + flag + gate — no new routes /
+// fetches) and renders GovernorChatActionResult in the message stream, so the chat rail finally reaches the
+// same pauseGovernor/resumeGovernor clients the Ledgers buttons call.
 
 const ASSISTANT_NAME = "LoopOver";
 /** Inline failure note appended after a failed turn — keeps history visible instead of StateBoundary wipe (#7077). */
@@ -40,12 +55,19 @@ export type PortfolioQueueChatCommandFn = (
   deps: HandlePortfolioQueueChatCommandDeps,
 ) => Promise<HandlePortfolioQueueChatCommandResult>;
 
+/** Injectable so tests can observe the dispatch; defaults to the real flag-gated `runGovernorChatAction`. */
+export type RunGovernorChatActionFn = typeof runGovernorChatAction;
+
 export type ChatConversationProps = {
   streamChatImpl?: StreamChatFn;
   /** Defaults to the real end-to-end portfolio release/requeue handler (#7075). */
   handlePortfolioQueueChatCommandImpl?: PortfolioQueueChatCommandFn;
   /** Partial override of production portfolio-command deps (tests inject loadItems / gates / env). */
   portfolioQueueChatDeps?: Partial<HandlePortfolioQueueChatCommandDeps>;
+  /** Defaults to the real flag-gated governor dispatch wire (#8670). */
+  runGovernorChatActionImpl?: RunGovernorChatActionFn;
+  /** Override of production governor registration deps (tests inject registry / pause / resume fns). */
+  governorChatDeps?: RegisterGovernorChatActionsOptions;
 };
 
 function defaultPortfolioQueueChatDeps(
@@ -63,10 +85,15 @@ export function ChatConversation({
   streamChatImpl = streamChat,
   handlePortfolioQueueChatCommandImpl = handlePortfolioQueueChatCommand,
   portfolioQueueChatDeps,
+  runGovernorChatActionImpl = runGovernorChatAction,
+  governorChatDeps,
 }: ChatConversationProps = {}) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [activeSource, setActiveSource] = useState<ChunkSource | null>(null);
   const [streaming, setStreaming] = useState(false);
+  // #8670: true for the duration of a governor pause/resume round-trip — drives the pending copy of
+  // GovernorChatActionResult below the list (the chat twin of LedgersPage's `actionPending`).
+  const [governorActionPending, setGovernorActionPending] = useState(false);
   // #7078: true from submit until the first SSE text chunk — drives MessageList's TypingIndicator so the
   // pre-first-token round-trip isn't a silent gap. Cleared on first chunk, stream completion, or error.
   const [awaitingFirstChunk, setAwaitingFirstChunk] = useState(false);
@@ -104,6 +131,60 @@ export function ChatConversation({
                 content: TURN_FAILED_MESSAGE,
                 timestamp: new Date().toISOString(),
               },
+            ]);
+          } finally {
+            setStreaming(false);
+          }
+        })();
+        return;
+      }
+
+      // #8670: try governor pause/resume resolution next — BEFORE opening a read-only stream, so
+      // governor-intent text actually reaches runGovernorChatAction instead of the generic assistant.
+      const governorResolved = resolveGovernorChatAction(text);
+      if (governorResolved.ok) {
+        setMessages((prev) => [...prev, userMessage]);
+        // Reuse the composer-disable flag for the action round-trip (no streaming source / typing indicator).
+        setStreaming(true);
+        void (async () => {
+          const stamp = () => new Date().toISOString();
+          try {
+            // Same idempotent registration the Vite dev-server entry performs — safe to repeat per dispatch,
+            // and the only path that works when the rail renders before (or without) that entry point.
+            registerGovernorChatActions(governorChatDeps ?? {});
+            const dispatch = await runGovernorChatActionImpl(
+              {
+                action: governorResolved.action,
+                ...(governorResolved.params ? { params: governorResolved.params } : {}),
+              },
+              {
+                env: enabledChatActionsEnv(),
+                ...(governorChatDeps?.registry ? { registry: governorChatDeps.registry } : {}),
+                onPending: setGovernorActionPending,
+              },
+            );
+            const result = unwrapGovernorPauseChatResult(dispatch);
+            setMessages((prev) => [
+              ...prev,
+              result
+                ? {
+                    id: nextId(),
+                    role: "system",
+                    content: formatGovernorPauseChatMessage(result),
+                    timestamp: stamp(),
+                    governorActionResult: result,
+                  }
+                : {
+                    id: nextId(),
+                    role: "system",
+                    content: `Couldn't run the governor action: ${dispatch.status}.`,
+                    timestamp: stamp(),
+                  },
+            ]);
+          } catch {
+            setMessages((prev) => [
+              ...prev,
+              { id: nextId(), role: "system", content: TURN_FAILED_MESSAGE, timestamp: stamp() },
             ]);
           } finally {
             setStreaming(false);
@@ -184,7 +265,14 @@ export function ChatConversation({
       // would be read as a functional update and *call* it instead of storing it.
       setActiveSource(() => source);
     },
-    [messages, streamChatImpl, handlePortfolioQueueChatCommandImpl, portfolioQueueChatDeps],
+    [
+      messages,
+      streamChatImpl,
+      handlePortfolioQueueChatCommandImpl,
+      portfolioQueueChatDeps,
+      runGovernorChatActionImpl,
+      governorChatDeps,
+    ],
   );
 
   return (
@@ -195,7 +283,13 @@ export function ChatConversation({
           messages={messages}
           composing={streaming && awaitingFirstChunk}
           footer={
-            streaming && activeSource ? (
+            governorActionPending ? (
+              // #8670: pending copy for an in-flight pause/resume, in the same viewport slot the live
+              // streaming render uses — GovernorChatActionResult owns the role="status" announcement.
+              <div className="px-3 pt-4" data-testid="chat-governor-pending">
+                <GovernorChatActionResult pending result={null} />
+              </div>
+            ) : streaming && activeSource ? (
               <div className="flex gap-3 px-3 pt-4" data-testid="chat-streaming-response">
                 <Avatar className="size-8 shrink-0">
                   <AvatarFallback>{ASSISTANT_NAME.slice(0, 2).toUpperCase()}</AvatarFallback>

--- a/apps/loopover-miner-ui/src/components/chat/fixtures.ts
+++ b/apps/loopover-miner-ui/src/components/chat/fixtures.ts
@@ -2,6 +2,8 @@
 // entirely by props (a message array + a composing flag); a real data source arrives in a later,
 // separately-scoped issue. The shapes below are exactly what MessageBubble / MessageList render against.
 
+import type { GovernorPauseStateResult } from "../../lib/governor";
+
 export type ChatRole = "user" | "assistant" | "system";
 
 export interface ChatMessage {
@@ -14,6 +16,9 @@ export interface ChatMessage {
   authorName?: string;
   /** Optional avatar image URL; when absent, MessageBubble renders the initials fallback only. */
   avatarUrl?: string;
+  /** When set, MessageBubble renders this turn through GovernorChatActionResult instead of the plain
+   *  `content` string (#8670) — `content` still carries the same copy for wire-history/plain-text use. */
+  governorActionResult?: GovernorPauseStateResult;
 }
 
 /** Empty conversation — drives MessageList's StateBoundary empty branch. */

--- a/apps/loopover-miner-ui/src/components/chat/message-bubble.tsx
+++ b/apps/loopover-miner-ui/src/components/chat/message-bubble.tsx
@@ -1,4 +1,5 @@
 import { Avatar, AvatarFallback, AvatarImage } from "@loopover/ui-kit/components/avatar";
+import { GovernorChatActionResult } from "./governor-action-result";
 import type { ChatMessage, ChatRole } from "./fixtures";
 
 // Role-differentiated bubble backgrounds, built ONLY from existing @loopover/ui-kit theme tokens
@@ -33,7 +34,13 @@ export function MessageBubble({ message }: { message: ChatMessage }) {
       </Avatar>
       <div className="flex min-w-0 flex-col gap-1">
         <div className={`whitespace-pre-wrap break-words rounded-token-sm px-3 py-2 text-token-sm ${bubbleClass}`}>
-          {message.content}
+          {message.governorActionResult ? (
+            // #8670: a resolved governor pause/resume turn renders through the dedicated result component
+            // (same Ledgers-verbatim copy as `content`), not as an undifferentiated plain-text bubble.
+            <GovernorChatActionResult pending={false} result={message.governorActionResult} />
+          ) : (
+            message.content
+          )}
         </div>
         <time className="text-token-xs text-muted-foreground" dateTime={message.timestamp}>
           {formatTimestamp(message.timestamp)}

--- a/apps/loopover-miner-ui/src/lib/chat-governor-resolve.test.ts
+++ b/apps/loopover-miner-ui/src/lib/chat-governor-resolve.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  GOVERNOR_PAUSE_CHAT_ACTION,
+  GOVERNOR_RESUME_CHAT_ACTION,
+  resolveGovernorChatAction,
+} from "./chat-governor-resolve";
+
+describe("resolveGovernorChatAction (#8670)", () => {
+  it("resolves plain pause intents to governor_pause with no params", () => {
+    for (const text of [
+      "pause the governor",
+      "Please PAUSE the governor now",
+      "halt the governor",
+      "suspend the governor",
+    ]) {
+      expect(resolveGovernorChatAction(text)).toEqual({ ok: true, action: GOVERNOR_PAUSE_CHAT_ACTION });
+    }
+  });
+
+  it("resolves resume intents to governor_resume", () => {
+    for (const text of ["resume the governor", "unpause the governor", "please Resume the governor"]) {
+      expect(resolveGovernorChatAction(text)).toEqual({ ok: true, action: GOVERNOR_RESUME_CHAT_ACTION });
+    }
+  });
+
+  it('does NOT read "unpause" as a pause intent (word boundaries keep the verb sets disjoint)', () => {
+    const resolved = resolveGovernorChatAction("unpause the governor");
+    expect(resolved).toEqual({ ok: true, action: GOVERNOR_RESUME_CHAT_ACTION });
+  });
+
+  it("extracts a pause reason from a trailing because-clause, trimming end punctuation", () => {
+    expect(resolveGovernorChatAction("pause the governor because release traffic spiked.")).toEqual({
+      ok: true,
+      action: GOVERNOR_PAUSE_CHAT_ACTION,
+      params: { reason: "release traffic spiked" },
+    });
+  });
+
+  it("extracts a pause reason from a reason: clause", () => {
+    expect(resolveGovernorChatAction("pause the governor reason: maintenance window")).toEqual({
+      ok: true,
+      action: GOVERNOR_PAUSE_CHAT_ACTION,
+      params: { reason: "maintenance window" },
+    });
+  });
+
+  it("omits an empty because-clause instead of sending an empty reason", () => {
+    expect(resolveGovernorChatAction("pause the governor because ")).toEqual({
+      ok: true,
+      action: GOVERNOR_PAUSE_CHAT_ACTION,
+    });
+  });
+
+  it("is unresolvable for empty / non-governor / verb-less / ambiguous text", () => {
+    for (const text of [
+      "",
+      "   ",
+      "pause everything", // no governor mention — a bare "pause" must not guess a target
+      "what is the governor status?", // governor question, no pause/resume verb
+      "governor paused?", // "paused" is not the verb "pause" (word-bounded)
+      "pause and then resume the governor", // both intents at once — ambiguous
+    ]) {
+      const resolved = resolveGovernorChatAction(text);
+      expect(resolved.ok).toBe(false);
+      if (!resolved.ok) {
+        expect(resolved.reason).toBe("unresolvable");
+        expect(resolved.message).toContain("governor");
+      }
+    }
+  });
+});

--- a/apps/loopover-miner-ui/src/lib/chat-governor-resolve.ts
+++ b/apps/loopover-miner-ui/src/lib/chat-governor-resolve.ts
@@ -1,0 +1,66 @@
+// Chat-text → governor pause/resume action resolution (#8670). Pure: no fetch, no dispatch. Mirrors
+// chat-portfolio-queue-resolve.ts's pattern: parse an operator's chat message into one of the two known
+// governor actions (`governor_pause` / `governor_resume`) plus the optional pause reason. Ambiguous /
+// malformed text returns an explicit unresolvable result so the caller never turns a best-guess into a
+// `dispatchChatAction` call — an ordinary governor *question* ("what is the governor status?") must keep
+// falling through to the read-only streaming assistant.
+
+import {
+  GOVERNOR_PAUSE_CHAT_ACTION,
+  GOVERNOR_RESUME_CHAT_ACTION,
+} from "../../../../packages/loopover-miner/lib/chat-governor-actions.js";
+
+export { GOVERNOR_PAUSE_CHAT_ACTION, GOVERNOR_RESUME_CHAT_ACTION };
+
+export type GovernorChatResolvedActionName = typeof GOVERNOR_PAUSE_CHAT_ACTION | typeof GOVERNOR_RESUME_CHAT_ACTION;
+
+export type GovernorChatResolveResult =
+  | { ok: true; action: GovernorChatResolvedActionName; params?: { reason: string } }
+  | { ok: false; reason: "unresolvable"; message: string };
+
+/** Verbs that read as a pause intent. Word-bounded so "unpaused" / "pauses" prose doesn't half-match. */
+const PAUSE_WORDS = ["pause", "halt", "suspend"] as const;
+/** Verbs that read as a resume intent. `\bpause\b` never matches inside "unpause", so the sets stay disjoint. */
+const RESUME_WORDS = ["resume", "unpause"] as const;
+
+/** The message must actually be about the governor — a bare "pause" (a stream? a queue?) stays unresolved. */
+const GOVERNOR_RE = /\bgovernor\b/i;
+
+/** Optional pause reason: everything after a trailing "because …" / "reason: …" clause. */
+const REASON_RE = /\b(?:because|reason:?)\s+(\S.*)$/i;
+
+const UNRESOLVABLE =
+  'Couldn\'t determine a governor action. Say something like "pause the governor", "pause the governor because <reason>", or "resume the governor".';
+
+function hasWord(text: string, words: readonly string[]): boolean {
+  return words.some((word) => new RegExp(`\\b${word}\\b`, "i").test(text));
+}
+
+/**
+ * Resolve chat text to a governor pause/resume request the runner (`runGovernorChatAction`) accepts.
+ * Does NOT call the dispatch layer — an unresolvable result must never be turned into a best-guess
+ * dispatch, exactly like the portfolio-queue resolver.
+ */
+export function resolveGovernorChatAction(text: string): GovernorChatResolveResult {
+  const trimmed = text.trim();
+  if (!trimmed || !GOVERNOR_RE.test(trimmed)) {
+    return { ok: false, reason: "unresolvable", message: UNRESOLVABLE };
+  }
+
+  const wantsPause = hasWord(trimmed, PAUSE_WORDS);
+  const wantsResume = hasWord(trimmed, RESUME_WORDS);
+  // Neither intent (a status question) or both at once (ambiguous) — never guess.
+  if (wantsPause === wantsResume) {
+    return { ok: false, reason: "unresolvable", message: UNRESOLVABLE };
+  }
+
+  if (wantsResume) {
+    return { ok: true, action: GOVERNOR_RESUME_CHAT_ACTION };
+  }
+
+  const reason = trimmed.match(REASON_RE)?.[1]?.replace(/[.?!\s]+$/, "");
+  // Mirror LedgersPage / readOptionalPauseReason: an empty reason is omitted, not sent as "".
+  return reason
+    ? { ok: true, action: GOVERNOR_PAUSE_CHAT_ACTION, params: { reason } }
+    : { ok: true, action: GOVERNOR_PAUSE_CHAT_ACTION };
+}


### PR DESCRIPTION
Closes #8670

## What

`apps/loopover-miner-ui`'s governor pause/resume chat-action family was fully built and unit-tested — `runGovernorChatAction` (dispatch wrapper), `GovernorChatActionResult` (result renderer), `chat-governor-action-copy.ts` (Ledgers-verbatim copy) — but dead in the product: `conversation.tsx`'s `handleSubmit` only resolved portfolio-queue text, so an operator typing "pause the governor" into the chat rail was silently answered by the generic read-only streaming assistant. `runGovernorChatAction` had zero non-test callers and `GovernorChatActionResult` was never imported outside its own test, exactly as the issue's repo-wide grep found.

## How

All four Deliverables, in this one PR:

- [x] **New text resolver** — `src/lib/chat-governor-resolve.ts` (`resolveGovernorChatAction`) mirrors `chat-portfolio-queue-resolve.ts`'s pattern: pure (no fetch, no dispatch), word-bounded pause/halt/suspend vs resume/unpause intent detection that must co-occur with the word "governor", an optional pause reason from a trailing `because …` / `reason: …` clause (mapped to the `{ reason }` params shape `isGovernorPauseChatParams` validates), and an explicit unresolvable result for empty/ambiguous/verb-less text so a governor *question* still falls through to the assistant and nothing is ever best-guess dispatched.
- [x] **`handleSubmit` wiring** — `conversation.tsx` resolves governor intent right after the portfolio-queue check and, on a match, performs the same idempotent `registerGovernorChatActions()` registration the Vite dev-server entry does, then dispatches through `runGovernorChatAction` (flag-gated `dispatchChatAction` + `governorGatedHandler`, never a direct handler call). Unresolved text streams exactly as before.
- [x] **`GovernorChatActionResult` rendered in the message stream** — the in-flight round-trip renders the component's pending state (`role="status"`, "Updating governor…") in the same viewport slot the live streaming render uses, and the resolved turn is committed to the message list with the result attached, where `MessageBubble` now renders it through `GovernorChatActionResult` (error → `role="alert"`, success → the Ledgers-verbatim "Paused since …"/"Not paused" copy). Non-executed dispatches (flag off / gated) and thrown dispatches surface as inline system notes, mirroring the existing failure convention.
- [x] **End-to-end RTL test** — `chat-conversation.test.tsx` gains a 7-test `#8670` describe that renders `ChatConversation`, types governor-intent text into the real composer, and drives the REAL registration + dispatch pipeline (`createChatActionRegistry()` + injected `pauseGovernor`/`resumeGovernor` clients only): asserts the pause action actually fires, the because-clause reaches `pauseGovernor("release traffic spiked")` as the structured reason, resume fires, `GovernorChatActionResult`'s copy appears in the message list, pending copy shows while outstanding, non-executed/thrown dispatches surface, and `streamChat` is never called for action turns (0 calls) while ordinary governor questions still stream. Resolver branches are pinned in `chat-governor-resolve.test.ts`.

## Before / after (RED proof)

The new end-to-end tests on unfixed `main` (fix stashed, tests kept) fail exactly as the issue describes — governor-intent text falls through to the generic assistant and no action ever fires:

```
× END-TO-END: typing "pause the governor" fires the pause action and renders GovernorChatActionResult copy
  AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
× typing "resume the governor" fires the resume action and renders the not-paused copy
  AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
(6 of the 7 new tests fail on main; the falls-through-to-assistant test passes, pinning the unchanged path)
```

With the fix, the full app suite:

```
Test Files  38 passed (38)
     Tests  407 passed (407)
```

Local vitest coverage thresholds (85/85/75/85, enforced in CI for this app) pass at 91.81% statements / 89.64% branches / 87.55% functions / 94.36% lines; every new/changed file is at 100% statements (`chat-governor-resolve.ts` 100% across all four metrics). `tsc --noEmit`, `eslint` and `prettier --check` on the changed files, and `git diff --check` are all green.

## UI Evidence

The miner-ui chat rail on the Overview route, served by `vite dev` in the app's own demo mode (`VITE_DEMO_MODE=1`, sample data, no live backend), captured per viewport × theme below. The read-only `POST /api/chat` stream is answered at the network boundary by a fixture (the generic grounded assistant reply); the governor path needs no fixture at all — in demo mode `pauseGovernor` performs the real demo-state write, so the After column is the actual resolver → registration → flag-gated dispatch → `GovernorChatActionResult` path executing in the browser. Look at the reply to **"pause the governor"**: before, the generic assistant answers in prose and nothing happens (the bug); after, the pause action executes and the system turn renders `GovernorChatActionResult`'s "Paused since …" copy. Capture note: current `main` cannot paint this SPA at all — `@loopover/engine`'s `dist/calibration/backtest-split.js` (#8097) reaches the browser graph through the chat-action registry chain and its top-level `node:crypto` access makes Vite's browser-external shim throw before first render, on clean `main` exactly as on this branch — so the harness replaces that shim with an inert stub at the network boundary; none of those node-only modules are executed by the surface being captured, and the un-stubbed behavior is identical (a blank page) before and after this change.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | <a href="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8670/lo8670-desktop-light-before.png"><img src="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8670/lo8670-desktop-light-before.png" alt="Desktop light before — pause the governor answered by the generic assistant, no action fires" width="240"></a> | <a href="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8670/lo8670-desktop-light-after.png"><img src="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8670/lo8670-desktop-light-after.png" alt="Desktop light after — pause dispatched, GovernorChatActionResult renders Paused since timestamp" width="240"></a> |
| Desktop · Dark | <a href="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8670/lo8670-desktop-dark-before.png"><img src="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8670/lo8670-desktop-dark-before.png" alt="Desktop dark before — pause the governor answered by the generic assistant, no action fires" width="240"></a> | <a href="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8670/lo8670-desktop-dark-after.png"><img src="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8670/lo8670-desktop-dark-after.png" alt="Desktop dark after — pause dispatched, GovernorChatActionResult renders Paused since timestamp" width="240"></a> |
| Tablet · Light | <a href="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8670/lo8670-tablet-light-before.png"><img src="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8670/lo8670-tablet-light-before.png" alt="Tablet light before — pause the governor answered by the generic assistant, no action fires" width="240"></a> | <a href="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8670/lo8670-tablet-light-after.png"><img src="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8670/lo8670-tablet-light-after.png" alt="Tablet light after — pause dispatched, GovernorChatActionResult renders Paused since timestamp" width="240"></a> |
| Tablet · Dark | <a href="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8670/lo8670-tablet-dark-before.png"><img src="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8670/lo8670-tablet-dark-before.png" alt="Tablet dark before — pause the governor answered by the generic assistant, no action fires" width="240"></a> | <a href="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8670/lo8670-tablet-dark-after.png"><img src="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8670/lo8670-tablet-dark-after.png" alt="Tablet dark after — pause dispatched, GovernorChatActionResult renders Paused since timestamp" width="240"></a> |
| Mobile · Light | <a href="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8670/lo8670-mobile-light-before.png"><img src="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8670/lo8670-mobile-light-before.png" alt="Mobile light before — chat sheet, pause the governor answered by the generic assistant" width="240"></a> | <a href="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8670/lo8670-mobile-light-after.png"><img src="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8670/lo8670-mobile-light-after.png" alt="Mobile light after — chat sheet, pause dispatched, Paused since copy rendered" width="240"></a> |
| Mobile · Dark | <a href="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8670/lo8670-mobile-dark-before.png"><img src="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8670/lo8670-mobile-dark-before.png" alt="Mobile dark before — chat sheet, pause the governor answered by the generic assistant" width="240"></a> | <a href="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8670/lo8670-mobile-dark-after.png"><img src="https://raw.githubusercontent.com/tryeverything24/loopover/pr-assets-8670/lo8670-mobile-dark-after.png" alt="Mobile dark after — chat sheet, pause dispatched, Paused since copy rendered" width="240"></a> |
