### PR TITLE
fix(engine): stop classifying non-CI YAML paths as ci changes

### DIFF
--- a/packages/loopover-engine/src/objective-anchor.ts
+++ b/packages/loopover-engine/src/objective-anchor.ts
@@ -228,7 +228,7 @@ function kindsFromPath(path: string): ObjectiveAnchorChangeKind[] {
   if (DOC_EXTENSIONS.has(extensionOf(path)) || segments.includes("docs") || filename.toLowerCase() === "readme.md") {
     kinds.push("docs");
   }
-  if (segments.some((segment) => CI_SEGMENTS.has(segment)) || filename.endsWith(".yml") || filename.endsWith(".yaml")) {
+  if (segments.some((segment) => CI_SEGMENTS.has(segment))) {
     kinds.push("ci");
   }
   if (CONFIG_FILENAMES.has(filename) || filename.endsWith(".jsonc") || filename.endsWith(".toml")) {

--- a/packages/loopover-engine/test/objective-anchor.test.ts
+++ b/packages/loopover-engine/test/objective-anchor.test.ts
@@ -383,3 +383,18 @@ test("renderObjectiveAnchorAuditMarkdown escapes markdown controls and collapses
   assert.ok(markdown.includes("- src/review/\\[unsafe\\].ts"));
   assert.ok(markdown.includes("- src/review/\\<unsafe\\>.ts"));
 });
+
+test("extractObjectiveAnchorFeatures does not classify non-CI YAML as ci (#8873)", () => {
+  const features = extractObjectiveAnchorFeatures({
+    paths: [".loopover.yml", "docs/mkdocs.yml", "config/app.yaml"],
+  });
+
+  assert.equal(features.changeKinds.includes("ci"), false);
+  assert.ok(features.changeKinds.includes("config"));
+  assert.ok(features.changeKinds.includes("docs"));
+
+  const ciWorkflow = extractObjectiveAnchorFeatures({
+    paths: [".github/workflows/ci.yml"],
+  });
+  assert.ok(ciWorkflow.changeKinds.includes("ci"));
+});


### PR DESCRIPTION
## Summary

- Drop the bare `.yml`/`.yaml` extension fallback in `kindsFromPath` so only real `CI_SEGMENTS` path matches (`.github`, `workflows`) classify as `"ci"`.
- Add a negative test that `.loopover.yml`, `docs/mkdocs.yml`, and `config/app.yaml` do **not** produce `"ci"`, while `.github/workflows/ci.yml` still does.

Closes #8873

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm --workspace @loopover/engine run build`
- [x] `node --test dist-test/objective-anchor.test.js` (20 passed)
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Engine package-local build + objective-anchor suite cover the change. Full monorepo typecheck/coverage not re-run locally.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — engine path-classification helper only; no UI surface change.

## Notes

-