### PR TITLE
fix(miner): fall back to global config.apiUrl in loopoverApiUrl

### DIFF
--- a/packages/loopover-miner/lib/github-token-resolution.ts
+++ b/packages/loopover-miner/lib/github-token-resolution.ts
@@ -30,6 +30,9 @@ type LoopoverConfigProfile = {
 type LoopoverConfig = {
   activeProfile?: unknown;
   profiles?: Record<string, LoopoverConfigProfile | undefined>;
+  // #8854: a top-level/global apiUrl, mirroring loopover-mcp's config shape — the fallback the miner's
+  // hand-copied resolver previously skipped (it read only the per-profile apiUrl).
+  apiUrl?: unknown;
 };
 
 const DEFAULT_API_URL = "https://api.loopover.ai";
@@ -85,10 +88,15 @@ function loopoverSessionToken(env: NodeJS.ProcessEnv): string | null {
 
 function loopoverApiUrl(env: NodeJS.ProcessEnv): string {
   if (env.LOOPOVER_API_URL) return env.LOOPOVER_API_URL.replace(/\/+$/, "");
-  const profileApiUrl = activeLoopoverProfile(env).apiUrl;
-  if (typeof profileApiUrl === "string" && profileApiUrl.trim()) {
-    const normalized = profileApiUrl.replace(/\/+$/, "");
-    if (!LEGACY_DEFAULT_API_URLS.has(normalized)) return normalized;
+  // #8854: mirror loopover-mcp's `activeProfile.apiUrl ?? config.apiUrl ?? default` — try the active profile's
+  // apiUrl first, THEN the top-level/global config.apiUrl, before the hardcoded default. The miner previously
+  // read only the profile apiUrl, so a config that set apiUrl globally fell straight to the default. Reuses the
+  // existing activeLoopoverProfile()/loadLoopoverConfig() readers (no new profile-selection branch here).
+  for (const candidate of [activeLoopoverProfile(env).apiUrl, loadLoopoverConfig(env).apiUrl]) {
+    if (typeof candidate === "string" && candidate.trim()) {
+      const normalized = candidate.replace(/\/+$/, "");
+      if (!LEGACY_DEFAULT_API_URLS.has(normalized)) return normalized;
+    }
   }
   return DEFAULT_API_URL;
 }

--- a/test/unit/miner-github-token-resolution.test.ts
+++ b/test/unit/miner-github-token-resolution.test.ts
@@ -134,6 +134,34 @@ describe("resolveGitHubToken (#6116)", () => {
     expect(capturedUrl).toBe("https://api.loopover.ai/v1/auth/github/token");
   });
 
+  it("falls back to the top-level/global config.apiUrl when the active profile has none (#8854)", async () => {
+    dir = mkdtempSync(join(tmpdir(), "loopover-miner-github-token-global-apiurl-"));
+    // apiUrl set globally (not per-profile); trailing slash proves normalization runs on the global branch too.
+    writeConfig(dir, { apiUrl: "https://global.example/", profiles: { default: { session: { token: "session-token" } } } });
+    let capturedUrl: string | undefined;
+    const fetchImpl = async (url: string) => {
+      capturedUrl = url;
+      return Response.json({ token: "live-token" });
+    };
+    await resolveGitHubToken(configuredEnv(dir), { fetchImpl });
+    expect(capturedUrl).toBe("https://global.example/v1/auth/github/token");
+  });
+
+  it("prefers the active profile's apiUrl over the global config.apiUrl (#8854)", async () => {
+    dir = mkdtempSync(join(tmpdir(), "loopover-miner-github-token-profile-over-global-"));
+    writeConfig(dir, {
+      apiUrl: "https://global.example",
+      profiles: { default: { apiUrl: "https://profile.example", session: { token: "session-token" } } },
+    });
+    let capturedUrl: string | undefined;
+    const fetchImpl = async (url: string) => {
+      capturedUrl = url;
+      return Response.json({ token: "live-token" });
+    };
+    await resolveGitHubToken(configuredEnv(dir), { fetchImpl });
+    expect(capturedUrl).toBe("https://profile.example/v1/auth/github/token");
+  });
+
   it("treats a legacy default API URL stored in the profile as absent, falling through to the current default", async () => {
     dir = mkdtempSync(join(tmpdir(), "loopover-miner-github-token-legacy-url-"));
     writeConfig(dir, { profiles: { default: { apiUrl: "https://gittensory-api.zeronode.workers.dev", session: { token: "session-token" } } } });


### PR DESCRIPTION
## What

`packages/loopover-miner/lib/github-token-resolution.ts`'s `loopoverApiUrl()` is a hand-maintained
copy of `loopover-mcp`'s config resolution (the file's own header says so — there is no shared
module). But it diverged: `loopover-mcp` falls back `activeProfile.apiUrl ?? config.apiUrl ?? default`
(a top-level/global `apiUrl`), while the miner read **only** the active profile's `apiUrl` and then
went straight to the hardcoded `DEFAULT_API_URL`. A config that set `apiUrl` globally (not per-profile)
was silently ignored by the miner.

## Change

- Add the top-level `apiUrl?` to the `LoopoverConfig` type (mirrors `loopover-mcp`'s config shape).
- `loopoverApiUrl()` now tries the active profile's `apiUrl` **then** the global `config.apiUrl` before
  the default, applying the same trim + trailing-slash normalization + legacy-URL rejection to both.

`LOOPOVER_API_URL` env override still wins first; behavior when neither a profile nor a global apiUrl
is set is unchanged (still the default).

## Validation

- New tests in `test/unit/miner-github-token-resolution.test.ts`: the global `config.apiUrl` is used
  when the profile has none (with trailing-slash normalization), and the profile's `apiUrl` takes
  precedence over the global one.
- `npx vitest run test/unit/miner-github-token-resolution.test.ts` → 30/30 pass; 100% coverage on the
  new resolution branch (lcov-verified).

Closes #8854
