### PR TITLE
Add soft quota-warning notifications before #7647's hard block

### DIFF
--- a/packages/loopover-engine/src/index.ts
+++ b/packages/loopover-engine/src/index.ts
@@ -679,8 +679,13 @@ export {
   type LoopRunFacts,
 } from "./loop-consumption.js";
 export {
+  DEFAULT_QUOTA_SOFT_WARNING_THRESHOLDS,
   evaluateTenantQuota,
+  evaluateTenantQuotaSoftWarnings,
   type QuotaDimension,
+  type QuotaSoftWarning,
+  type QuotaSoftWarningSeverity,
+  type QuotaSoftWarningThresholds,
   type TenantQuota,
   type TenantQuotaDecision,
   type TenantUsage,

--- a/packages/loopover-engine/src/tenant-quota.ts
+++ b/packages/loopover-engine/src/tenant-quota.ts
@@ -99,3 +99,62 @@ export function evaluateTenantQuota(usage: TenantUsage, quota: TenantQuota): Ten
     remaining,
   };
 }
+
+/** Fractions of a dimension's cap remaining below which a soft warning fires (#7662). */
+export type QuotaSoftWarningThresholds = {
+  /** Warn once remaining drops to or below this fraction of the cap (default 0.2 = 80% consumed). */
+  lowRemainingFraction: number;
+  /** Escalate once remaining drops to or below this fraction (default 0.1 = 90% consumed). */
+  criticalRemainingFraction: number;
+};
+
+export const DEFAULT_QUOTA_SOFT_WARNING_THRESHOLDS: QuotaSoftWarningThresholds = {
+  lowRemainingFraction: 0.2,
+  criticalRemainingFraction: 0.1,
+};
+
+export type QuotaSoftWarningSeverity = "low" | "critical";
+
+export type QuotaSoftWarning = {
+  dimension: QuotaDimension;
+  severity: QuotaSoftWarningSeverity;
+  remaining: number;
+  cap: number;
+};
+
+function remainingFraction(remaining: number, cap: number): number | null {
+  const capNorm = finiteNonNegativeInt(cap);
+  if (capNorm === 0) return null;
+  return finiteNonNegativeInt(remaining) / capNorm;
+}
+
+/**
+ * Surface soft quota warnings for dimensions that are still within quota but running low (#7662). Pure: reads
+ * only the already-computed {@link TenantQuotaDecision} and the tenant's allocation. Hard-blocked tenants get
+ * no warnings here — the admission gate handles the block; this is the "before" path only.
+ */
+export function evaluateTenantQuotaSoftWarnings(
+  decision: TenantQuotaDecision,
+  quota: TenantQuota,
+  thresholds: QuotaSoftWarningThresholds = DEFAULT_QUOTA_SOFT_WARNING_THRESHOLDS,
+): QuotaSoftWarning[] {
+  if (!decision.allowed) return [];
+
+  const dimensions: Array<{ dimension: QuotaDimension; remaining: number; cap: number }> = [
+    { dimension: "compute", remaining: decision.remaining.computeUnits, cap: quota.computeUnits },
+    { dimension: "time", remaining: decision.remaining.wallClockMs, cap: quota.wallClockMs },
+    { dimension: "concurrency", remaining: decision.remaining.concurrentLoops, cap: quota.maxConcurrentLoops },
+  ];
+
+  const warnings: QuotaSoftWarning[] = [];
+  for (const { dimension, remaining, cap } of dimensions) {
+    const fraction = remainingFraction(remaining, cap);
+    if (fraction === null) continue;
+    if (fraction <= thresholds.criticalRemainingFraction) {
+      warnings.push({ dimension, severity: "critical", remaining: finiteNonNegativeInt(remaining), cap: finiteNonNegativeInt(cap) });
+    } else if (fraction <= thresholds.lowRemainingFraction) {
+      warnings.push({ dimension, severity: "low", remaining: finiteNonNegativeInt(remaining), cap: finiteNonNegativeInt(cap) });
+    }
+  }
+  return warnings;
+}

