### PR TITLE
fix(ui): thread errorKind through dead-letter-queue and overview error states

### DIFF
--- a/apps/loopover-ui/src/components/site/dead-letter-queue-panel.test.tsx
+++ b/apps/loopover-ui/src/components/site/dead-letter-queue-panel.test.tsx
@@ -150,6 +150,26 @@ describe("DeadLetterQueuePanel", () => {
     expect(screen.getByText("insufficient_role")).toBeTruthy();
   });
 
+  // #8668: the panel's own errorTitle/errorDescription are fixed strings that always win over
+  // ErrorState's network-aware copy defaults, so a network-kind failure is only observable via the
+  // icon swap (WifiOff vs AlertTriangle) -- errorKind previously wasn't threaded through at all, so
+  // this rendered the generic icon even when the API was completely unreachable.
+  it("shows the offline (WifiOff) icon for a network-kind failure, not the generic one", async () => {
+    apiFetch.mockResolvedValue({ ok: false, message: "fetch failed", kind: "network" });
+    const { container } = render(<DeadLetterQueuePanel />);
+    await screen.findByText("Couldn't load the dead-letter queue");
+    expect(container.querySelector(".lucide-wifi-off")).toBeTruthy();
+    expect(container.querySelector(".lucide-triangle-alert")).toBeNull();
+  });
+
+  it("keeps the generic (AlertTriangle) icon for a non-network failure", async () => {
+    apiFetch.mockResolvedValue({ ok: false, message: "insufficient_role", kind: "http" });
+    const { container } = render(<DeadLetterQueuePanel />);
+    await screen.findByText("Couldn't load the dead-letter queue");
+    expect(container.querySelector(".lucide-triangle-alert")).toBeTruthy();
+    expect(container.querySelector(".lucide-wifi-off")).toBeNull();
+  });
+
   it("shows an error state when the response is malformed", async () => {
     apiFetch.mockResolvedValue({ ok: true, data: { generatedAt: "x" } });
     render(<DeadLetterQueuePanel />);

--- a/apps/loopover-ui/src/components/site/dead-letter-queue-panel.tsx
+++ b/apps/loopover-ui/src/components/site/dead-letter-queue-panel.tsx
@@ -120,6 +120,7 @@ export function DeadLetterQueuePanel() {
         <StateBoundary
           isLoading={resource.status === "loading"}
           isError={resource.status === "error" || isMalformed}
+          errorKind={resource.status === "error" ? resource.errorKind : undefined}
           isEmpty={page !== null && page.items.length === 0}
           onRetry={resource.reload}
           onRefresh={resource.reload}

--- a/apps/loopover-ui/src/routes/app.index.test.tsx
+++ b/apps/loopover-ui/src/routes/app.index.test.tsx
@@ -1,8 +1,45 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
 
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { SparkStat } from "./app.index";
+
+const { apiFetch } = vi.hoisted(() => ({ apiFetch: vi.fn() }));
+vi.mock("@/lib/api/request", () => ({ apiFetch: (...args: unknown[]) => apiFetch(...args) }));
+vi.mock("@/lib/api/origin", () => ({ getApiOrigin: () => "https://api.test" }));
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => () => ({}),
+  Link: ({ to, children }: { to: string; children: ReactNode }) => <a href={to}>{children}</a>,
+  useNavigate: () => () => Promise.resolve(),
+}));
+
+import { AppOverview } from "./app.index";
+
+function mockOverviewFetch(
+  overview: { ok: true } | { ok: false; kind?: "network" | "timeout" | "http" },
+) {
+  apiFetch.mockImplementation((url: string) => {
+    if (url.endsWith("/v1/auth/session")) {
+      return Promise.resolve({
+        ok: true,
+        data: {
+          status: "authenticated",
+          login: "test-user",
+          roles: ["miner"],
+          confirmed_miner: false,
+        },
+      });
+    }
+    if (url.endsWith("/v1/app/overview")) {
+      return overview.ok
+        ? Promise.resolve({ ok: true, data: { metrics: [], recentRuns: [] } })
+        : Promise.resolve({ ok: false, message: "fetch failed", kind: overview.kind });
+    }
+    return Promise.resolve({ ok: false, message: "unhandled in test" });
+  });
+}
 
 // #6984: SparkStat's loading branch hand-rolled its own animate-pulse divs instead of the shared
 // Skeleton primitive every other loading placeholder in this app already uses.
