### PR TITLE
fix(github): keep public profile when repos JSON parse fails (#8891)

### DIFF
--- a/src/github/public.ts
+++ b/src/github/public.ts
@@ -94,14 +94,30 @@ export async function fetchPublicContributorProfile(login: string, env?: Pick<En
     ]);
     if (!userResponse.ok) throw new Error(`GitHub user lookup failed (${userResponse.status})`);
     const user = (await userResponse.json()) as GitHubUserResponse;
-    const repos: GitHubRepoResponse[] = reposResponse.ok ? ((await reposResponse.json()) as GitHubRepoResponse[]) : [];
-    let linkHeader = reposResponse.ok ? reposResponse.headers.get("link") : null;
+    // Isolate repos-list fetch/parse from the user profile (#8891): an HTTP failure already degraded to
+    // `repos = []` while keeping `user`; a truncated/invalid JSON body previously escaped to the outer catch
+    // and discarded the successfully-parsed user as `source: "unavailable"`.
+    let repos: GitHubRepoResponse[] = [];
+    let linkHeader: string | null = null;
+    if (reposResponse.ok) {
+      try {
+        repos = (await reposResponse.json()) as GitHubRepoResponse[];
+        linkHeader = reposResponse.headers.get("link");
+      } catch {
+        repos = [];
+        linkHeader = null;
+      }
+    }
     for (let page = 2; page <= MAX_REPO_PAGES && linkHeader?.includes('rel="next"'); page += 1) {
       const nextResponse = await fetchWithTimeout(`https://api.github.com/users/${safeLogin}/repos?per_page=100&sort=updated&page=${page}`);
       if (!nextResponse.ok) break;
-      const batch = (await nextResponse.json()) as GitHubRepoResponse[];
-      repos.push(...batch);
-      linkHeader = nextResponse.headers.get("link");
+      try {
+        const batch = (await nextResponse.json()) as GitHubRepoResponse[];
+        repos.push(...batch);
+        linkHeader = nextResponse.headers.get("link");
+      } catch {
+        break;
+      }
     }
     const languageCounts = new Map<string, number>();
     for (const repo of repos) {

--- a/test/unit/adapters.test.ts
+++ b/test/unit/adapters.test.ts
@@ -179,6 +179,72 @@ describe("small adapters and normalizers", () => {
     expect(profile.topLanguages).toContain("Go");
   });
 
+  it("REGRESSION (#8891): a repos-list JSON-parse failure keeps the fetched user and only clears topLanguages", async () => {
+    // HTTP non-ok already degraded this way; a truncated/invalid JSON body after reposResponse.ok previously
+    // discarded the whole profile as source: "unavailable".
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.endsWith("/users/parsefail")) {
+        return Response.json({
+          login: "parsefail",
+          name: "Parse Fail",
+          bio: "still here",
+          company: "Acme",
+          public_repos: 4,
+          followers: 2,
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-02-01T00:00:00Z",
+        });
+      }
+      if (url.includes("/users/parsefail/repos?")) {
+        return new Response("{not-json", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const profile = await fetchPublicContributorProfile("parsefail");
+    expect(profile).toMatchObject({
+      login: "parsefail",
+      name: "Parse Fail",
+      bio: "still here",
+      company: "Acme",
+      publicRepos: 4,
+      followers: 2,
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-02-01T00:00:00Z",
+      topLanguages: [],
+      source: "github",
+    });
+    expect(profile.source).not.toBe("unavailable");
+  });
+
+  it("stops paginating when a later repos page returns unparseable JSON (#8891)", async () => {
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.endsWith("/users/pageparse")) return Response.json({ login: "pageparse", public_repos: 200 });
+      if (url.includes("/pageparse/repos?") && !url.includes("page=2")) {
+        return Response.json(
+          Array.from({ length: 100 }, () => ({ language: "Go" })),
+          { headers: { link: '<https://api.github.com/users/pageparse/repos?page=2>; rel="next"' } },
+        );
+      }
+      if (url.includes("/pageparse/repos?") && url.includes("page=2")) {
+        return new Response("{truncated", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const profile = await fetchPublicContributorProfile("pageparse");
+    expect(profile.source).toBe("github");
+    expect(profile.topLanguages).toContain("Go");
+  });
+
   it("authenticates public profile requests with GITHUB_PUBLIC_TOKEN to lift the rate ceiling (#790)", async () => {
     const authHeaders: Array<string | null> = [];
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {


### PR DESCRIPTION

## Summary

- Closes #8891
- Catches repos-list JSON parse failures separately from the user fetch so already-parsed profile fields survive with `topLanguages: []` and `source: "github"` — matching the existing HTTP non-ok degrade path.
- Also stops pagination cleanly if a later repos page returns unparseable JSON (keeps page-1 languages).
- Adds regression coverage in `test/unit/adapters.test.ts`.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npx vitest run test/unit/adapters.test.ts` — 11 passed
- [x] CI-scoped Codecov simulation: `npx vitest run --changed=origin/main --coverage.all=false --coverage && npx diff-cover coverage/lcov.info --compare-branch=origin/main` — **100%** patch lines (13/13) and **100%** patch branches (2/2) on `src/github/public.ts`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

Narrow `src/github/public.ts` fix; full `test:ci` left for the opener before push. Targeted adapters tests cover the new catch paths (first-page parse + later-page parse).

## Notes for reviewers / gate

- No secrets, wallets, hotkeys, trust scores, or reward values.
- Does not touch `site/`, `CNAME`, `**/lovable/**`, or `CHANGELOG.md`.
- No UI Evidence (backend-only).