--- a/src/notifications/quota-events.ts
+++ b/src/notifications/quota-events.ts
@@ -1,0 +1,90 @@
+// Rent-a-Loop quota soft-warning notification bridge (#7662). Pure builders for DetectedNotificationEvent rows
+// that run-agent admission feeds into evaluateNotificationEvent → notify-deliver — the same path job-dispatch.ts
+// uses for webhook-detected kinds. No parallel delivery store.
+
+import type { QuotaDimension, QuotaSoftWarning, QuotaSoftWarningSeverity } from "@loopover/engine";
+import type { DetectedNotificationEvent } from "../types";
+import { nowIso } from "../utils/json";
+
+function normalizeLogin(login: string): string {
+  return login.trim().toLowerCase();
+}
+
+function dimensionLabel(dimension: QuotaDimension): string {
+  switch (dimension) {
+    case "compute":
+      return "compute units";
+    case "time":
+      return "wall-clock time";
+    case "concurrency":
+      return "concurrent loops";
+  }
+}
+
+/** Public-safe copy for a quota soft-warning badge notification (#7662). */
+export function buildTenantQuotaWarningNotification(input: {
+  warning: QuotaSoftWarning;
+}): { title: string; body: string } {
+  const label = dimensionLabel(input.warning.dimension);
+  const urgency = input.warning.severity === "critical" ? "critically low" : "running low";
+  return {
+    title: `Quota ${urgency}: ${label}`,
+    body: `You have ${input.warning.remaining} of ${input.warning.cap} ${label} remaining in your current allocation. Increase your allocation or pace your loops before a hard block stops new runs.`,
+  };
+}
+
+/**
+ * Build a quota soft-warning event. Not repo-scoped — `repoFullName` is a stable synthetic scope
+ * (`rent-a-loop/quota`); `pullNumber` is 0.
+ */
+export function buildTenantQuotaWarningEvent(input: {
+  recipientLogin: string;
+  warning: QuotaSoftWarning;
+  detectedAt?: string;
+}): DetectedNotificationEvent {
+  const recipientLogin = normalizeLogin(input.recipientLogin);
+  const detectedAt = input.detectedAt ?? nowIso();
+  const { warning } = input;
+  return {
+    eventType: "tenant_quota_warning",
+    recipientLogin,
+    repoFullName: "rent-a-loop/quota",
+    pullNumber: 0,
+    dedupKey: `tenant_quota_warning:${recipientLogin}:${warning.dimension}:${warning.severity}:${warning.remaining}:${warning.cap}`,
+    deeplink: "https://github.com/JSONbored/loopover",
+    actorLogin: recipientLogin,
+    detectedAt,
+  };
+}
+
+export function quotaWarningEventsForActor(
+  actorLogin: string,
+  warnings: readonly QuotaSoftWarning[],
+  detectedAt?: string,
+): DetectedNotificationEvent[] {
+  return warnings.map((warning) =>
+    buildTenantQuotaWarningEvent({
+      recipientLogin: actorLogin,
+      warning,
+      ...(detectedAt === undefined ? {} : { detectedAt }),
+    }),
+  );
+}
+
+/** Decode the warning embedded in a tenant_quota_warning dedupKey; null when malformed. */
+export function parseTenantQuotaWarningDedupKey(dedupKey: string): QuotaSoftWarning | null {
+  const parts = dedupKey.split(":");
+  if (parts.length !== 6 || parts[0] !== "tenant_quota_warning") return null;
+  const dimension = parts[2];
+  const severity = parts[3];
+  const remaining = Number(parts[4]);
+  const cap = Number(parts[5]);
+  if (dimension !== "compute" && dimension !== "time" && dimension !== "concurrency") return null;
+  if (!isQuotaSoftWarningSeverity(severity)) return null;
+  if (!Number.isFinite(remaining) || !Number.isFinite(cap)) return null;
+  return { dimension, severity, remaining, cap };
+}
+
+export function isQuotaSoftWarningSeverity(value: unknown): value is QuotaSoftWarningSeverity {
+  return value === "low" || value === "critical";
+}

--- a/src/notifications/service.ts
+++ b/src/notifications/service.ts
@@ -10,6 +10,7 @@ import {
 } from "../db/repositories";
 import { isGrabbableHighMultiplierIssue } from "../signals/engine";
 import { canLoginAccessRepo } from "../services/control-panel-roles";
+import { buildTenantQuotaWarningNotification, parseTenantQuotaWarningDedupKey } from "./quota-events";
 import type {
   DetectedNotificationEvent,
   IssueRecord,
@@ -106,6 +107,21 @@ export function buildAmsPrOutcomeNotification(event: DetectedNotificationEvent):
   };
 }
 
