### PR TITLE
fix(orb): degrade getOrbGlobalStats to zeros on a DB error

### DIFF
--- a/src/orb/outcomes.ts
+++ b/src/orb/outcomes.ts
@@ -63,8 +63,9 @@ export interface OrbGlobalStats {
 export async function getOrbGlobalStats(env: Env, opts: { excludeAccount?: string } = {}): Promise<OrbGlobalStats> {
   // excludeAccount de-dups an account already counted by another source. "" = include all.
   const exclude = (opts.excludeAccount ?? "").toLowerCase();
-  const row = await env.DB.prepare(
-    `SELECT
+  try {
+    const row = await env.DB.prepare(
+      `SELECT
        SUM(CASE WHEN o.outcome = 'merged' THEN 1 ELSE 0 END) AS merged,
        SUM(CASE WHEN o.outcome = 'closed' THEN 1 ELSE 0 END) AS closed,
        COUNT(*) AS total
@@ -75,10 +76,16 @@ export async function getOrbGlobalStats(env: Env, opts: { excludeAccount?: strin
        AND ae.event_type = 'github_app.pr_public_surface_published'
      WHERE (? = '' OR LOWER(COALESCE(i.account_login, '')) <> ?)
        AND ae.id IS NULL`,
-  )
-    .bind(exclude, exclude)
-    .first<{ merged: number | null; closed: number | null; total: number | null }>();
-  /* v8 ignore next -- an aggregate query always returns exactly one row; this guards the nullable .first() type only */
-  if (!row) return { merged: 0, closed: 0, total: 0 };
-  return { merged: row.merged ?? 0, closed: row.closed ?? 0, total: row.total ?? 0 };
+    )
+      .bind(exclude, exclude)
+      .first<{ merged: number | null; closed: number | null; total: number | null }>();
+    /* v8 ignore next -- an aggregate query always returns exactly one row; this guards the nullable .first() type only */
+    if (!row) return { merged: 0, closed: 0, total: 0 };
+    return { merged: row.merged ?? 0, closed: row.closed ?? 0, total: row.total ?? 0 };
+  } catch {
+    // #8879: degrade to zeros on a DB error, mirroring computeFleetAnalytics's try/catch (src/orb/analytics.ts)
+    // so a D1 failure on this join drops ONLY the orb aggregate instead of 503-ing the entire /v1/public/stats
+    // payload (accuracyTrend/reuseRateTrend/reviewVolumeTrend/rulePrecision) via the route-level catch.
+    return { merged: 0, closed: 0, total: 0 };
+  }
 }

--- a/test/integration/orb-outcomes.test.ts
+++ b/test/integration/orb-outcomes.test.ts
@@ -111,4 +111,13 @@ describe("getOrbGlobalStats", () => {
     await recordOrbPrOutcome(e, "pull_request", closedPr("acme/new", 2, null, 100)); // closed, no own-ledger counterpart → must still count
     expect(await getOrbGlobalStats(e)).toEqual({ merged: 0, closed: 1, total: 1 });
   });
+
+  // #8879: a D1 error on the join must degrade to zeros (like computeFleetAnalytics), not throw out of the
+  // Promise.all in public-stats.ts and 503 the whole /v1/public/stats payload.
+  it("degrades to zeros on a DB error instead of throwing (#8879)", async () => {
+    const brokenDb = {
+      prepare: () => ({ bind: () => ({ first: () => Promise.reject(new Error("D1 exceeded its CPU time limit and was reset")) }) }),
+    } as unknown as Env["DB"];
+    await expect(getOrbGlobalStats({ DB: brokenDb } as unknown as Env)).resolves.toEqual({ merged: 0, closed: 0, total: 0 });
+  });
 });


### PR DESCRIPTION
## What

`getOrbGlobalStats` (`src/orb/outcomes.ts`) runs in
`Promise.all([getOrbGlobalStats(env), computeFleetAnalytics(env)])` in
`src/review/public-stats.ts`. Its sibling `computeFleetAnalytics` wraps its DB reads in try/catch and
degrades to an all-null/zero report on any D1 error — but `getOrbGlobalStats` had no such guard, so a
D1 error on its join query (the exact "exceeded its CPU time limit and was reset" failure the function's
own header documents) threw straight out of the `Promise.all`. The only net was the route-level catch,
which then 503s the **entire** `/v1/public/stats` payload (accuracyTrend, reuseRateTrend,
reviewVolumeTrend, rulePrecision all lost) instead of degrading just the orb aggregate.

## Change

Wrap the query in try/catch, returning `{ merged: 0, closed: 0, total: 0 }` on failure — matching
`computeFleetAnalytics`'s degrade-gracefully posture exactly, so a D1 error drops only the orb aggregate
rather than the whole stats payload.

## Validation

- New test in `test/integration/orb-outcomes.test.ts`: an injected DB whose `first()` rejects makes
  `getOrbGlobalStats` resolve to `{ merged: 0, closed: 0, total: 0 }` rather than throw.
- `npx vitest run test/integration/orb-outcomes.test.ts` → 11/11 pass; the new catch branch is covered
  (lcov-verified), the existing success paths remain covered.

Closes #8879
