### PR TITLE
fix(engine): classify 'ci' change-kind only by real CI path segments, not any .yml/.yaml (#8873)

### DIFF
--- a/packages/loopover-engine/src/objective-anchor.ts
+++ b/packages/loopover-engine/src/objective-anchor.ts
@@ -228,7 +228,10 @@ function kindsFromPath(path: string): ObjectiveAnchorChangeKind[] {
   if (DOC_EXTENSIONS.has(extensionOf(path)) || segments.includes("docs") || filename.toLowerCase() === "readme.md") {
     kinds.push("docs");
   }
-  if (segments.some((segment) => CI_SEGMENTS.has(segment)) || filename.endsWith(".yml") || filename.endsWith(".yaml")) {
+  // "ci" is classified ONLY by a real CI path segment (CI_SEGMENTS), matching the path-segment discipline every
+  // other kind here uses. The old bare `.yml`/`.yaml` extension fallback tagged any YAML file anywhere (root
+  // `.loopover.yml`, `docs/mkdocs.yml`) as "ci", diluting the signal scoreObjectiveAnchor relies on (#8873).
+  if (segments.some((segment) => CI_SEGMENTS.has(segment))) {
     kinds.push("ci");
   }
   if (CONFIG_FILENAMES.has(filename) || filename.endsWith(".jsonc") || filename.endsWith(".toml")) {

--- a/test/unit/engine-objective-anchor-config-classification.test.ts
+++ b/test/unit/engine-objective-anchor-config-classification.test.ts
@@ -14,6 +14,18 @@ describe("loopover-engine objective-anchor config-filename classification", () =
     });
 
     expect(features.changeKinds).toContain("config");
+    // #8873: a config YAML at the repo root must NOT be tagged "ci" purely by its extension.
+    expect(features.changeKinds).not.toContain("ci");
     expect(features.paths).toEqual([".loopover.yml"]);
+  });
+
+  it("does NOT tag a non-CI YAML file (docs/mkdocs.yml) as a 'ci' change kind (#8873)", () => {
+    const features = extractObjectiveAnchorFeatures({ paths: ["docs/mkdocs.yml"], labels: [], titles: [], notes: [] });
+    expect(features.changeKinds).not.toContain("ci");
+  });
+
+  it("still tags a YAML under a real CI path segment (.github/workflows/ci.yml) as 'ci' (#8873)", () => {
+    const features = extractObjectiveAnchorFeatures({ paths: [".github/workflows/ci.yml"], labels: [], titles: [], notes: [] });
+    expect(features.changeKinds).toContain("ci");
   });
 });


### PR DESCRIPTION
## Problem

Closes #8873.

`packages/loopover-engine/src/objective-anchor.ts`'s `kindsFromPath` classified `ci` via `CI_SEGMENTS.has(segment) || filename.endsWith('.yml') || filename.endsWith('.yaml')`. The bare-extension fallback tagged **any** YAML file — root `.loopover.yml`, `docs/mkdocs.yml` — as `ci` regardless of location, diluting the `ci` change-kind dimension `scoreObjectiveAnchor` relies on.

## Fix

Drop the extension fallback. `ci` is now classified **only** via a real CI path segment (`CI_SEGMENTS`), the same path-segment discipline every other change-kind in the function already uses.

## Tests

- `.loopover.yml` (root) → `config` but **not** `ci`.
- `docs/mkdocs.yml` → **not** `ci`.
- `.github/workflows/ci.yml` → still `ci` (proves `CI_SEGMENTS` path classification is unaffected).

Reverting the change fails the negative assertions. `git diff --check` clean.