### PR TITLE
fix(engine): warn on out-of-range self-plagiarism similarityThreshold

### DIFF
--- a/packages/loopover-engine/src/miner-goal-spec.ts
+++ b/packages/loopover-engine/src/miner-goal-spec.ts
@@ -255,18 +255,22 @@ function normalizeSelfPlagiarismPolicy(
     warnings.push(`MinerGoalSpec field "${field}" must be a mapping; falling back to defaults.`);
     return fallback;
   }
-  const resolved = resolveSelfPlagiarismConfig(value);
   const record = value as Record<string, unknown>;
-  if (
-    record.similarityThreshold !== undefined &&
-    typeof record.similarityThreshold !== "number"
-  ) {
-    warnings.push(
-      `MinerGoalSpec field "${field}.similarityThreshold" must be a number; falling back to ${fallback.similarityThreshold}.`,
-    );
-    return fallback;
+  if (record.similarityThreshold !== undefined) {
+    if (typeof record.similarityThreshold !== "number" || !Number.isFinite(record.similarityThreshold)) {
+      warnings.push(
+        `MinerGoalSpec field "${field}.similarityThreshold" must be a number; falling back to ${fallback.similarityThreshold}.`,
+      );
+      return fallback;
+    }
+    if (record.similarityThreshold < 0 || record.similarityThreshold > 1) {
+      warnings.push(
+        `MinerGoalSpec field "${field}.similarityThreshold" must be between 0 and 1; falling back to ${fallback.similarityThreshold}.`,
+      );
+      return fallback;
+    }
   }
-  return resolved;
+  return resolveSelfPlagiarismConfig(value);
 }
 
 function normalizeKillSwitchPolicy(

--- a/packages/loopover-engine/test/miner-goal-spec-parser.test.ts
+++ b/packages/loopover-engine/test/miner-goal-spec-parser.test.ts
@@ -215,6 +215,36 @@ test("parseMinerGoalSpec: malformed fields fall back independently with targeted
   assert.match(warningText, /truncated an over-long entry/i);
 });
 
+test("parseMinerGoalSpec: selfPlagiarism.similarityThreshold out of [0,1] warns and falls back (#8862)", () => {
+  const tooHigh = parseMinerGoalSpec({
+    wantedPaths: ["src/**"],
+    selfPlagiarism: { similarityThreshold: 5 },
+  });
+  assert.deepEqual(tooHigh.spec.selfPlagiarism, { similarityThreshold: 0.85 });
+  assert.match(tooHigh.warnings.join(" "), /selfPlagiarism\.similarityThreshold.*between 0 and 1/i);
+
+  const tooLow = parseMinerGoalSpec({
+    wantedPaths: ["src/**"],
+    selfPlagiarism: { similarityThreshold: -1 },
+  });
+  assert.deepEqual(tooLow.spec.selfPlagiarism, { similarityThreshold: 0.85 });
+  assert.match(tooLow.warnings.join(" "), /selfPlagiarism\.similarityThreshold.*between 0 and 1/i);
+
+  const nonFinite = parseMinerGoalSpec({
+    wantedPaths: ["src/**"],
+    selfPlagiarism: { similarityThreshold: Number.NaN },
+  });
+  assert.deepEqual(nonFinite.spec.selfPlagiarism, { similarityThreshold: 0.85 });
+  assert.match(nonFinite.warnings.join(" "), /selfPlagiarism\.similarityThreshold.*must be a number/i);
+
+  const valid = parseMinerGoalSpec({
+    wantedPaths: ["src/**"],
+    selfPlagiarism: { similarityThreshold: 0.9 },
+  });
+  assert.deepEqual(valid.spec.selfPlagiarism, { similarityThreshold: 0.9 });
+  assert.deepEqual(valid.warnings, []);
+});
+
 test("parseMinerGoalSpec: unknown-only or default-only content stays absent with a fallback warning", () => {
   const unknownOnly = parseMinerGoalSpec({ mystery: true });
   assert.equal(unknownOnly.present, false);


### PR DESCRIPTION
## Summary

- `normalizeSelfPlagiarismPolicy` now warns and falls back to the default threshold when `similarityThreshold` is non-finite or outside `[0,1]`, matching sibling normalizers instead of silently clamping via `resolveSelfPlagiarismConfig`.
- Add parser tests for `5`, `-1`, `NaN`, and a valid `0.9` threshold.

Closes #8862

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm --workspace @loopover/engine run build`
- [x] `node --test dist-test/miner-goal-spec-parser.test.js` (18 passed)
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Engine package-local build + parser suite cover the change. Full monorepo typecheck/coverage not re-run locally.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — engine MinerGoalSpec normalizer only; no UI surface change.

## Notes

-