### PR TITLE
test(ui): cover formatReversalEventType's three branches directly

### DIFF
--- a/apps/loopover-ui/src/lib/reversal-event-type-format.test.ts
+++ b/apps/loopover-ui/src/lib/reversal-event-type-format.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { formatReversalEventType } from "@/components/site/app-panels/reversal-health-card-model";
+
+// (#8665) Direct unit coverage for formatReversalEventType. Previously only the "reversal_reopened"
+// arm was exercised — and only indirectly, through ReversalHealthCard's render in
+// reversal-health-card.test.tsx. The headline "reversal_reverted" -> "merge reverted" branch (the
+// bot-merge-revert case this card exists to surface) and the generic underscore-humanizing fallback
+// had no direct test, so a typo or refactor regression in either string comparison would go
+// undetected. These assert each of the three branches against the pure helper itself.
+describe("formatReversalEventType (#8665)", () => {
+  it("maps reversal_reverted to the 'merge reverted' headline", () => {
+    expect(formatReversalEventType("reversal_reverted")).toBe("merge reverted");
+  });
+
+  it("maps reversal_reopened to 'close reopened'", () => {
+    expect(formatReversalEventType("reversal_reopened")).toBe("close reopened");
+  });
+
+  it("humanizes any other event type by replacing every underscore with a space", () => {
+    expect(formatReversalEventType("some_new_event")).toBe("some new event");
+    expect(formatReversalEventType("a_b_c")).toBe("a b c");
+  });
+});


### PR DESCRIPTION
test(ui): cover formatReversalEventType's three branches directly

Add a standalone unit test for the pure formatReversalEventType helper,
asserting each of its three branches: the headline reversal_reverted ->
"merge reverted" case, reversal_reopened -> "close reopened", and the
generic underscore-humanizing fallback. Previously only the reopened arm
was exercised, and only indirectly through ReversalHealthCard's render, so
a regression in the reverted or fallback comparison went uncaught.

Closes #8665



## Validation

Verified locally on this branch before opening:
- [x] `npm run typecheck`
- [x] `npx turbo run build:tsc build:verify`
- [x] `npm run test:coverage` — patch coverage 100.0% of changed lines
