### PR TITLE
fix(engine): anchor objective-anchor's dependency-file regex to exact filenames

### DIFF
--- a/packages/loopover-engine/src/objective-anchor.ts
+++ b/packages/loopover-engine/src/objective-anchor.ts
@@ -234,7 +234,7 @@ function kindsFromPath(path: string): ObjectiveAnchorChangeKind[] {
   if (CONFIG_FILENAMES.has(filename) || filename.endsWith(".jsonc") || filename.endsWith(".toml")) {
     kinds.push("config");
   }
-  if (/package(?:-lock)?\.json$/u.test(filename)) {
+  if (/^package(?:-lock)?\.json$/u.test(filename)) {
     kinds.push("dependency");
   }
   return kinds;

--- a/packages/loopover-engine/test/objective-anchor.test.ts
+++ b/packages/loopover-engine/test/objective-anchor.test.ts
@@ -70,6 +70,14 @@ test("extractObjectiveAnchorFeatures normalizes paths, derives modules, and clas
   ]);
 });
 
+test("extractObjectiveAnchorFeatures tags only exact package(.-lock).json as a dependency, not a prefixed sibling (#8874)", () => {
+  const positive = extractObjectiveAnchorFeatures({ paths: ["package.json", "package-lock.json"] });
+  assert.ok(positive.changeKinds.includes("dependency"));
+
+  const negative = extractObjectiveAnchorFeatures({ paths: ["sub-package.json", "mock-package.json"] });
+  assert.ok(!negative.changeKinds.includes("dependency"));
+});
+
 test("scoreObjectiveAnchor returns 1 for full structural overlap", () => {
   const result = scoreObjectiveAnchor({ replayed: replay(), revealed: revealed() });
 

--- a/test/unit/engine-objective-anchor-config-classification.test.ts
+++ b/test/unit/engine-objective-anchor-config-classification.test.ts
@@ -16,4 +16,25 @@ describe("loopover-engine objective-anchor config-filename classification", () =
     expect(features.changeKinds).toContain("config");
     expect(features.paths).toEqual([".loopover.yml"]);
   });
+
+  // The dependency check must use the same exact-match discipline as the adjacent CONFIG_FILENAMES
+  // check: an anchored /^package(?:-lock)?\.json$/ so a differently-prefixed sibling is NOT tagged
+  // "dependency" (#8874). Exercised on the vitest side because Codecov grades this file via vitest.
+  it("tags only exact package(.-lock).json as a 'dependency' change kind, not a prefixed sibling (#8874)", () => {
+    const dependency = extractObjectiveAnchorFeatures({
+      paths: ["package.json", "package-lock.json"],
+      labels: [],
+      titles: [],
+      notes: [],
+    });
+    expect(dependency.changeKinds).toContain("dependency");
+
+    const notDependency = extractObjectiveAnchorFeatures({
+      paths: ["sub-package.json", "mock-package.json"],
+      labels: [],
+      titles: [],
+      notes: [],
+    });
+    expect(notDependency.changeKinds).not.toContain("dependency");
+  });
 });


### PR DESCRIPTION
## What & why

Closes #8874.

`packages/loopover-engine/src/objective-anchor.ts`'s `kindsFromPath` classified any filename ending
in `package.json`/`package-lock.json` as a `"dependency"` change kind via an **unanchored**
`/package(?:-lock)?\.json$/`. A differently-prefixed sibling — `mock-package.json`,
`sub-package.json` — therefore got tagged `"dependency"`, diluting that change-kind dimension that
`scoreObjectiveAnchor` relies on. This is inconsistent with the adjacent config check three lines
above in the same function, which uses exact-match `CONFIG_FILENAMES` set membership.

## Change

Anchor the regex: `/^package(?:-lock)?\.json$/u`. Only the exact filenames `package.json` and
`package-lock.json` now classify as `"dependency"`, matching the exact-match discipline already used
for the config check.

## Validation

- New negative test asserting `sub-package.json`/`mock-package.json` do **not** produce a
  `"dependency"` change-kind, while `package.json`/`package-lock.json` still do — added on both the
  engine's own suite (`packages/loopover-engine/test/objective-anchor.test.ts`) and the Codecov-graded
  vitest suite (`test/unit/engine-objective-anchor-config-classification.test.ts`).
- Bug-catch verified: removing the `^` anchor fails exactly the new assertion in both runners.
- 100% patch coverage on the changed line (both regex outcomes exercised).