@@ -37,5 +74,41 @@ describe("SparkStat loading state (#6984)", () => {
     expect(screen.getByText("Open PRs")).toBeTruthy();
     expect(screen.getByText("4")).toBeTruthy();
     expect(screen.queryByRole("status", { name: "Loading Open PRs" })).toBeNull();
+  });
+});
+
+// #8668: the overview metrics ErrorState passed only title/description (both fixed strings), never
+// errorKind or onRetry -- so a network outage always rendered the generic AlertTriangle treatment
+// with no retry action, even though `overview.errorKind`/`overview.reload` were both already
+// available from useApiResource.
+describe("AppOverview metrics error state (#8668)", () => {
+  it("shows the offline (WifiOff) icon for a network-kind overview failure, not the generic one", async () => {
+    mockOverviewFetch({ ok: false, kind: "network" });
+    const { container } = render(<AppOverview />);
+    await screen.findByText("App overview is unavailable right now");
+    expect(container.querySelector(".lucide-wifi-off")).toBeTruthy();
+    expect(container.querySelector(".lucide-triangle-alert")).toBeNull();
+  });
+
+  it("keeps the generic (AlertTriangle) icon for a non-network overview failure", async () => {
+    mockOverviewFetch({ ok: false, kind: "http" });
+    const { container } = render(<AppOverview />);
+    await screen.findByText("App overview is unavailable right now");
+    expect(container.querySelector(".lucide-triangle-alert")).toBeTruthy();
+    expect(container.querySelector(".lucide-wifi-off")).toBeNull();
+  });
+
+  it("retrying the overview error re-fetches /v1/app/overview", async () => {
+    mockOverviewFetch({ ok: false, kind: "network" });
+    render(<AppOverview />);
+    await screen.findByText("App overview is unavailable right now");
+
+    apiFetch.mockClear();
+    mockOverviewFetch({ ok: false, kind: "network" });
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+
+    await waitFor(() =>
+      expect(apiFetch).toHaveBeenCalledWith("https://api.test/v1/app/overview", expect.any(Object)),
+    );
   });
 });

--- a/apps/loopover-ui/src/routes/app.index.tsx
+++ b/apps/loopover-ui/src/routes/app.index.tsx
@@ -102,7 +102,7 @@ type AppOverviewResponse = {
   }>;
 };
 
