### PR TITLE
fix(ui): point roadmap owner-console card at the dedicated /app/owner route

### DIFF
--- a/apps/loopover-ui/src/routes/roadmap.test.tsx
+++ b/apps/loopover-ui/src/routes/roadmap.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { ReactNode } from "react";
-import { vi } from "vitest";
 
 // jsdom has no IntersectionObserver; RoadmapPage wraps its content in <Reveal>, a framer-motion
 // viewport-triggered animation that needs one to mount. No other test in this file tree renders

--- a/apps/loopover-ui/src/routes/roadmap.test.tsx
+++ b/apps/loopover-ui/src/routes/roadmap.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { ReactNode } from "react";
+import { vi } from "vitest";
+
+// jsdom has no IntersectionObserver; RoadmapPage wraps its content in <Reveal>, a framer-motion
+// viewport-triggered animation that needs one to mount. No other test in this file tree renders
+// Reveal yet, so there's no existing global stub to reuse -- a minimal no-op observer is enough,
+// since the tests here only assert on rendered link hrefs, not the reveal animation itself.
+class MockIntersectionObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
+
+// Stub TanStack Router the same way install.permissions.test.tsx does: Link becomes a plain <a>
+// carrying the resolved `to` as its href, so the rendered destination can be asserted directly.
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => () => ({}),
+  Link: ({ to, children }: { to: string; children: ReactNode }) => <a href={to}>{children}</a>,
+}));
+
+import { RoadmapPage } from "./roadmap";
+
+// #8669: the "Phase 3: repo owner intake console" card linked to /app/repos, which defaults to the
+// Maintainer console tab (app.repos.tsx:27) with no search param -- the opposite surface from what
+// the card describes. Locks in the fix to the dedicated /app/owner route, and guards that no other
+// phase's link moved as a side effect.
+describe("RoadmapPage phase links (#8669)", () => {
+  it("routes the repo owner intake console card to the dedicated Owner workspace, not the Maintainer tab", () => {
+    render(<RoadmapPage />);
+    const link = screen.getByRole("link", { name: /Open repos console/i });
+    expect(link.getAttribute("href")).toBe("/app/owner");
+  });
+
+  it("leaves the maintainer trust card's link unchanged (sibling regression guard)", () => {
+    render(<RoadmapPage />);
+    const link = screen.getByRole("link", { name: /Open maintainer console/i });
+    expect(link.getAttribute("href")).toBe("/app/maintainer");
+  });
+});

--- a/apps/loopover-ui/src/routes/roadmap.tsx
+++ b/apps/loopover-ui/src/routes/roadmap.tsx
@@ -100,7 +100,7 @@ const LINK_MAP: Record<string, { to: string; label: string }> = {
     to: "/app/maintainer",
     label: "Open maintainer console",
   },
