### PR TITLE
fix(db): tie-break getLatestPublishedAiReview on rowid

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -5094,7 +5094,7 @@ export async function getLatestPublishedAiReview(
 ): Promise<{ notes: string; reviewerCount: number; findings: AdvisoryFinding[]; headSha?: string | undefined; metadata?: Record<string, unknown> | undefined } | null> {
   const row = await env.DB
     .prepare(
-      "SELECT notes, reviewer_count AS reviewerCount, head_sha AS headSha, findings_json AS findingsJson, metadata_json AS metadataJson FROM ai_review_cache WHERE repo_full_name = ? AND pull_number = ? AND ai_review_mode = ? AND published_at IS NOT NULL ORDER BY published_at DESC LIMIT 1",
+      "SELECT notes, reviewer_count AS reviewerCount, head_sha AS headSha, findings_json AS findingsJson, metadata_json AS metadataJson FROM ai_review_cache WHERE repo_full_name = ? AND pull_number = ? AND ai_review_mode = ? AND published_at IS NOT NULL ORDER BY published_at DESC, rowid DESC LIMIT 1",
     )
     .bind(repoFullName, pullNumber, mode)
     .first<{ notes: string; reviewerCount: number; headSha: string; findingsJson: string | null; metadataJson: string | null }>();

--- a/test/unit/ai-review-cache.test.ts
+++ b/test/unit/ai-review-cache.test.ts
@@ -470,6 +470,31 @@ describe("AI review cache (#1)", () => {
       }
     });
 
+    it("breaks ties on identical published_at via rowid DESC (#8894)", async () => {
+      const env = createTestEnv();
+      const publishedAt = "2026-07-09T12:00:00.000Z";
+      // Insert order ⇒ rising rowid; with equal published_at the higher rowid must win.
+      await env.DB.prepare(
+        `INSERT INTO ai_review_cache (repo_full_name, pull_number, head_sha, ai_review_mode, notes, reviewer_count, findings_json, metadata_json, cacheable, published_at, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+        .bind("o/r", 56, "sha-earlier-rowid", "block", "earlier rowid", 1, "[]", "{}", 1, publishedAt, publishedAt)
+        .run();
+      await env.DB.prepare(
+        `INSERT INTO ai_review_cache (repo_full_name, pull_number, head_sha, ai_review_mode, notes, reviewer_count, findings_json, metadata_json, cacheable, published_at, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+        .bind("o/r", 56, "sha-later-rowid", "block", "later rowid", 1, "[]", "{}", 1, publishedAt, publishedAt)
+        .run();
+
+      expect(await getLatestPublishedAiReview(env, "o/r", 56, "block")).toEqual({
+        notes: "later rowid",
+        reviewerCount: 1,
+        findings: [],
+        headSha: "sha-later-rowid",
+      });
+    });
+
     it("omits headSha from the payload when the stored head_sha is empty", async () => {
       const env = createTestEnv();
       await env.DB.prepare(


### PR DESCRIPTION
## Summary

- Add `rowid DESC` tiebreaker to `getLatestPublishedAiReview`'s `ORDER BY published_at DESC`, matching sibling latest-row queries.
- Unit test inserts two published rows with identical `published_at` and asserts the higher `rowid` wins.

Closes #8894

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) - a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ?99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Local Node is v24; repo engines pin Node 22. New coverage is in `test/unit/ai-review-cache.test.ts` and will run under CI. Single-commit PR (one-shot repo).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A - no visible UI changes.

## Notes

-