-function AppOverview() {
+export function AppOverview() {
   const { session } = useSession();
   const { status, connection } = useApiStatus();
   const overview = useApiResource<AppOverviewResponse>("/v1/app/overview", "App overview");
@@ -175,6 +175,8 @@ function AppOverview() {
               className="col-span-full"
               title="App overview is unavailable right now"
               description={overview.error}
+              errorKind={overview.errorKind}
+              onRetry={overview.reload}
             />
           )}
           {series.length === 0 ? (


### PR DESCRIPTION
## Summary

- `dead-letter-queue-panel.tsx`'s `StateBoundary` and `app.index.tsx`'s overview `ErrorState` both call into `ErrorState`/`StateBoundary` without passing `errorKind`, so a genuine network/timeout outage always rendered the generic `AlertTriangle` "something went wrong" treatment instead of the `WifiOff` "can't reach the server" one already used correctly by four sibling call sites (`notification-readiness-card.tsx`, `app.operator.tsx`, `app.analytics.tsx`, `app.runs.tsx`). The overview error also had no retry action at all. This threads `errorKind` (and adds `onRetry`) through both remaining call sites.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` — skipped, no `.github/workflows`/composite-action changes.
- [x] `npm run typecheck` (via `npm run ui:typecheck` — clean)
- [ ] `npm run test:coverage` locally — `apps/**` is excluded from `codecov/patch` gating (confirmed against `vitest.config.ts`/`codecov.yml`, and the issue's own body states the same). Ran the applicable equivalent: `npx vitest run src/components/site/dead-letter-queue-panel.test.tsx src/routes/app.index.test.tsx` (39/39 passed) and the full `npm run ui:test` (635/635 + 407/407 passed across `@loopover/ui` + `@loopover/ui-miner`).
- [ ] `npm run test:workers` — skipped, no Workers/backend code touched.
- [ ] `npm run build:mcp` — skipped, no MCP package changes.
- [ ] `npm run test:mcp-pack` — skipped, no MCP package changes.
- [ ] `npm run ui:openapi:check` — skipped, no API/OpenAPI schema changes.
- [x] `npm run ui:lint` — 0 errors (pre-existing `react-refresh/only-export-components` warnings only, same pattern already present elsewhere).
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate` — 5 pre-existing high-severity advisories in the `eslint`/`minimatch`/`brace-expansion` dev-dependency chain, unrelated to this change (zero new dependencies added).
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — new tests in both existing test files assert the actual icon rendered (`.lucide-wifi-off` vs `.lucide-triangle-alert`) for network-kind vs. other failures, plus a retry-click test for the overview page.

If any required check was skipped, explain why:

- `test:workers`/`test:mcp-pack`/`ui:openapi:check`/`actionlint` all skipped as not applicable — this diff touches exactly four files under `apps/loopover-ui/src/`, nothing else.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no such changes.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no such changes.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — the screenshots below use a network-mocked local dev server (standard test technique, only the network layer is faked) purely to demonstrate the real, unmocked `ErrorState`/`StateBoundary` rendering logic; the deployed app always uses live API data, untouched by this diff.
- [x] Visible UI changes include a `UI Evidence` section below with screenshots. — see below.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — N/A.

## UI Evidence

Real before/after captures — genuinely different, not identical, since this fix changes what actually renders for a network-kind failure. Captured by running the real app locally and reverting/reapplying this exact diff between shots (before = commit-reverted working tree, after = this PR's committed code), with only `/v1/auth/session` and the relevant data endpoint's network layer faked (a genuine connection failure via Playwright's `route.abort()`, not a mocked HTTP response) so `apiFetch` classifies it the same way a real outage would. `apps/loopover-ui` is dark-mode-only (theme toggle removed), so Dark is the only theme.

**App overview (`/app`)**

| Viewport | Before | After |
| --- | --- | --- |
| Desktop · Dark | <a href="https://raw.githubusercontent.com/hurryup52/loopover/screenshots/desktop-overview-errorkind-before.png"><img src="https://raw.githubusercontent.com/hurryup52/loopover/screenshots/desktop-overview-errorkind-before.png" alt="Desktop before" width="260"></a> | <a href="https://raw.githubusercontent.com/hurryup52/loopover/screenshots/desktop-overview-errorkind.png"><img src="https://raw.githubusercontent.com/hurryup52/loopover/screenshots/desktop-overview-errorkind.png" alt="Desktop after" width="260"></a> |
| Tablet · Dark | <a href="https://raw.githubusercontent.com/hurryup52/loopover/screenshots/tablet-overview-errorkind-before.png"><img src="https://raw.githubusercontent.com/hurryup52/loopover/screenshots/tablet-overview-errorkind-before.png" alt="Tablet before" width="260"></a> | <a href="https://raw.githubusercontent.com/hurryup52/loopover/screenshots/tablet-overview-errorkind.png"><img src="https://raw.githubusercontent.com/hurryup52/loopover/screenshots/tablet-overview-errorkind.png" alt="Tablet after" width="260"></a> |
| Mobile · Dark | <a href="https://raw.githubusercontent.com/hurryup52/loopover/screenshots/mobile-overview-errorkind-before.png"><img src="https://raw.githubusercontent.com/hurryup52/loopover/screenshots/mobile-overview-errorkind-before.png" alt="Mobile before" width="260"></a> | <a href="https://raw.githubusercontent.com/hurryup52/loopover/screenshots/mobile-overview-errorkind.png"><img src="https://raw.githubusercontent.com/hurryup52/loopover/screenshots/mobile-overview-errorkind.png" alt="Mobile after" width="260"></a> |

**Dead-letter queue (`/app/operator`)**

| Viewport | Before | After |
| --- | --- | --- |
| Desktop · Dark | <a href="https://raw.githubusercontent.com/hurryup52/loopover/screenshots/desktop-operator-errorkind-before.png"><img src="https://raw.githubusercontent.com/hurryup52/loopover/screenshots/desktop-operator-errorkind-before.png" alt="Desktop before" width="260"></a> | <a href="https://raw.githubusercontent.com/hurryup52/loopover/screenshots/desktop-operator-errorkind.png"><img src="https://raw.githubusercontent.com/hurryup52/loopover/screenshots/desktop-operator-errorkind.png" alt="Desktop after" width="260"></a> |
| Tablet · Dark | <a href="https://raw.githubusercontent.com/hurryup52/loopover/screenshots/tablet-operator-errorkind-before.png"><img src="https://raw.githubusercontent.com/hurryup52/loopover/screenshots/tablet-operator-errorkind-before.png" alt="Tablet before" width="260"></a> | <a href="https://raw.githubusercontent.com/hurryup52/loopover/screenshots/tablet-operator-errorkind.png"><img src="https://raw.githubusercontent.com/hurryup52/loopover/screenshots/tablet-operator-errorkind.png" alt="Tablet after" width="260"></a> |
| Mobile · Dark | <a href="https://raw.githubusercontent.com/hurryup52/loopover/screenshots/mobile-operator-errorkind-before.png"><img src="https://raw.githubusercontent.com/hurryup52/loopover/screenshots/mobile-operator-errorkind-before.png" alt="Mobile before" width="260"></a> | <a href="https://raw.githubusercontent.com/hurryup52/loopover/screenshots/mobile-operator-errorkind.png"><img src="https://raw.githubusercontent.com/hurryup52/loopover/screenshots/mobile-operator-errorkind.png" alt="Mobile after" width="260"></a> |

The before shots also show the app overview's missing retry button, fixed by the added `onRetry` prop (visible as "Try again" in the after shot).

## Notes

- Closes #8668.
- All four Deliverables are covered: both call sites now pass `errorKind` (verified via the `.lucide-wifi-off` vs `.lucide-triangle-alert` class assertions in the new tests, since both surfaces keep their own fixed title/description text — only the icon is `errorKind`-driven per `ErrorState`'s own `??` override logic), the overview page now has a working retry action, and new tests cover both surfaces directly at the previously-broken call sites.
