### PR TITLE
feat(api): surface computeRuleGateEval's per-(project, ruleCode) rows

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -300,6 +300,7 @@ import { handleInternalCalibration, handleInternalDecision, type OpsAgentConfig 
 import { computeParityReadiness, isParityAuditEnabled } from "../review/parity-wire";
 import { computePredictedGateAgreement } from "../review/predicted-gate-agreement";
 import { computeContributorGateEval, contributorFairnessFlags, computeBlendedContributorGateEval, contributorGlobalFairnessFlags } from "../review/contributor-gate-eval";
+import { computeRuleGateEval } from "../review/rule-gate-eval";
 import { getContributorTrustProfile } from "../review/contributor-trust-profile";
 import { backfillContributorGateHistory } from "../review/contributor-gate-history-backfill";
 import { isFairnessAnalyticsEnabled, resolveFairnessAnalyticsManifestOverride } from "../review/contributor-trust-profile-wire";
@@ -4402,6 +4403,18 @@ export function createApp() {
   app.get("/v1/internal/fleet/analytics", async (c) => {
     const days = parsePositiveInt(c.req.query("days")) ?? 90;
     return c.json(await computeFleetAnalytics(c.env, { windowDays: days }));
+  });
+
+  // Per-(project, ruleCode) gate-decision accuracy (#8906): the finer-grained sibling of the blended
+  // view already wired into the operator-dashboard tile (rulesBelowClosePrecisionFloor) and the
+  // concrete-evidence breaker exemption cache (outcomes-wire.ts). No privacy concern — ruleCode isn't a
+  // contributor identity — so unlike the fairness/contributors split, this returns the full
+  // per-project report directly rather than a detail route + summary-only dashboard tile. Owner-only:
+  // bearer-gated by the `/v1/internal/*` middleware (INTERNAL_JOB_TOKEN). `?days=` windows the lookback
+  // (default 90, matching BREAKER_EVAL_WINDOW_DAYS and the fairness routes' hardcoded window).
+  app.get("/v1/internal/rule-gate-eval", async (c) => {
+    const days = parsePositiveInt(c.req.query("days")) ?? 90;
+    return c.json(await computeRuleGateEval(c.env, { days, nowMs: Date.now() }));
   });
 
   // Orb instance registry — the fleet trust gate. Every self-host instance that ingests is recorded here,

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -4273,6 +4273,62 @@ describe("api routes", () => {
     expect((await app.request("/v1/internal/fairness/contributors", { headers }, offEnv)).status).toBe(404);
   });
 
+  it("GET /v1/internal/rule-gate-eval returns the per-(project, ruleCode) breakdown, not the blended view (#8906)", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const now = new Date().toISOString();
+    // Same ruleCode ("surface_lane_reject"), two DIFFERENT projects — proves the response is
+    // genuinely per-project, not pooled/blended (which would collapse this to one row with
+    // projectCount: 2 instead of two rows each carrying its own `project`).
+    for (const [id, project] of [
+      ["gd-1", "owner/repo-a"],
+      ["gd-2", "owner/repo-b"],
+    ] as const) {
+      await env.DB.prepare(
+        `INSERT INTO review_audit (id, project, target_id, event_type, decision, summary, source, created_at) VALUES (?, ?, ?, 'gate_decision', 'close', 'surface_lane_reject', 'gittensory-native', ?)`,
+      )
+        .bind(id, project, `${project}#1`, now)
+        .run();
+      await env.DB.prepare(
+        `INSERT INTO review_audit (id, project, target_id, event_type, decision, source, created_at) VALUES (?, ?, ?, 'pr_outcome', 'merged', 'github', ?)`,
+      )
+        .bind(`po-${id}`, project, `${project}#1`, now)
+        .run();
+    }
+
+    const headers = { authorization: `Bearer ${env.INTERNAL_JOB_TOKEN}` };
+    const res = await app.request("/v1/internal/rule-gate-eval", { headers }, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      rows: Array<{ project: string; ruleCode: string; wouldClose: number; closeFalse: number }>;
+      hasSignal: boolean;
+    };
+    expect(body.rows).toHaveLength(2);
+    expect(body.rows.map((r) => r.project).sort()).toEqual(["owner/repo-a", "owner/repo-b"]);
+    expect(body.rows.every((r) => r.ruleCode === "surface_lane_reject" && r.wouldClose === 1 && r.closeFalse === 1)).toBe(true);
+    expect(body.hasSignal).toBe(false); // each row's `decided` is 1, below the signal floor
+  });
+
+  it("GET /v1/internal/rule-gate-eval honors ?days and defaults to a 90-day window when omitted", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const headers = { authorization: `Bearer ${env.INTERNAL_JOB_TOKEN}` };
+
+    const withDays = await app.request("/v1/internal/rule-gate-eval?days=30", { headers }, env);
+    expect(withDays.status).toBe(200);
+    expect(await withDays.json()).toEqual({ rows: [], hasSignal: false });
+
+    const withoutDays = await app.request("/v1/internal/rule-gate-eval", { headers }, env);
+    expect(withoutDays.status).toBe(200);
+    expect(await withoutDays.json()).toEqual({ rows: [], hasSignal: false });
+  });
+
+  it("GET /v1/internal/rule-gate-eval 401s without the internal bearer token", async () => {
+    const app = createApp();
+    const res = await app.request("/v1/internal/rule-gate-eval", {}, createTestEnv());
+    expect(res.status).toBe(401);
+  });
+
   it("POST /v1/internal/jobs/backfill-contributor-gate-history/run backfills synchronously and honors `limit`; 404 when off (#fairness-analytics)", async () => {
     const app = createApp();
     const env = createTestEnv({ LOOPOVER_FAIRNESS_ANALYTICS: "true" });


### PR DESCRIPTION
## Summary

- `computeRuleGateEval` (`src/review/rule-gate-eval.ts`) is the finer-grained "which rule is broken on which repo" sibling of `computeBlendedRuleGateEval`, but had zero consumers outside its own unit test. Adds `GET /v1/internal/rule-gate-eval` so an operator can actually reach the per-(project, ruleCode) breakdown.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves — `Closes #8906`.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` — not run (no workflow files touched).
- [x] `npm run typecheck` — clean.
- [x] `npm run test:coverage` locally — ran the full suite; see notes below.
- [ ] `npm run test:workers` / `npm run build:mcp` / `npm run test:mcp-pack` / `npm run ui:openapi:check` / `npm run ui:lint` / `npm run ui:typecheck` / `npm run ui:build` — not run; this change touches only `src/api/routes.ts` (a backend route) and a backend integration test, no UI/worker/MCP/OpenAPI-spec surface (confirmed no `/v1/internal/*` route appears in `src/openapi/spec.ts` — internal routes aren't documented there, matching the existing sibling routes this PR mirrors).
- [x] `npm audit --audit-level=moderate` — no new dependencies added.
- [x] New behavior has tests for the new branches (`?days=` present/absent, per-project vs. pooled response shape, 401 without the bearer token).

If any required check was skipped, explain why:

- UI/worker/MCP/OpenAPI checks skipped: this PR's diff is `src/api/routes.ts` (new route only) + `test/integration/api.test.ts` (new tests only) — no UI, Worker entrypoint, MCP package, or OpenAPI spec files changed.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed. (`ruleCode` is not sensitive — unlike a contributor login, which is why the fairness/contributors routes need a detail+summary split and this doesn't.)
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth changes include negative-path tests — new test asserts 401 without the internal bearer token (the route rides the existing shared `/v1/internal/*` middleware; no new auth logic was written).
- [x] API/OpenAPI/MCP behavior is updated and tested where needed — new route has a dedicated test; no OpenAPI registration needed (see above).
- [x] UI changes use live API data or real empty/error/loading states — N/A, no UI changes.
- [ ] UI Evidence — N/A, no visible UI change (backend-only route).

## UI Evidence

N/A — backend-only change, no UI surface touched.

## Notes

- Design choice: the issue's own text offers "a route (or a new operator-dashboard field), following the existing pattern used for the blended view." The blended view's *actual* pattern in `operator-dashboard.ts` only ever surfaces a **derived count** (`rulesBelowClosePrecisionFloor(...).length`), never raw rows — matching that literally would not satisfy the issue's stated goal ("operator can see which specific rule is broken on which specific repo"), since a count alone doesn't identify project/rule pairs. `rule-gate-eval.ts`'s own module header says it "mirrors contributor-gate-eval.ts EXACTLY" — and that sibling module's finer-grained view is already exposed via a dedicated route (`/v1/internal/fairness/contributors/:login`) rather than a dashboard field, precisely because raw per-entity rows need their own reachable endpoint. Since `ruleCode` (unlike a contributor login) carries no privacy concern, the closer and simpler precedent is the unflagged `GET /v1/internal/fleet/analytics` (single route, `?days=`, no detail/summary split) — that's what this PR mirrors.
