### PR TITLE
test(ui): cover formatReversalEventType's three branches directly

### DIFF
--- a/apps/loopover-ui/src/components/site/app-panels/reversal-health-card.test.tsx
+++ b/apps/loopover-ui/src/components/site/app-panels/reversal-health-card.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import { ReversalHealthCard } from "@/components/site/app-panels/reversal-health-card";
 import {
   formatRatePct,
+  formatReversalEventType,
   reversalHealthStatus,
   type ReversalHealth,
 } from "@/components/site/app-panels/reversal-health-card-model";
@@ -36,6 +37,20 @@ describe("reversalHealthStatus", () => {
       tone: "info",
       label: "no auto-actions in window",
     });
+  });
+});
+
+describe("formatReversalEventType", () => {
+  it("labels reversal_reverted as a merge reverted", () => {
+    expect(formatReversalEventType("reversal_reverted")).toBe("merge reverted");
+  });
+
+  it("labels reversal_reopened as a close reopened", () => {
+    expect(formatReversalEventType("reversal_reopened")).toBe("close reopened");
+  });
+
+  it("falls back to underscore-to-space formatting for unrecognized event types", () => {
+    expect(formatReversalEventType("some_new_event")).toBe("some new event");
   });
 });
 


### PR DESCRIPTION
The formatReversalEventType helper in reversal-health-card-model.ts has three branches (reversal_reverted, reversal_reopened, and a generic fallback), but only reversal_reopened was exercised, and only indirectly through a ReversalHealthCard render assertion. This adds direct unit tests for all three branches, including the previously-uncovered "merge reverted" case.

Closes #8665

## Validation
- `npx vitest run src/components/site/app-panels/reversal-health-card.test.tsx` — 9/9 passed
- `npm --workspace @loopover/ui run test` — 88 files / 626 tests passed
- `npm --workspace @loopover/ui-miner run test` — 37 files / 393 tests passed
- `npm test` (root suite) — 1156 files / 21627 tests passed
- `npm run test:workers` — 3/3 passed
- `npm run typecheck`, `npm run actionlint`, and the full drift/manifest/reference check suite — all green
- `npx turbo run lint --filter=@loopover/ui --filter=@loopover/ui-miner` — 0 errors