### PR TITLE
fix(engine): align no-preference miner lane-fit score to 0.5

### DIFF
--- a/packages/loopover-engine/src/miner-goal-lane-fit.ts
+++ b/packages/loopover-engine/src/miner-goal-lane-fit.ts
@@ -36,7 +36,8 @@ export function computeMinerGoalLaneFit(
 
   let score: number;
   if (preferred.length === 0) {
-    score = 1;
+    // Match computeLaneFit's documented neutral: no preference configured → 0.5, never 0 or 1 (#8870).
+    score = 0.5;
   } else {
     const preferredMatch = preferred.some((want) => issueLabels.includes(want));
     if (preferredMatch) {

--- a/packages/loopover-engine/test/miner-goal-lane-fit.test.ts
+++ b/packages/loopover-engine/test/miner-goal-lane-fit.test.ts
@@ -9,8 +9,8 @@ test("isMinerRepoTargetable respects minerEnabled opt-out", () => {
   assert.equal(isMinerRepoTargetable({ ...DEFAULT_MINER_GOAL_SPEC, minerEnabled: false }), false);
 });
 
-test("computeMinerGoalLaneFit returns 1 when no preferred labels are configured", () => {
-  assert.equal(computeMinerGoalLaneFit({ labels: ["docs"] }, DEFAULT_MINER_GOAL_SPEC), 1);
+test("computeMinerGoalLaneFit returns 0.5 when no preferred labels are configured (#8870)", () => {
+  assert.equal(computeMinerGoalLaneFit({ labels: ["docs"] }, DEFAULT_MINER_GOAL_SPEC), 0.5);
 });
 
 test("computeMinerGoalLaneFit matches preferred labels case-insensitively", () => {
@@ -39,7 +39,7 @@ test("computeMinerGoalLaneFit applies issueDiscoveryPolicy modifiers", () => {
 test("computeMinerGoalLaneFit returns 0 when a blocked label matches case-insensitively", () => {
   const spec = { ...DEFAULT_MINER_GOAL_SPEC, blockedLabels: ["wontfix"] };
   assert.equal(computeMinerGoalLaneFit({ labels: ["WontFix"] }, spec), 0);
-  assert.equal(computeMinerGoalLaneFit({ labels: ["bug"] }, spec), 1);
+  assert.equal(computeMinerGoalLaneFit({ labels: ["bug"] }, spec), 0.5);
 });
 
 test("computeMinerGoalLaneFit ignores malformed label entries safely", () => {

--- a/test/unit/miner-goal-lane-fit.test.ts
+++ b/test/unit/miner-goal-lane-fit.test.ts
@@ -89,7 +89,15 @@ describe("computeMinerGoalLaneFit", () => {
     expect(computeMinerGoalLaneFit({ labels: ["feature"] }, spec)).toBe(0.25);
   });
 
-  it("scores normally when no blocked labels are configured", () => {
-    expect(computeMinerGoalLaneFit({ labels: ["docs"] }, DEFAULT_MINER_GOAL_SPEC)).toBe(1);
+  it("scores a neutral 0.5 when no preferred labels are configured (#8870)", () => {
+    expect(computeMinerGoalLaneFit({ labels: ["docs"] }, DEFAULT_MINER_GOAL_SPEC)).toBe(0.5);
+  });
+
+  it("still applies the encouraged floor when no preferred labels are configured", () => {
+    const encouraged = {
+      ...DEFAULT_MINER_GOAL_SPEC,
+      issueDiscoveryPolicy: "encouraged" as const,
+    };
+    expect(computeMinerGoalLaneFit({ labels: ["docs"] }, encouraged)).toBe(0.85);
   });
 });


### PR DESCRIPTION
## Summary

- Align `computeMinerGoalLaneFit`'s empty-`preferredLabels` branch to return `0.5`, matching `computeLaneFit`'s documented neutral score (#8870).
- Update package + root vitest assertions (including the encouraged floor still applying via `Math.max(0.5, 0.85)`).

Closes #8870

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npx vitest run test/unit/miner-goal-lane-fit.test.ts` (9 passed)
- [x] `npm --workspace @loopover/engine run build` + `node --test dist-test/miner-goal-lane-fit.test.js` (10 passed)
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Focused engine lane-fit change with vitest + package tests. Full monorepo typecheck/coverage not re-run locally.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — engine scoring helper only; no UI surface change.

## Notes

-