### PR TITLE
chore(orb): move the beta-channel target to 3.5.0

### DIFF
--- a/orb-manifest.json
+++ b/orb-manifest.json
@@ -1,4 +1,4 @@
 {
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Source of truth for the self-hostable loopover-orb container image's target release version (ghcr.io/jsonbored/loopover-selfhost). Bumped by a maintainer when a feat/fix/breaking change since the last stable orb-v tag warrants moving to a new target version -- scripts/orb-release-core.ts and .github/workflows/orb-beta-release.yml read this file to decide what version the next automated beta snapshot targets. Promoting a beta to a stable orb-vX.Y.Z release is still a manual `git tag` -- this manifest only drives the automated beta channel."
 }


### PR DESCRIPTION
One-line manifest bump: v3.4.0 shipped stable, and main since gained feat-level changes (calibration epic: live-gate threshold backtest, advisory-mode signal recording, implicit confirmations, self-tune track-record line) plus the disposition-alignment and AI-review reliability fixes. Re-arms orb-beta-release.yml to cut orb-v3.5.0-beta.1 (its due-check currently reports targetAlreadyStable + manifestStale). Release flow per the manifest's own doc comment.