### PR TITLE
fix(scenarios): sync forbidden public-language regex across summary guards

### DIFF
--- a/src/scenarios/input-model.ts
+++ b/src/scenarios/input-model.ts
@@ -29,7 +29,8 @@ export const scenarioSignalSources = [
 ] as const;
 export type ScenarioSignalSource = (typeof scenarioSignalSources)[number];
 
-const FORBIDDEN_PUBLIC_LANGUAGE =
+/** Shared public-safety term set for scenario input + public summary guards (#8885 / #913). */
+export const FORBIDDEN_PUBLIC_LANGUAGE =
   /wallet|hotkey|coldkey|mnemonic|seed phrase|payout|estimated[-\s]?rewards?|rewards?|reward[-\s]?estimate|rankings?|farming|raw trust|trust[-\s]?score|scoreability|private[-\s]?reviewability|public[-\s]?score[-\s]?(?:estimate|prediction)/i;
 
 const FORBIDDEN_SOURCE_UPLOAD_KEYS =

--- a/src/scenarios/scenario-summary.ts
+++ b/src/scenarios/scenario-summary.ts
@@ -4,7 +4,7 @@ import type { OpenPrPressureSimulation, OpenPrStrategyOption } from "../services
 import type { ScoreGateBlocker } from "../scoring/preview";
 import type { PendingPrScenarioDetection, OpenPrPendingClass } from "../scoring/pending-pr-scenarios";
 import type { AgentScenarioInput } from "./input-model";
