### PR TITLE
fix(orb): score enforcement closes as their own class, not quality mispredictions

### DIFF
--- a/src/orb/analytics.ts
+++ b/src/orb/analytics.ts
@@ -41,6 +41,10 @@ export interface Cell {
   verdict: string | null;
   outcome: string;
   reversal_flag: string;
+  /** #8825: `policy_action` marks a deliberate enforcement close (contributor cap, blacklist, copycat,
+   *  review-nag, screenshot-table, linked-issue hard rule) rather than a claim about code quality. Null on
+   *  rows exported before the bucket existed — treated as a normal quality verdict, matching prior behavior. */
+  gate_reasoncode_bucket?: string | null;
   n: number;
 }
 
@@ -68,6 +72,10 @@ export interface InstanceMetrics {
    *  Measured on the live fleet the two differ by ~6 points (93.6% vs 99.6%) — the gap is real errors, not
    *  rounding. null when the instance made no merge/close verdicts at all (holds only). */
   decisionAccuracy: number | null;
+  /** #8825: enforcement closes excluded from the precision/accuracy scoring above (contributor cap, blacklist,
+   *  copycat, review-nag, screenshot-table, linked-issue hard rule). Reported so the volume of policy actions
+   *  stays visible instead of vanishing from every metric. */
+  policyActions: number;
 }
 
 /** #2350: one self-hosted instance whose combined volume/precision/reversal-rate pattern looks like it is
@@ -133,10 +141,18 @@ export function percentile(sorted: number[], p: number): number | null {
 export function foldInstance(instanceId: string, cells: Cell[]): InstanceMetrics {
   let wouldMerge = 0, mergeConfirmed = 0, mergeFalse = 0;
   let wouldClose = 0, closeConfirmed = 0, closeFalse = 0;
-  let reversals = 0, decided = 0;
+  let reversals = 0, decided = 0, policyActions = 0;
   for (const c of cells) {
     decided += c.n;
     if (c.reversal_flag !== "none") reversals += c.n;
+    // #8825: a deliberate enforcement close is not a quality prediction and can be neither confirmed nor
+    // disconfirmed as one, so it is excluded from the precision/accuracy scoring entirely — counted on its own
+    // (policyActions) rather than silently inflating either side. It still contributes to `decided` and
+    // reversalRate, which measure activity and human overrides rather than gate correctness.
+    if (c.gate_reasoncode_bucket === "policy_action") {
+      policyActions += c.n;
+      continue;
+    }
     if (c.verdict === "merge") {
       wouldMerge += c.n;
       if (c.outcome === "merged" && c.reversal_flag !== "reverted") mergeConfirmed += c.n;
@@ -157,6 +173,7 @@ export function foldInstance(instanceId: string, cells: Cell[]): InstanceMetrics
     fnRate: wouldClose > 0 ? closeFalse / wouldClose : null,
     reversalRate: reversals / decided, // decided ≥ 1 (the instance has at least one cell)
     decisionAccuracy: verdicts > 0 ? (mergeConfirmed + closeConfirmed) / verdicts : null,
+    policyActions,
   };
 }
 
@@ -173,9 +190,9 @@ export async function computeFleetAnalytics(env: Env, opts: { windowDays?: numbe
   try {
     const matrix = await env.DB
       .prepare(
-        `SELECT instance_id, gate_verdict AS verdict, outcome, reversal_flag, COUNT(*) AS n
+        `SELECT instance_id, gate_verdict AS verdict, outcome, reversal_flag, gate_reasoncode_bucket, COUNT(*) AS n
          FROM orb_signals WHERE received_at >= ?
-         GROUP BY instance_id, gate_verdict, outcome, reversal_flag`,
+         GROUP BY instance_id, gate_verdict, outcome, reversal_flag, gate_reasoncode_bucket`,
       )
       .bind(cutoff)
       .all<Cell>();

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -3275,13 +3275,28 @@ async function runAgentMaintenancePlanAndExecute(
   // downstream autonomous disposition (merge/close/hold), not only the gate check conclusion. In particular, a
   // failing gate can still become a concrete auto-close after CI/conflict/duplicate/linked-issue planning; recording
   // only the gate's hold-shaped conclusion would blind the close-precision breaker to those live closes.
+  // #8825: a POLICY close (contributor cap, blacklist, copycat, review-nag, screenshot-table, linked-issue
+  // hard rule) carries no gate blocker, so blockerClass is "none" and the reason used to fall back to the
+  // gate's own conclusion -- recording "success" on a PR the bot deliberately closed. Every one of those rows
+  // then scored as a quality misprediction ("said merge, ended closed") when the gate never made a quality
+  // claim at all; measured on the live fleet, all 210 rows in that class carried the bare summary "success".
+  // Naming the closeKind makes the policy action distinguishable from a quality verdict at scoring time.
+  const policyCloseKind =
+    disposition.actionClass === "close"
+      ? breakerOnPlan.find((planned) => planned.actionClass === "close" && planned.closeKind !== undefined)?.closeKind
+      : undefined;
   await recordNativeGateDecision(env, {
     project: repoFullName,
     pullNumber: pr.number,
     headSha: pr.headSha,
     conclusion: gate.conclusion,
     action: disposition.actionClass,
-    reasonCode: disposition.blockerClass === "none" ? gate.conclusion : disposition.blockerClass,
+    reasonCode:
+      disposition.blockerClass !== "none"
+        ? disposition.blockerClass
+        : policyCloseKind !== undefined
+          ? `policy_close:${policyCloseKind}`
+          : gate.conclusion,
     // #2352: this row is the ACTUAL autonomous disposition that the precision breaker evaluates, so preserve
     // the same miner-authored scope as the gate-check audit row below. Omitting it defaults to non-miner and can
     // erase a prior miner-authored prediction for the same head.

--- a/src/selfhost/orb-collector.ts
+++ b/src/selfhost/orb-collector.ts
@@ -138,6 +138,11 @@ export async function getOrCreateAnonSecret(db: D1Database): Promise<string> {
 export function bucketReasonCode(summary: string | null | undefined): string {
   if (!summary) return "none";
   const s = summary.toLowerCase();
+  // #8825: a POLICY close (contributor cap, blacklist, copycat, review-nag, screenshot-table, linked-issue
+  // hard rule) is a deliberate enforcement action, NOT a claim about code quality — scoring it as a quality
+  // prediction distorts precision in both directions. Checked FIRST so the prefix wins over the substring
+  // rules below (e.g. `policy_close:linked-issue-hard-rule` must not bucket as plain issue_policy).
+  if (s.startsWith("policy_close:")) return "policy_action";
   if (s.includes("linked_issue") || s.includes("linked issue")) return "issue_policy";
   if (s.includes("duplicate")) return "duplicate_risk";
   if (s.includes("slop")) return "slop_advisory";

--- a/test/unit/orb-analytics.test.ts
+++ b/test/unit/orb-analytics.test.ts
@@ -8,15 +8,15 @@ async function signals(
   env: Env,
   instance: string,
   n: number,
-  o: { verdict?: string | null; outcome?: string; reversal?: string; ms?: number | null } = {},
+  o: { verdict?: string | null; outcome?: string; reversal?: string; ms?: number | null; bucket?: string | null } = {},
 ): Promise<void> {
   for (let i = 0; i < n; i++) {
     await env.DB
       .prepare(
-        `INSERT INTO orb_signals (instance_id, repo_hash, pr_hash, gate_verdict, outcome, reversal_flag, time_to_close_ms)
-         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO orb_signals (instance_id, repo_hash, pr_hash, gate_verdict, outcome, reversal_flag, time_to_close_ms, gate_reasoncode_bucket)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
       )
-      .bind(instance, `repo${seq}`, `pr${seq++}`, o.verdict ?? "merge", o.outcome ?? "merged", o.reversal ?? "none", o.ms ?? null)
+      .bind(instance, `repo${seq}`, `pr${seq++}`, o.verdict ?? "merge", o.outcome ?? "merged", o.reversal ?? "none", o.ms ?? null, o.bucket ?? null)
       .run();
   }
 }
@@ -101,6 +101,28 @@ describe("computeFleetAnalytics()", () => {
     // The old published formula would have called this ~100% — every miss here is marker-less, and the 30
     // holds dominate its denominator. This gap IS the bug.
     expect(1 - inst.reversalRate).toBe(1);
+  });
+
+  it("#8825: a POLICY close is excluded from accuracy scoring — it is enforcement, not a quality prediction", async () => {
+    const env = createTestEnv();
+    await signals(env, "i", 8, { verdict: "close", outcome: "closed" }); // real quality closes, all confirmed
+    await signals(env, "i", 2, { verdict: "close", outcome: "merged" }); // real quality misses
+    // Enforcement closes: the gate made no quality claim, so they must not count either way.
+    await signals(env, "i", 40, { verdict: "close", outcome: "closed", bucket: "policy_action" });
+    const inst = (await computeFleetAnalytics(env)).instances[0]!;
+    expect(inst.decisionAccuracy).toBeCloseTo(8 / 10); // NOT 48/50 — the 40 enforcement closes are excluded
+    expect(inst.closePrecision).toBeCloseTo(8 / 10);
+    expect(inst.policyActions).toBe(40);
+    expect(inst.decided).toBe(50); // still counted as activity
+  });
+
+  it("#8825: rows exported BEFORE the bucket existed (null) still score as ordinary quality verdicts", async () => {
+    const env = createTestEnv();
+    await signals(env, "i", 4, { verdict: "close", outcome: "closed", bucket: null });
+    await signals(env, "i", 1, { verdict: "close", outcome: "merged", bucket: "other" });
+    const inst = (await computeFleetAnalytics(env)).instances[0]!;
+    expect(inst.decisionAccuracy).toBeCloseTo(4 / 5);
+    expect(inst.policyActions).toBe(0);
   });
 
   it("decisionAccuracy is null for a holds-only instance (no decision to score) and drives the fleet median", async () => {

--- a/test/unit/selfhost-orb-collector.test.ts
+++ b/test/unit/selfhost-orb-collector.test.ts
@@ -59,6 +59,11 @@ describe("bucketReasonCode()", () => {
     expect(bucketReasonCode("self_authored_with_maintainer_cut")).toBe("author_policy");
     expect(bucketReasonCode("ci_state failing")).toBe("ci_readiness");
     expect(bucketReasonCode("something_unmapped")).toBe("other");
+    // #8825: an enforcement close buckets as policy_action, and the prefix wins over the substring rules
+    // below it -- `policy_close:linked-issue-hard-rule` must NOT flatten into plain issue_policy.
+    expect(bucketReasonCode("policy_close:contributor_cap")).toBe("policy_action");
+    expect(bucketReasonCode("policy_close:linked-issue-hard-rule")).toBe("policy_action");
+    expect(bucketReasonCode("policy_close:blacklist")).toBe("policy_action");
   });
 });
 


### PR DESCRIPTION
## What

Scores enforcement closes as their own class instead of as quality mispredictions. Closes #8825 (the remaining half — the recording-order fix shipped in #8826).

## Why

A **policy** close — contributor cap, blacklist, copycat, review-nag, screenshot-table, linked-issue hard rule — carries no gate blocker. So `disposition.blockerClass` was `"none"` and the recorded reason fell back to the gate's own conclusion, writing **`success`** on a PR the bot had deliberately closed.

Calibration then scored every one of those as *"the gate said merge and it ended up closed"* — a quality misprediction, when the gate never made a quality claim at all. Measured on the live fleet, **all 210 rows** in that class carried the bare summary `success`, completely indistinguishable from a real verdict. That was the root reason the class couldn't simply be filtered out: the information wasn't in the ledger.

An enforcement close is a deliberate decision, not an error. It can be neither confirmed nor disconfirmed as a prediction about code quality, so counting it on *either* side of accuracy is wrong.

## How

1. **`processors.ts`** — name the close kind in the recorded reason (`policy_close:<kind>`) instead of falling back to the conclusion, so the action is identifiable in the ledger at all.
2. **`orb-collector.ts`** — bucket that prefix as `policy_action`, checked *before* the substring rules so `policy_close:linked-issue-hard-rule` doesn't flatten into plain `issue_policy`.
3. **`analytics.ts`** — carry `gate_reasoncode_bucket` through the confusion matrix (`Cell` + the matrix `GROUP BY`), and exclude `policy_action` cells from `decisionAccuracy`/`mergePrecision`/`closePrecision`. They still count toward `decided` and `reversalRate`, which measure activity and human overrides rather than gate correctness, and the volume is reported separately as `policyActions` so it never silently vanishes.

**Backward compatible:** rows exported before the bucket existed carry `null` and keep scoring as ordinary quality verdicts, so historical data is unchanged and no backfill is required.

## Effect on the published number

This removes a systematic *downward* bias. Combined with #8824 (reversals were under-counted → biased up) and #8826 (verdicts contradicting actions → biased down), all three known distortions in the accuracy metric are now addressed, and the figure becomes defensible in both directions for the first time.

## Verification

- TSC clean; 399 tests green across analytics, collector, public-stats, queue, queue-2 and mcp-fleet-analytics.
- New tests assert the exact failure mode: an instance with 40 enforcement closes alongside 8 confirmed and 2 missed quality closes scores **8/10**, not 48/50, with `policyActions = 40` and `decided = 50`. Plus null-bucket back-compat and the bucket-precedence case.
- Changed-line coverage: 0 uncovered statements/branches.