-  "Phase 3: repo owner intake console": { to: "/app/repos", label: "Open repos console" },
+  "Phase 3: repo owner intake console": { to: "/app/owner", label: "Open repos console" },
   "Phase 4: adoption analytics and launch system": {
     to: "/app/analytics",
     label: "Open analytics",
@@ -108,7 +108,7 @@ const LINK_MAP: Record<string, { to: string; label: string }> = {
   "Phase 5: ecosystem distribution": { to: "/app/digest", label: "Preview the digest" },
 };
 
-function RoadmapPage() {
+export function RoadmapPage() {
   const grouped = COLUMNS.map((c) => ({
     ...c,
     items: ROADMAP_ITEMS.filter((r) => r.status === c.key),


### PR DESCRIPTION
## Summary

- The "Phase 3: repo owner intake console" roadmap card linked to `/app/repos`, which defaults to the Maintainer console tab when no `search` param is given (`app.repos.tsx:27`) — the opposite surface from what the card describes. Every other phase links to its own dedicated route; this points Phase 3 at its dedicated route, `/app/owner`, the same way.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` — skipped, no `.github/workflows`/composite-action changes.
- [x] `npm run typecheck` (via `npm run ui:typecheck` — clean)
- [ ] `npm run test:coverage` locally — `apps/**` is excluded from `codecov/patch` gating (confirmed against `vitest.config.ts`/`codecov.yml`). Ran the applicable equivalent: `npx vitest run src/routes/roadmap.test.tsx` (2/2 passed) and the full `npm run ui:test` (630/630 + 407/407 passed across `@loopover/ui` + `@loopover/ui-miner`).
- [ ] `npm run test:workers` — skipped, no Workers/backend code touched.
- [ ] `npm run build:mcp` — skipped, no MCP package changes.
- [ ] `npm run test:mcp-pack` — skipped, no MCP package changes.
- [ ] `npm run ui:openapi:check` — skipped, no API/OpenAPI schema changes.
- [x] `npm run ui:lint` — 0 errors (11 pre-existing `react-refresh/only-export-components` warnings across the codebase, same pre-existing pattern already present elsewhere; unrelated to this diff).
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate` — 5 pre-existing high-severity advisories in the `eslint`/`minimatch`/`brace-expansion` dev-dependency chain, unrelated to this change (zero new dependencies added).
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — new `roadmap.test.tsx` asserts the actual resolved link destination (not just link presence), plus a sibling regression guard that Phase 2's link is untouched.

If any required check was skipped, explain why:

- `test:workers`/`test:mcp-pack`/`ui:openapi:check`/`actionlint` all skipped as not applicable — this diff touches exactly two files under `apps/loopover-ui/src/routes/`, nothing else.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no such changes.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no such changes.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, this changes a link `href` target only, no data-fetching behavior.
- [x] Visible UI changes include a `UI Evidence` section below with screenshots. — see below; no screenshots needed for this specific change, with reasoning given.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — N/A.

## UI Evidence

This change only redirects a link's destination (`to: "/app/repos"` → `to: "/app/owner"`); the card's rendered text, layout, color, and position are unchanged. Freshly captured this submission, running the real app locally against `/roadmap` (a public route, no auth/mocking needed). `apps/loopover-ui` is a dark-mode-only build (theme toggle removed — `apps/loopover-ui/src/components/site/theme-toggle.tsx`), so Dark is the only theme this app has.

| Viewport | Before | After |
| --- | --- | --- |
| Desktop · Dark | <a href="https://raw.githubusercontent.com/hurryup52/loopover/screenshots/desktop-roadmap.png"><img src="https://raw.githubusercontent.com/hurryup52/loopover/screenshots/desktop-roadmap.png" alt="Desktop Dark before" width="240"></a> | <a href="https://raw.githubusercontent.com/hurryup52/loopover/screenshots/desktop-roadmap.png"><img src="https://raw.githubusercontent.com/hurryup52/loopover/screenshots/desktop-roadmap.png" alt="Desktop Dark after" width="240"></a> |
| Tablet · Dark | <a href="https://raw.githubusercontent.com/hurryup52/loopover/screenshots/tablet-roadmap.png"><img src="https://raw.githubusercontent.com/hurryup52/loopover/screenshots/tablet-roadmap.png" alt="Tablet Dark before" width="240"></a> | <a href="https://raw.githubusercontent.com/hurryup52/loopover/screenshots/tablet-roadmap.png"><img src="https://raw.githubusercontent.com/hurryup52/loopover/screenshots/tablet-roadmap.png" alt="Tablet Dark after" width="240"></a> |
| Mobile · Dark | <a href="https://raw.githubusercontent.com/hurryup52/loopover/screenshots/mobile-roadmap.png"><img src="https://raw.githubusercontent.com/hurryup52/loopover/screenshots/mobile-roadmap.png" alt="Mobile Dark before" width="240"></a> | <a href="https://raw.githubusercontent.com/hurryup52/loopover/screenshots/mobile-roadmap.png"><img src="https://raw.githubusercontent.com/hurryup52/loopover/screenshots/mobile-roadmap.png" alt="Mobile Dark after" width="240"></a> |

Before and after are the identical image in every row, intentionally — the fix changes only an anchor's `href`, not anything rendered, so a genuine before/after comparison shows no visual difference.

## Notes

- Closes #8669.
- Both Deliverables not covered by the summary above: (1) the fix reaches the Owner workspace via the dedicated-route form (`/app/owner`), matching the pattern of every other phase, per the issue's stated preference; (2) no other phase's `LINK_MAP` entry was touched, verified by a sibling regression test asserting Phase 2's link is unchanged.