-import { serializeScenarioInputPublic } from "./input-model";
+import { FORBIDDEN_PUBLIC_LANGUAGE, serializeScenarioInputPublic } from "./input-model";
 
 /**
  * Public-safe rendering of scenario simulator outputs for MCP/API clients and
@@ -92,9 +92,6 @@ const PUBLIC_BLOCKER_TEXT: Partial<Record<ScoreGateBlocker["code"], string>> = {
   stale_work: "Stale open PR(s) detected; consider closing stale work before opening more.",
 };
 
-const FORBIDDEN_PUBLIC_LANGUAGE =
-  /wallet|hotkey|coldkey|mnemonic|seed phrase|payout|reward[-\s]?estimate|farming|raw trust|trust[-\s]?score|scoreability|private[-\s]?reviewability|public[-\s]?score[-\s]?(?:estimate|prediction)/i;
-
 function renderOptions(simulation: OpenPrPressureSimulation): RenderedScenarioOption[] {
   return simulation.scenarios.map((s) => {
     const rationaleParts = [...s.facts.slice(0, 1), ...s.tradeoffs.slice(0, 1)];
@@ -180,17 +177,16 @@ function extractDataClassification(scenarioInput: AgentScenarioInput | undefined
   };
 }
 
-function assertPublicSummaryClean(summary: PublicScenarioSummary): void {
+/** Defensive final guard: catches forbidden terms that slipped past per-field sanitization (#8885). */
+export function assertPublicSummaryClean(summary: PublicScenarioSummary): void {
   // Scan only rendered free-text fields. repoFullName/generatedAt are structural identifiers (the repo
   // the summary is about), not sanitized content -- a legitimately named repo (e.g. "owner/hotkey-vault")
   // must not make this guard throw and fail the whole summary.
   const { repoFullName: _repoFullName, generatedAt: _generatedAt, ...renderedContent } = summary;
   const serialized = JSON.stringify(renderedContent);
-  /* v8 ignore start -- Defensive: every rendered field is individually sanitized; this guards a future unsanitized field. */
   if (FORBIDDEN_PUBLIC_LANGUAGE.test(serialized)) {
     throw new Error("Public scenario summary still contains forbidden language.");
   }
-  /* v8 ignore end */
 }
 
 /**

--- a/test/unit/scenario-summary.test.ts
+++ b/test/unit/scenario-summary.test.ts
@@ -1,16 +1,21 @@
 import { describe, expect, it } from "vitest";
 import { sanitizePublicComment } from "../../src/github/commands";
-import { buildScenarioInput, createScenarioSignalEntry } from "../../src/scenarios/input-model";
-import { renderPublicScenarioSummary } from "../../src/scenarios/scenario-summary";
+import {
+  buildScenarioInput,
+  createScenarioSignalEntry,
+  FORBIDDEN_PUBLIC_LANGUAGE,
+} from "../../src/scenarios/input-model";
+import {
+  assertPublicSummaryClean,
+  renderPublicScenarioSummary,
+  type PublicScenarioSummary,
+} from "../../src/scenarios/scenario-summary";
 import { deriveEligibilityPlan } from "../../src/services/eligibility-plan";
 import { simulateOpenPrPressure } from "../../src/services/open-pr-pressure-scenarios";
 import type { PendingPrScenarioDetection } from "../../src/scoring/pending-pr-scenarios";
 import { buildScorePreview, type ScoreGateBlocker } from "../../src/scoring/preview";
 import type { QueueHealth, RoleContext } from "../../src/signals/engine";
 import type { ScoringModelSnapshotRecord } from "../../src/types";
-
-const FORBIDDEN_PUBLIC_LANGUAGE =
-  /wallet|hotkey|coldkey|mnemonic|seed phrase|payout|reward[-\s]?estimate|farming|raw trust|trust[-\s]?score|scoreability|private[-\s]?reviewability|public[-\s]?score[-\s]?(?:estimate|prediction)/i;
 
 const snapshot: ScoringModelSnapshotRecord = {
   id: "scenario-summary-model",
@@ -410,5 +415,32 @@ describe("renderPublicScenarioSummary", () => {
 
     expect(summary.pendingScenarioNotes.join(" ")).not.toMatch(/Projected open PR count after pending cleanup/i);
     expect(summary.pendingPullRequests[0]?.classification).toBe("custom pending class");
+  });
+
+  it("assertPublicSummaryClean rejects bare rewards/rankings like the input-model guard (#8885)", () => {
+    const base: PublicScenarioSummary = {
+      repoFullName: "octo/demo",
+      generatedAt: "2026-06-03T00:00:00.000Z",
+      advisoryOnly: true,
+      notAutonomousPrBot: true,
+      notPublicScoring: true,
+      headline: "Advisory scenario summary generated from available repo signals.",
+      options: [],
+      eligibilityNotes: [],
+      blockerNotes: [],
+      pendingScenarioNotes: [],
+      pendingPullRequests: [],
+      dataClassification: { facts: [], assumptions: [], unavailableSignals: [] },
+    };
+
+    expect(() => assertPublicSummaryClean({ ...base, headline: "Projected rewards look strong." })).toThrow(
+      /forbidden language/i,
+    );
+    expect(() => assertPublicSummaryClean({ ...base, eligibilityNotes: ["Private rankings leaked."] })).toThrow(
+      /forbidden language/i,
+    );
+    // Shared constant must stay identical to the input-model #913 term set.
+    expect(FORBIDDEN_PUBLIC_LANGUAGE.test("rewards")).toBe(true);
+    expect(FORBIDDEN_PUBLIC_LANGUAGE.test("rankings")).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Export a single `FORBIDDEN_PUBLIC_LANGUAGE` from `input-model.ts` (the #913 term set including `rewards?` / `estimated rewards` / `rankings?`).
- `scenario-summary.ts` now imports that shared constant instead of a stale private copy that missed those terms.
- Export `assertPublicSummaryClean` and add a unit test proving bare `rewards` / `rankings` in headline/notes throw.

Closes #8885

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npx vitest run test/unit/scenario-summary.test.ts` (11 passed)
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Narrow `src/scenarios` + unit-test change; vitest covers the synced guard. Full monorepo typecheck/coverage not re-run locally.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — backend/scenarios public-safety guard only; no UI surface change.

## Notes

-