### PR TITLE
fix(engine): reject non-finite maxIterations in the iterate-loop guard

### DIFF
--- a/packages/loopover-engine/src/miner/iterate-loop.ts
+++ b/packages/loopover-engine/src/miner/iterate-loop.ts
@@ -360,7 +360,11 @@ async function runIterateLoopCore(input: IterateLoopInput, deps: IterateLoopDeps
   // reject), silently permitting one extra iteration beyond the caller's intent. Normalizing once here keeps
   // both checks watching the exact same integer ceiling.
   const maxIterations = Math.max(0, Math.trunc(input.maxIterations));
-  if (maxIterations <= 0) return immediateAbandonNoIterationsPermitted(input, deps);
+  // Number.isFinite rejects NaN/Infinity before the `<= 0` check: Math.trunc(NaN) is NaN (and NaN <= 0 is
+  // false), and Infinity passes `<= 0` too, so without this a NaN input would skip the guard and fall through
+  // to the "unreachable in practice" fail-closed fallback with a corrupted iterationsUsed: NaN, while Infinity
+  // would let the `for` loop run without its own bound ever terminating it (#8860).
+  if (!Number.isFinite(maxIterations) || maxIterations <= 0) return immediateAbandonNoIterationsPermitted(input, deps);
 
   safeAppendAttemptLogEvent(deps, {
     eventType: "attempt_started",

--- a/packages/loopover-engine/test/iterate-loop.test.ts
+++ b/packages/loopover-engine/test/iterate-loop.test.ts
@@ -106,6 +106,20 @@ test("immediate abandon: maxIterations <= 0 abandons before ever invoking the dr
   assert.equal(events[0]?.eventType, "attempt_aborted");
 });
 
+test("immediate abandon: a NaN or Infinity maxIterations abandons rather than corrupting iterationsUsed or looping unbounded (#8860)", async () => {
+  for (const badMax of [Number.NaN, Number.POSITIVE_INFINITY]) {
+    let driverCalled = false;
+    const { deps } = collectingDeps({ driver: { async run() { driverCalled = true; return okResult(); } } });
+    const result = await runIterateLoop(baseInput({ maxIterations: badMax }), deps);
+
+    assert.equal(result.outcome, "abandon");
+    assert.equal(result.finalDecision.abandonReason, "max_iterations_reached");
+    assert.equal(result.iterationsUsed, 0);
+    assert.equal(Number.isNaN(result.iterationsUsed), false);
+    assert.equal(driverCalled, false, "the driver must never run for a non-finite maxIterations");
+  }
+});
+
 test("paused mode: does not invoke the coding-agent driver (regression for pause gate bypass)", async () => {
   let driverCalled = false;
   const { deps, events } = collectingDeps({ driver: { async run() { driverCalled = true; return okResult(); } } });

--- a/test/unit/iterate-loop-usage-guard.test.ts
+++ b/test/unit/iterate-loop-usage-guard.test.ts
@@ -95,4 +95,18 @@ describe("runIterateLoop usage guard (#5827)", () => {
       expect(Number.isFinite(result.totalCostUsd)).toBe(true);
     }
   });
+
+  it("abandons immediately on a NaN or Infinity maxIterations rather than corrupting iterationsUsed or looping unbounded (#8860)", async () => {
+    for (const badMax of [Number.NaN, Number.POSITIVE_INFINITY]) {
+      let driverCalled = false;
+      const { deps } = collectingDeps({ async run() { driverCalled = true; return { ok: true, changedFiles: ["src/upload.ts"], summary: "x" }; } });
+      const result = await runIterateLoop(passingInput({ maxIterations: badMax as number }), deps);
+
+      expect(result.outcome).toBe("abandon");
+      expect(result.finalDecision.abandonReason).toBe("max_iterations_reached");
+      expect(result.iterationsUsed).toBe(0);
+      expect(Number.isNaN(result.iterationsUsed)).toBe(false);
+      expect(driverCalled).toBe(false);
+    }
+  });
 });


### PR DESCRIPTION
## What & why

Closes #8860.

`packages/loopover-engine/src/miner/iterate-loop.ts`'s entry guard computed
`const maxIterations = Math.max(0, Math.trunc(input.maxIterations))` and then checked
`if (maxIterations <= 0)`. Two non-finite inputs slipped through:

- **NaN**: `Math.trunc(NaN)` is `NaN`, and `NaN <= 0` is `false`, so the guard was skipped. The
  `for` loop body never ran (`1 <= NaN` is false), and execution fell into the block explicitly
  marked `/* v8 ignore next 8 -- unreachable in practice */`, returning a corrupted
  `iterationsUsed: NaN`.
- **Infinity**: passes `<= 0` too, and the `for` loop then has no bound of its own to terminate it.

## Change

Guard with `if (!Number.isFinite(maxIterations) || maxIterations <= 0)` so `NaN` and `Infinity`
route to `immediateAbandonNoIterationsPermitted` exactly like `0`/negative inputs. The "unreachable
in practice" fallback stays genuinely unreachable for these inputs.

## Validation

- New test asserting `maxIterations: NaN` and `maxIterations: Infinity` each return the abandon
  result with `iterationsUsed: 0` (no `NaN` propagating) and never invoke the driver — added on both
  the engine's own suite (`packages/loopover-engine/test/iterate-loop.test.ts`) and the Codecov-graded
  vitest guard suite (`test/unit/iterate-loop-usage-guard.test.ts`).
- Bug-catch verified: reverting to the old `<= 0`-only guard fails exactly the new assertion in both
  runners.
- 100% patch coverage on both new input-validation branches.
