### PR TITLE
fix(services): warn when contributor evidence-graph outcomes are capped

### DIFF
--- a/src/services/contributor-evidence-graph.ts
+++ b/src/services/contributor-evidence-graph.ts
@@ -270,6 +270,7 @@ export function buildContributorEvidenceGraph(args: ContributorEvidenceGraphInpu
     ...(reposCapped ? [`Evidence graph repo relationships capped at ${CONTRIBUTOR_EVIDENCE_GRAPH_MAX_REPOS}.`] : []),
     ...(labels.length < allLabels.length ? [`Evidence graph label relationships capped at ${CONTRIBUTOR_EVIDENCE_GRAPH_MAX_LABELS}.`] : []),
     ...(paths.length < allPaths.length ? [`Evidence graph path relationships capped at ${CONTRIBUTOR_EVIDENCE_GRAPH_MAX_PATHS}.`] : []),
+    ...(outcomes.length < allOutcomes.length ? [`Evidence graph outcome relationships capped at ${CONTRIBUTOR_EVIDENCE_GRAPH_MAX_OUTCOMES}.`] : []),
   ];
 
   const sources = buildSources(generatedAt, args.profile, args.gittensorSnapshot, repoNodes, labels, paths, outcomes);

--- a/test/unit/contributor-evidence-graph.test.ts
+++ b/test/unit/contributor-evidence-graph.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildContributorEvidenceGraph,
   CONTRIBUTOR_EVIDENCE_GRAPH_MAX_LABELS,
+  CONTRIBUTOR_EVIDENCE_GRAPH_MAX_OUTCOMES,
   CONTRIBUTOR_EVIDENCE_GRAPH_MAX_PATHS,
   CONTRIBUTOR_EVIDENCE_GRAPH_MAX_REPOS,
   evidenceGraphTouchedRepoFullNames,
@@ -473,6 +474,30 @@ describe("contributor evidence graph", () => {
     expect(graphA.warnings).toEqual(
       expect.arrayContaining([expect.stringContaining("repo relationships capped"), expect.stringContaining("label relationships capped"), expect.stringContaining("path relationships capped")]),
     );
+  });
+
+  it("warns when outcome relationships exceed the max-outcomes cap (#8887)", () => {
+    const repoFullName = "owner/outcomes-cap";
+    // Multiple outcome rows for one included repo — buildOutcomeEdges does not dedupe by repo, so the
+    // outcomes slice can exceed MAX_OUTCOMES even when repos stay under MAX_REPOS.
+    const manyOutcomes = Array.from({ length: CONTRIBUTOR_EVIDENCE_GRAPH_MAX_OUTCOMES + 1 }, (_, index) =>
+      outcome(repoFullName, { pullRequests: index + 1, openPullRequests: 1, lane: index % 2 === 0 ? "direct_pr" : "issue_linked" }),
+    );
+    const graph = buildContributorEvidenceGraph({
+      login: "dev",
+      generatedAt: GENERATED_AT,
+      profile: profile({
+        registeredRepoActivity: { pullRequests: 1, mergedPullRequests: 0, issues: 0, reposTouched: [repoFullName], dominantLabels: [] },
+      }),
+      outcomeHistory: history(manyOutcomes),
+      roleContexts: [role(repoFullName)],
+      repositories: [repo(repoFullName)],
+      pullRequests: [pr(repoFullName, 1)],
+      pullRequestFiles: [],
+    });
+
+    expect(graph.outcomes).toHaveLength(CONTRIBUTOR_EVIDENCE_GRAPH_MAX_OUTCOMES);
+    expect(graph.warnings).toEqual(expect.arrayContaining([expect.stringContaining("outcome relationships capped")]));
   });
 
   it("selects only registered touched repos for bounded path-cache loading", () => {


### PR DESCRIPTION
## Summary

- Add an outcomes-cap warning to `buildContributorEvidenceGraph`, matching the existing repos/labels/paths pattern.
- Cover the new branch with a fixture that exceeds `CONTRIBUTOR_EVIDENCE_GRAPH_MAX_OUTCOMES` and asserts the warning.

Closes #8887

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Full suite not re-run locally (Node 24 vs engines Node 22). Diff is one warning branch plus a dedicated unit test; CI is source of truth.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — no visible UI changes.

## Notes

-