### PR TITLE
fix(db): add eight latest-only signal_snapshots types to retention dedupe

### DIFF
--- a/src/db/retention.ts
+++ b/src/db/retention.ts
@@ -118,6 +118,18 @@ export const LATEST_ONLY_SIGNAL_SNAPSHOT_TYPES = [
   "contributor-evidence-graph",
   "contributor-outcome-history",
   "contributor-strategy",
+  // #8900: these eight writers also INSERT a fresh row every run (persistSignalSnapshot is not an
+  // upsert) while every consumer reads only index [0] / the latest row — same latest-only contract as
+  // the repo-* and contributor-intelligence types above. queue-health stays EXCLUDED (feeds
+  // buildQueueTrendReport as a real series).
+  "config-quality",
+  "label-audit",
+  "maintainer-lane",
+  "maintainer-cut-readiness",
+  "contributor-intake-health",
+  "issue-quality",
+  "repo-outcome-patterns",
+  "pr-reviewability",
 ] as const;
 
 /**

--- a/test/unit/retention.test.ts
+++ b/test/unit/retention.test.ts
@@ -201,6 +201,39 @@ describe("dedupeSignalSnapshots", () => {
     expect(ids).toContain("pack-2");
   });
 
+  it("dedupes the eight latest-only signal types added in #8900 to one row per repo", async () => {
+    const env = createTestEnv();
+    const types = [
+      "config-quality",
+      "label-audit",
+      "maintainer-lane",
+      "maintainer-cut-readiness",
+      "contributor-intake-health",
+      "issue-quality",
+      "repo-outcome-patterns",
+      "pr-reviewability",
+    ] as const;
+    for (const signalType of types) {
+      await insertSignalSnapshot(env, `${signalType}-old`, signalType, "JSONbored/loopover", "2026-07-01T00:00:00.000Z");
+      await insertSignalSnapshot(env, `${signalType}-mid`, signalType, "JSONbored/loopover", "2026-07-02T00:00:00.000Z");
+      await insertSignalSnapshot(env, `${signalType}-new`, signalType, "JSONbored/loopover", "2026-07-03T00:00:00.000Z");
+      await insertSignalSnapshot(env, `${signalType}-other`, signalType, "other/repo", "2026-07-03T00:00:00.000Z");
+    }
+
+    const results = await dedupeSignalSnapshots(env);
+    const byType = Object.fromEntries(results.map((r) => [r.signalType, r.deleted]));
+    for (const signalType of types) {
+      expect(byType[signalType]).toBe(2); // old + mid deleted; new kept; other/repo untouched
+      expect(await countSignalSnapshots(env, signalType)).toBe(2); // latest for loopover + other/repo
+    }
+    const remaining = await env.DB.prepare("SELECT id FROM signal_snapshots ORDER BY id").all<{ id: string }>();
+    const ids = (remaining.results ?? []).map((row) => row.id);
+    expect(ids).toContain("pr-reviewability-new");
+    expect(ids).toContain("pr-reviewability-other");
+    expect(ids).not.toContain("pr-reviewability-old");
+    expect(ids).not.toContain("pr-reviewability-mid");
+  });
+
   it("dedupes private and public focus-manifest cache snapshots (regression for storage exhaustion)", async () => {
     const env = createTestEnv();
     await insertSignalSnapshot(env, "private-old", REPO_FOCUS_MANIFEST_SIGNAL, "JSONbored/loopover", "2026-06-01T00:00:00.000Z");


### PR DESCRIPTION
## Summary

- Add eight latest-only-consumed signal types to `LATEST_ONLY_SIGNAL_SNAPSHOT_TYPES`: `config-quality`, `label-audit`, `maintainer-lane`, `maintainer-cut-readiness`, `contributor-intake-health`, `issue-quality`, `repo-outcome-patterns`, `pr-reviewability`.
- Extend the `dedupeSignalSnapshots` harness so each of the eight types collapses N stale rows to 1 per repo (other repos preserved).

Closes #8900

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Full suite / typecheck / UI / MCP not re-run locally (Node 24 vs engines Node 22). Change is the exported `LATEST_ONLY_SIGNAL_SNAPSHOT_TYPES` list plus a dedicated `dedupeSignalSnapshots` unit test covering all 8 types; CI is source of truth.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — no visible UI changes.

## Notes

- Same retention pattern as the existing repo-* / contributor-intelligence latest-only entries; `queue-health` remains excluded as a real historical series.