### PR TITLE
fix(orb): repair two drift checks #8841 left red on main

### DIFF
--- a/config/examples/loopover.full.yml
+++ b/config/examples/loopover.full.yml
@@ -121,6 +121,9 @@ publicNotes:
 #   block    — the finding can become a hard `LoopOver Gate` blocker
 #              (always confirmed-contributor-gated).
 gate:
+  # Percent (0-20) of would-auto-close PRs randomly HELD for human adjudication instead of closing --
+  # the randomized holdout behind the unbiased close-precision estimate (#8831). 0/absent disables.
+  # closeAuditHoldoutPct: 5
   # Legacy check-run publish switch (#5355) — despite the name, this does NOT turn the deterministic
   # gate itself on or off. Gate evaluation, comments, labels, audit records, spend, and autonomous
   # merge/close all run identically whether this is true, false, or unset; the per-dimension modes

--- a/src/selfhost/metrics.ts
+++ b/src/selfhost/metrics.ts
@@ -168,6 +168,7 @@ export const DEFAULT_METRIC_META: readonly (readonly [string, MetricMeta])[] = [
   ["loopover_orb_relay_malformed_events_total", { help: "Orb relay batch entries dropped for missing/mistyped required fields (deliveryId/eventName/rawBody).", type: "counter" }],
   ["loopover_orb_relay_register_total", { help: "Orb relay registration attempts, by mode and result (registered/recovered/failed).", type: "counter" }],
   ["loopover_pr_outcomes_total", { help: "Recorded PR gate outcomes, by decision.", type: "counter" }],
+  ["loopover_close_audit_holdouts_total", { help: "Would-auto-close PRs diverted to human adjudication by the close-audit holdout (#8831).", type: "counter" }],
   ["loopover_public_origin_acknowledged", { help: "1 when the configured public origin is acknowledged as reachable; 0 otherwise.", type: "gauge" }],
   ["loopover_repo_culture_profile_cache_hit_total", { help: "Repo-culture-profile cache hits.", type: "counter" }],
   ["loopover_repo_culture_profile_cache_miss_total", { help: "Repo-culture-profile cache misses.", type: "counter" }],


### PR DESCRIPTION
Main is currently red on `config-templates` (the `.loopover.yml.example` doc block added in #8841 was never mirrored into its `config/examples/loopover.full.yml` twin) and on the `selfhost-metrics` drift guard (`loopover_close_audit_holdouts_total` is emitted but was never registered in `DEFAULT_METRIC_META`). Both repaired; 62 tests in the two suites green, TSC clean.

Small and standalone so every open PR (#8843, #8845) goes green on rebase rather than each carrying the same fix. My miss in #8841 — the parity pair and the metric registry both have drift guards precisely for this, and they worked.