+// #7662: soft quota headroom before #7647's hard block — public-safe; no reward/trust figures.
+export function buildTenantQuotaWarningNotificationFromEvent(event: DetectedNotificationEvent): { title: string; body: string } {
+  const warning = parseTenantQuotaWarningDedupKey(event.dedupKey);
+  if (!warning) {
+    return {
+      title: sanitizePublicComment("Quota running low"),
+      body: sanitizePublicComment(
+        "Your current allocation is running low. Increase your allocation or pace your loops before a hard block stops new runs.",
+      ),
+    };
+  }
+  const copy = buildTenantQuotaWarningNotification({ warning });
+  return { title: sanitizePublicComment(copy.title), body: sanitizePublicComment(copy.body) };
+}
+
 // Maps a detected event to its public-safe notification content.
 export function buildNotificationContent(event: DetectedNotificationEvent): { title: string; body: string } {
   switch (event.eventType) {
@@ -121,6 +137,8 @@ export function buildNotificationContent(event: DetectedNotificationEvent): { ti
       return buildAmsGovernorPausedNotification(event);
     case "ams_pr_outcome":
       return buildAmsPrOutcomeNotification(event);
+    case "tenant_quota_warning":
+      return buildTenantQuotaWarningNotificationFromEvent(event);
     case "pull_request_changes_requested":
       return buildChangesRequestedNotification(event);
   }

--- a/src/queue/job-dispatch.ts
+++ b/src/queue/job-dispatch.ts
@@ -24,6 +24,7 @@ import { isRecapEnabled, resolveMaintainerRecapManifestOverride, runMaintainerRe
 import { performRepoDocRefresh } from "../github/repo-doc-refresh-runner";
 import { executeAgentRun } from "../services/agent-orchestrator";
 import { deliverNotification, evaluateNotificationEvent } from "../notifications/service";
+import { admitRunAgentJob } from "./run-agent-quota-admission";
 import { isOpsEnabled, resolveOpsManifestOverride, runOpsAlerts } from "../review/ops-wire";
 import { isSweepWatchdogEnabled, resolveSweepWatchdogManifestOverride, runSweepLivenessWatchdog } from "../review/sweep-watchdog";
 import { isLoopEscalationSweepEnabled, resolveLoopEscalationManifestOverride, runLoopEscalationSweep } from "../review/loop-escalation-wire";
@@ -76,6 +77,22 @@ import {
 // fan-out, same shape as GLOBAL_OPEN_ITEM_LIVE_CHECK_CONCURRENCY in processors.ts. Moved here (rather than
 // imported back) since processJob was its only caller.
 const NOTIFY_EVALUATE_EVENT_CONCURRENCY = 5;
+
+async function enqueueNotificationDeliveries(env: Env, events: DetectedNotificationEvent[]): Promise<void> {
+  if (events.length === 0) return;
+  const deliveries = (
+    await mapWithConcurrency(events, NOTIFY_EVALUATE_EVENT_CONCURRENCY, (event) => evaluateNotificationEvent(env, event))
+  ).flat();
+  await Promise.all(
+    deliveries.map((delivery) =>
+      env.JOBS.send({
+        type: "notify-deliver",
+        requestedBy: "notify-evaluate",
+        deliveryId: delivery.id,
+      }),
+    ),
+  );
+}
 
 export async function processJob(env: Env, message: JobMessage): Promise<void> {
   switch (message.type) {
@@ -286,9 +303,15 @@ export async function processJob(env: Env, message: JobMessage): Promise<void> {
         message.prCreatedAt,
       );
       return;
-    case "run-agent":
+    case "run-agent": {
+      // #7647 hard-block + #7662 soft-warning admission — warnings fire through the same notify-evaluate path
+      // as every other DetectedNotificationEvent before executeAgentRun is reached.
+      const admission = await admitRunAgentJob(env, message.runId);
+      await enqueueNotificationDeliveries(env, admission.warningEvents);
+      if (!admission.admitted) return;
       await executeAgentRun(env, message.runId);
       return;
+    }
     case "notify-evaluate": {
       // Legacy payload compat: a row enqueued before the batched-events deploy (#selfhost-maintenance-self-pin)
       // still carries the OLD singular `event` field on disk, not `events` -- a rolling deploy can process such
@@ -296,18 +319,7 @@ export async function processJob(env: Env, message: JobMessage): Promise<void> {
       // already matches the current type (which only the type checker, not the durable queue, enforces).
       const legacyMessage = message as unknown as { events?: DetectedNotificationEvent[]; event?: DetectedNotificationEvent };
       const events = Array.isArray(legacyMessage.events) ? legacyMessage.events : legacyMessage.event ? [legacyMessage.event] : [];
-      const deliveries = (
-        await mapWithConcurrency(events, NOTIFY_EVALUATE_EVENT_CONCURRENCY, (event) => evaluateNotificationEvent(env, event))
-      ).flat();
-      await Promise.all(
-        deliveries.map((delivery) =>
-          env.JOBS.send({
-            type: "notify-deliver",
-            requestedBy: "notify-evaluate",
-            deliveryId: delivery.id,
-          }),
-        ),
-      );
+      await enqueueNotificationDeliveries(env, events);
       return;
     }
     case "notify-deliver":

--- a/src/queue/run-agent-quota-admission.ts
+++ b/src/queue/run-agent-quota-admission.ts
@@ -1,0 +1,99 @@
+// run-agent tenant-quota admission (#7647 hard block + #7662 soft-warning notifications). Evaluated at the
+// job-dispatch `run-agent` arm — the single admission-check point for both issues. When a tenant still has
+// headroom but is running low, soft warnings are returned for delivery BEFORE executeAgentRun; when blocked,
+// the run is failed in place and never executed.
+
+import {
+  evaluateTenantQuota,
+  evaluateTenantQuotaSoftWarnings,
+  type TenantQuota,
+  type TenantUsage,
+} from "@loopover/engine";
+import { getAgentRun, updateAgentRun } from "../db/repositories";
+import { quotaWarningEventsForActor } from "../notifications/quota-events";
+import type { AgentRunRecord, DetectedNotificationEvent } from "../types";
+
+export type RunAgentTenantQuotaContext = {
+  usage: TenantUsage;
+  quota: TenantQuota;
+};
+
+export type RunAgentQuotaAdmissionDecision = {
+  admitted: boolean;
+  reason: string | null;
+  warningEvents: DetectedNotificationEvent[];
+};
+
+export type RunAgentQuotaAdmissionDeps = {
+  loadQuotaContext: (env: Env, actorLogin: string) => Promise<RunAgentTenantQuotaContext | null>;
+  getRun: (env: Env, runId: string) => Promise<AgentRunRecord | null>;
+  failRun: (env: Env, runId: string, reason: string) => Promise<void>;
+  detectedAt?: () => string;
+};
+
+/** Pure admission decision given already-resolved usage + quota (#7647 / #7662). */
+export function decideRunAgentQuotaAdmission(input: {
+  actorLogin: string;
+  usage: TenantUsage;
+  quota: TenantQuota;
+  detectedAt?: string;
+}): RunAgentQuotaAdmissionDecision {
+  const decision = evaluateTenantQuota(input.usage, input.quota);
+  const warnings = evaluateTenantQuotaSoftWarnings(decision, input.quota);
+  const warningEvents = quotaWarningEventsForActor(input.actorLogin, warnings, input.detectedAt);
+  if (!decision.allowed) {
+    return { admitted: false, reason: decision.reason, warningEvents: [] };
+  }
+  return { admitted: true, reason: null, warningEvents };
+}
+
+/** Fail-open when no rental-ledger context exists yet (#4792 persistence is a separate concern). */
+export async function loadRunAgentTenantQuotaContext(
+  _env: Env,
+  _actorLogin: string,
+): Promise<RunAgentTenantQuotaContext | null> {
+  return null;
+}
+
+const defaultDeps: RunAgentQuotaAdmissionDeps = {
+  loadQuotaContext: loadRunAgentTenantQuotaContext,
+  getRun: getAgentRun,
+  failRun: async (env, runId, reason) => {
+    await updateAgentRun(env, runId, { status: "failed", errorSummary: reason });
+  },
+};
+
+/**
+ * Admission gate for `run-agent` jobs (#7647 / #7662). Returns soft-warning events to deliver before execution
+ * and whether the run may proceed. Missing quota context admits without checks until the rental ledger lands.
+ */
+export async function admitRunAgentJob(
+  env: Env,
+  runId: string,
+  deps: RunAgentQuotaAdmissionDeps = defaultDeps,
+): Promise<RunAgentQuotaAdmissionDecision> {
+  const run = await deps.getRun(env, runId);
+  if (!run) {
+    return { admitted: true, reason: null, warningEvents: [] };
+  }
+
+  const context = await deps.loadQuotaContext(env, run.actorLogin);
+  if (context === null) {
+    return { admitted: true, reason: null, warningEvents: [] };
+  }
+
+  const detectedAt = deps.detectedAt?.();
+  const decision = decideRunAgentQuotaAdmission({
+    actorLogin: run.actorLogin,
+    usage: context.usage,
+    quota: context.quota,
+    ...(detectedAt === undefined ? {} : { detectedAt }),
+  });
+
+  if (!decision.admitted) {
+    if (decision.reason) await deps.failRun(env, runId, decision.reason);
+    return decision;
+  }
+
+  return decision;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -2473,7 +2473,9 @@ export type NotificationEventType =
   | "ams_attempt_started"
   | "ams_attempt_failed"
   | "ams_governor_paused"
-  | "ams_pr_outcome";
+  | "ams_pr_outcome"
+  // Rent-a-Loop quota headroom (#7662): soft warning before #7647's hard block at run-agent admission.
+  | "tenant_quota_warning";
 
 /** #699 path B: a miner's standing watch on a repo for new grabbable issues. `labels` ([]=any) filters
  *  which issues notify. The `pullNumber` field of the resulting notification event carries the ISSUE number. */

--- a/test/unit/job-dispatch.test.ts
+++ b/test/unit/job-dispatch.test.ts
@@ -4,6 +4,8 @@ import { processJob } from "../../src/queue/job-dispatch";
 import { createTestEnv } from "../helpers/d1";
 import { upsertInstallation, upsertRepositoryFromGitHub } from "../../src/db/repositories";
 import type { JobMessage } from "../../src/types";
+import * as agentOrchestrator from "../../src/services/agent-orchestrator";
+import * as runAgentQuotaAdmission from "../../src/queue/run-agent-quota-admission";
 
 describe("processJob unknown job type (#5836)", () => {
   afterEach(() => {
@@ -102,5 +104,71 @@ describe("processJob backfill-registered-repos fan-out isolation (#8355)", () =>
     await expect(processJob(env, { type: "backfill-registered-repos", requestedBy: "schedule" } as JobMessage)).resolves.toBeUndefined();
     expect(sentTo.sort()).toEqual(["owner2/ok-1", "owner2/ok-2"]);
     expect(errorLogs.some((line) => line.includes("backfill_registered_repos_fanout_send_failed"))).toBe(false);
+  });
+});
+
+describe("processJob run-agent quota admission (#7647 / #7662)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("enqueues quota-warning deliveries before executeAgentRun and skips execution on hard block", async () => {
+    const sent: Array<{ type: string; deliveryId?: string; requestedBy?: string }> = [];
+    const env = createTestEnv({
+      JOBS: {
+        async send(message: { type: string; deliveryId?: string; requestedBy?: string }) {
+          sent.push(message);
+        },
+      } as unknown as Queue,
+    });
+    const executeAgentRun = vi.spyOn(agentOrchestrator, "executeAgentRun").mockResolvedValue({
+      run: {
+        id: "run-quota-dispatch",
+        objective: "plan",
+        actorLogin: "miner",
+        surface: "api",
+        mode: "copilot",
+        status: "completed",
+        dataQualityStatus: "complete",
+        payload: {},
+      },
+      actions: [],
+      contextSnapshots: [],
+      summary: "done",
+    });
+    vi.spyOn(runAgentQuotaAdmission, "admitRunAgentJob").mockResolvedValueOnce({
+      admitted: true,
+      reason: null,
+      warningEvents: [
+        {
+          eventType: "tenant_quota_warning",
+          recipientLogin: "miner",
+          repoFullName: "rent-a-loop/quota",
+          pullNumber: 0,
+          dedupKey: "tenant_quota_warning:miner:compute:low:15:100",
+          deeplink: "https://github.com/JSONbored/loopover",
+          actorLogin: "miner",
+          detectedAt: "2026-07-26T00:00:00.000Z",
+        },
+      ],
+    });
+
+    await processJob(env, { type: "run-agent", requestedBy: "api", runId: "run-quota-dispatch" } as JobMessage);
+
+    expect(sent.some((message) => message.type === "notify-deliver")).toBe(true);
+    expect(executeAgentRun).toHaveBeenCalledWith(env, "run-quota-dispatch");
+  });
+
+  it("does not call executeAgentRun when admission hard-blocks", async () => {
+    const env = createTestEnv();
+    const executeAgentRun = vi.spyOn(agentOrchestrator, "executeAgentRun");
+    vi.spyOn(runAgentQuotaAdmission, "admitRunAgentJob").mockResolvedValueOnce({
+      admitted: false,
+      reason: "Quota exceeded",
+      warningEvents: [],
+    });
+
+    await processJob(env, { type: "run-agent", requestedBy: "api", runId: "blocked-run" } as JobMessage);
+    expect(executeAgentRun).not.toHaveBeenCalled();
   });
 });

--- a/test/unit/notifications-service.test.ts
+++ b/test/unit/notifications-service.test.ts
@@ -198,6 +198,53 @@ describe("AMS notification event kinds (#7657)", () => {
   });
 });
 
+describe("tenant quota soft-warning notifications (#7662)", () => {
+  it("builds public-safe quota-warning copy and routes by event type", () => {
+    const warning = buildNotificationContent(
+      event({
+        eventType: "tenant_quota_warning",
+        repoFullName: "rent-a-loop/quota",
+        pullNumber: 0,
+        dedupKey: "tenant_quota_warning:miner:compute:critical:10:100",
+      }),
+    );
+    expect(warning.title.toLowerCase()).toContain("critically low");
+    expect(warning.body).toContain("10 of 100");
+    expect(JSON.stringify(warning)).not.toMatch(/reward|payout|trust score|wallet|\$/i);
+
+    const fallback = buildNotificationContent(
+      event({
+        eventType: "tenant_quota_warning",
+        repoFullName: "rent-a-loop/quota",
+        pullNumber: 0,
+        dedupKey: "tenant_quota_warning:malformed",
+      }),
+    );
+    expect(fallback.title.toLowerCase()).toContain("quota");
+  });
+
+  it("evaluates quota-warning events through the notify-deliver handoff", async () => {
+    const sent: Array<{ type: string; deliveryId?: string; requestedBy?: string }> = [];
+    const env = createTestEnv({
+      JOBS: {
+        async send(message: { type: string; deliveryId?: string; requestedBy?: string }) {
+          sent.push(message);
+        },
+      } as unknown as Queue,
+    });
+    const deliveries = await evaluateAndEnqueueNotificationDeliveries(env, [
+      event({
+        eventType: "tenant_quota_warning",
+        repoFullName: "rent-a-loop/quota",
+        pullNumber: 0,
+        dedupKey: "tenant_quota_warning:miner:time:low:5000:60000",
+      }),
+    ]);
+    expect(deliveries).toHaveLength(1);
+    expect(sent).toEqual([{ type: "notify-deliver", requestedBy: "notify-evaluate", deliveryId: deliveries[0]!.id }]);
+  });
+});
+
 describe("evaluateNotificationEvent", () => {
   it("creates exactly one badge delivery and is idempotent on a duplicate event", async () => {
     const env = createTestEnv();

--- a/test/unit/quota-events.test.ts
+++ b/test/unit/quota-events.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildTenantQuotaWarningEvent,
+  buildTenantQuotaWarningNotification,
+  parseTenantQuotaWarningDedupKey,
+  quotaWarningEventsForActor,
+} from "../../src/notifications/quota-events";
+
+describe("quota notification events (#7662)", () => {
+  it("builds public-safe copy for each dimension label", () => {
+    expect(buildTenantQuotaWarningNotification({ warning: { dimension: "compute", severity: "low", remaining: 5, cap: 100 } }).body).toContain(
+      "compute units",
+    );
+    expect(buildTenantQuotaWarningNotification({ warning: { dimension: "time", severity: "critical", remaining: 1, cap: 10 } }).title).toContain(
+      "critically low",
+    );
+    expect(buildTenantQuotaWarningNotification({ warning: { dimension: "concurrency", severity: "low", remaining: 1, cap: 3 } }).body).toContain(
+      "concurrent loops",
+    );
+  });
+
+  it("embeds warning figures in the dedupKey and round-trips through the parser", () => {
+    const event = buildTenantQuotaWarningEvent({
+      recipientLogin: "Miner",
+      warning: { dimension: "compute", severity: "low", remaining: 15, cap: 100 },
+      detectedAt: "2026-07-26T00:00:00.000Z",
+    });
+    expect(event.recipientLogin).toBe("miner");
+    expect(parseTenantQuotaWarningDedupKey(event.dedupKey)).toEqual({
+      dimension: "compute",
+      severity: "low",
+      remaining: 15,
+      cap: 100,
+    });
+    expect(parseTenantQuotaWarningDedupKey("tenant_quota_warning:bad")).toBeNull();
+    expect(parseTenantQuotaWarningDedupKey("tenant_quota_warning:miner:bad:low:1:2")).toBeNull();
+  });
+
+  it("fans out one event per warning", () => {
+    const events = quotaWarningEventsForActor("miner", [
+      { dimension: "compute", severity: "low", remaining: 15, cap: 100 },
+      { dimension: "time", severity: "critical", remaining: 1000, cap: 60_000 },
+    ]);
+    expect(events).toHaveLength(2);
+    expect(events.every((event) => event.eventType === "tenant_quota_warning")).toBe(true);
+  });
+});

--- a/test/unit/run-agent-quota-admission.test.ts
+++ b/test/unit/run-agent-quota-admission.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createAgentRun, getAgentRun } from "../../src/db/repositories";
+import {
+  admitRunAgentJob,
+  decideRunAgentQuotaAdmission,
+  type RunAgentQuotaAdmissionDeps,
+} from "../../src/queue/run-agent-quota-admission";
+import { createTestEnv } from "../helpers/d1";
+import type { AgentRunRecord } from "../../src/types";
+
+const QUOTA = { computeUnits: 100, wallClockMs: 60_000, maxConcurrentLoops: 3 };
+
+function runRecord(overrides: Partial<AgentRunRecord> = {}): AgentRunRecord {
+  return {
+    id: "run-quota-1",
+    objective: "plan",
+    actorLogin: "miner",
+    surface: "api",
+    mode: "copilot",
+    status: "queued",
+    dataQualityStatus: "unknown",
+    payload: {},
+    ...overrides,
+  };
+}
+
+describe("decideRunAgentQuotaAdmission (#7647 / #7662)", () => {
+  it("admits with soft-warning events when still within quota but low on headroom", () => {
+    const decision = decideRunAgentQuotaAdmission({
+      actorLogin: "miner",
+      usage: { computeUnitsUsed: 85, wallClockMsUsed: 0, activeLoops: 0 },
+      quota: QUOTA,
+      detectedAt: "2026-07-26T00:00:00.000Z",
+    });
+    expect(decision.admitted).toBe(true);
+    expect(decision.reason).toBeNull();
+    expect(decision.warningEvents).toHaveLength(1);
+    expect(decision.warningEvents[0]).toMatchObject({
+      eventType: "tenant_quota_warning",
+      recipientLogin: "miner",
+      dedupKey: "tenant_quota_warning:miner:compute:low:15:100",
+    });
+  });
+
+  it("hard-blocks without soft warnings once quota is exhausted", () => {
+    const decision = decideRunAgentQuotaAdmission({
+      actorLogin: "miner",
+      usage: { computeUnitsUsed: 100, wallClockMsUsed: 0, activeLoops: 0 },
+      quota: QUOTA,
+    });
+    expect(decision.admitted).toBe(false);
+    expect(decision.reason).toContain("compute units");
+    expect(decision.warningEvents).toEqual([]);
+  });
+
+  it("admits cleanly when headroom is above the soft-warning thresholds", () => {
+    const decision = decideRunAgentQuotaAdmission({
+      actorLogin: "miner",
+      usage: { computeUnitsUsed: 50, wallClockMsUsed: 10_000, activeLoops: 1 },
+      quota: QUOTA,
+    });
+    expect(decision).toEqual({ admitted: true, reason: null, warningEvents: [] });
+  });
+});
+
+describe("admitRunAgentJob", () => {
+  it("fail-opens when the run record is missing", async () => {
+    const env = createTestEnv();
+    const decision = await admitRunAgentJob(env, "missing-run");
+    expect(decision).toEqual({ admitted: true, reason: null, warningEvents: [] });
+  });
+
+  it("fail-opens when no rental-ledger context is available", async () => {
+    const env = createTestEnv();
+    await createAgentRun(env, runRecord());
+    const decision = await admitRunAgentJob(env, "run-quota-1");
+    expect(decision).toEqual({ admitted: true, reason: null, warningEvents: [] });
+  });
+
+  it("delivers warnings then admits when quota context is still within limits", async () => {
+    const env = createTestEnv();
+    await createAgentRun(env, runRecord());
+    const deps: RunAgentQuotaAdmissionDeps = {
+      loadQuotaContext: async () => ({
+        usage: { computeUnitsUsed: 90, wallClockMsUsed: 0, activeLoops: 0 },
+        quota: QUOTA,
+      }),
+      getRun: getAgentRun,
+      failRun: vi.fn(),
+      detectedAt: () => "2026-07-26T00:00:00.000Z",
+    };
+
+    const decision = await admitRunAgentJob(env, "run-quota-1", deps);
+    expect(decision.admitted).toBe(true);
+    expect(decision.warningEvents[0]?.eventType).toBe("tenant_quota_warning");
+    expect(deps.failRun).not.toHaveBeenCalled();
+  });
+
+  it("fails the run and skips warnings when quota is exhausted", async () => {
+    const env = createTestEnv();
+    await createAgentRun(env, runRecord());
+    const failRun = vi.fn();
+    const deps: RunAgentQuotaAdmissionDeps = {
+      loadQuotaContext: async () => ({
+        usage: { computeUnitsUsed: 100, wallClockMsUsed: 0, activeLoops: 0 },
+        quota: QUOTA,
+      }),
+      getRun: getAgentRun,
+      failRun,
+    };
+
+    const decision = await admitRunAgentJob(env, "run-quota-1", deps);
+    expect(decision.admitted).toBe(false);
+    expect(decision.warningEvents).toEqual([]);
+    expect(failRun).toHaveBeenCalledOnce();
+    expect((await getAgentRun(env, "run-quota-1"))?.status).toBe("queued");
+  });
+});

--- a/test/unit/tenant-quota.test.ts
+++ b/test/unit/tenant-quota.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { evaluateTenantQuota } from "../../packages/loopover-engine/src/tenant-quota";
+import {
+  evaluateTenantQuota,
+  evaluateTenantQuotaSoftWarnings,
+} from "../../packages/loopover-engine/src/tenant-quota";
 
 const QUOTA = { computeUnits: 100, wallClockMs: 60_000, maxConcurrentLoops: 3 };
 
@@ -70,5 +73,50 @@ describe("evaluateTenantQuota (#4796)", () => {
     expect(under.allowed).toBe(true);
     // Re-evaluating the over-quota tenant does not change the under-quota tenant's independent decision.
     expect(evaluateTenantQuota({ computeUnitsUsed: 5, wallClockMsUsed: 5_000, activeLoops: 1 }, QUOTA)).toEqual(under);
+  });
+});
+
+describe("evaluateTenantQuotaSoftWarnings (#7662)", () => {
+  it("returns no warnings when every dimension is above the low threshold", () => {
+    const decision = evaluateTenantQuota({ computeUnitsUsed: 70, wallClockMsUsed: 40_000, activeLoops: 1 }, QUOTA);
+    expect(evaluateTenantQuotaSoftWarnings(decision, QUOTA)).toEqual([]);
+  });
+
+  it("warns at the low threshold (20% remaining) but not just above it", () => {
+    const atThreshold = evaluateTenantQuota({ computeUnitsUsed: 80, wallClockMsUsed: 0, activeLoops: 0 }, QUOTA);
+    expect(evaluateTenantQuotaSoftWarnings(atThreshold, QUOTA)).toEqual([
+      { dimension: "compute", severity: "low", remaining: 20, cap: 100 },
+    ]);
+
+    const aboveThreshold = evaluateTenantQuota({ computeUnitsUsed: 79, wallClockMsUsed: 0, activeLoops: 0 }, QUOTA);
+    expect(evaluateTenantQuotaSoftWarnings(aboveThreshold, QUOTA)).toEqual([]);
+  });
+
+  it("escalates to critical at 10% remaining and prefers critical over low", () => {
+    const critical = evaluateTenantQuota({ computeUnitsUsed: 90, wallClockMsUsed: 0, activeLoops: 0 }, QUOTA);
+    expect(evaluateTenantQuotaSoftWarnings(critical, QUOTA)).toEqual([
+      { dimension: "compute", severity: "critical", remaining: 10, cap: 100 },
+    ]);
+  });
+
+  it("reports each exhausted-but-still-allowed dimension independently", () => {
+    const decision = evaluateTenantQuota({ computeUnitsUsed: 85, wallClockMsUsed: 55_000, activeLoops: 2 }, QUOTA);
+    expect(evaluateTenantQuotaSoftWarnings(decision, QUOTA)).toEqual([
+      { dimension: "compute", severity: "low", remaining: 15, cap: 100 },
+      { dimension: "time", severity: "critical", remaining: 5000, cap: 60_000 },
+    ]);
+  });
+
+  it("returns no warnings once the tenant is hard-blocked", () => {
+    const blocked = evaluateTenantQuota({ computeUnitsUsed: 100, wallClockMsUsed: 0, activeLoops: 0 }, QUOTA);
+    expect(blocked.allowed).toBe(false);
+    expect(evaluateTenantQuotaSoftWarnings(blocked, QUOTA)).toEqual([]);
+  });
+
+  it("honors custom threshold fractions", () => {
+    const decision = evaluateTenantQuota({ computeUnitsUsed: 50, wallClockMsUsed: 0, activeLoops: 0 }, QUOTA);
+    expect(
+      evaluateTenantQuotaSoftWarnings(decision, QUOTA, { lowRemainingFraction: 0.6, criticalRemainingFraction: 0.4 }),
+    ).toEqual([{ dimension: "compute", severity: "low", remaining: 50, cap: 100 }]);
   });
 });


### PR DESCRIPTION
Fixes #7662
  ## Summary
  Adds **soft quota-warning notifications** for Rent-a-Loop tenants who still have headroom but are
  running low on compute, wall-clock time, or concurrency — **before** the hard admission block from
  #7647 stops new `run-agent` jobs.
  Warnings reuse the existing notification pipeline (`DetectedNotificationEvent` →
  `evaluateNotificationEvent` → `deliverNotification`); there is no parallel delivery store.
  ## What changed
  ### Engine (`@loopover/engine`)
  - `evaluateTenantQuotaSoftWarnings()` — pure helper that flags dimensions below configurable
  thresholds (default: **20%** remaining = `low`, **10%** = `critical`)
  - Exported types: `QuotaSoftWarning`, `QuotaSoftWarningSeverity`, `QuotaSoftWarningThresholds`
  ### Worker admission (`run-agent`)
  - New `run-agent-quota-admission.ts` — single admission gate for #7647 (hard block) and #7662 (soft
  warnings)
  - `job-dispatch.ts` `run-agent` arm: evaluate admission → **deliver warning events first** → only
  then call `executeAgentRun`
  - Fail-open when rental-ledger quota context is not available yet (same posture as #7647)
  ### Notifications
  - New `quota-events.ts` — builds `tenant_quota_warning` events with stable dedup keys and
  user-facing copy
  - `notifications/service.ts` — handles `tenant_quota_warning` in the evaluate path
  ### Tests
  - Unit coverage for soft-warning thresholds, admission decisions, notification copy/dedup, and
  `job-dispatch` wiring
  ## Behavior
  | State | Action |
  |-------|--------|
  | Within quota, headroom OK | Run proceeds, no notification |
  | Within quota, running low | Warning notification delivered, run **still admitted** |
  | Quota exhausted (#7647) | Run failed in place, **no** soft warning (hard block wins) |
  ## Testing
  - [x] `npm run check-node-version`
  - [x] `npm run actionlint`
  - [x] `npm run typecheck`
  - [x] `npm run test:changed`
  - [x] `npm run build --workspace @loopover/engine`
  ## Notes / follow-ups
  - Warning thresholds use `DEFAULT_QUOTA_SOFT_WARNING_THRESHOLDS` (20% / 10%); configurable later if
  product wants per-tenant tuning.
  - `loadRunAgentTenantQuotaContext` still returns `null` until rental-ledger persistence (#4792)
  lands — admission remains fail-open in that case.
  - Related: #7647 (hard block), #4792 (rental ledger), #4796 (quota evaluation)
  ---
