### PR TITLE
fix(engine): dedup provider-track-record aggregation per provider+target

### DIFF
--- a/packages/loopover-engine/src/calibration/provider-track-record.ts
+++ b/packages/loopover-engine/src/calibration/provider-track-record.ts
@@ -100,9 +100,17 @@ export function computeProviderTrackRecords(
     stances.set(signal.provider, signal.vote === "fail");
   }
 
+  // #8876: collapse repeated (provider, targetKey) signals to the LATEST one before aggregating. A provider
+  // re-reviewing the same PR (common after a new push) emits another audit row, and loadLiveProviderTrackRecords
+  // reads raw rows with no dedup — so iterating `signals` directly counted signals/decided/shared/consensus once
+  // per row rather than once per distinct (provider, targetKey) pair, inflating that provider's precision and
+  // agreement stats. Keep the last row per pair, matching stancesByTarget's own latest-vote `.set` dedup above.
+  const latestByProviderTarget = new Map<string, ProviderReviewSignal>();
+  for (const signal of signals) latestByProviderTarget.set(`${signal.provider} ${signal.targetKey}`, signal);
+
   const perRepo = new Map<string, Map<string, MutableStats>>(); // provider → repo → stats
   const overall = new Map<string, MutableStats>();
-  for (const signal of signals) {
+  for (const signal of latestByProviderTarget.values()) {
     let repos = perRepo.get(signal.provider);
     if (repos === undefined) {
       repos = new Map();

--- a/test/unit/provider-track-record-engine.test.ts
+++ b/test/unit/provider-track-record-engine.test.ts
@@ -63,6 +63,22 @@ describe("computeProviderTrackRecords (#8228)", () => {
     expect(aRepo).toMatchObject({ signals: aOverall.signals, decided: aOverall.decided, precision: aOverall.precision });
   });
 
+  // #8876: a provider re-reviewing the same PR (a second audit row after a push) must count ONCE per
+  // (provider, targetKey), scored on the LATEST vote — not inflate its signals/precision/agreement per raw row.
+  it("collapses a provider's repeated same-target signals to the latest, not double-counting (#8876)", () => {
+    const records = computeProviderTrackRecords(
+      [
+        signal("solo", "acme/widgets#1", "pass"), // first review
+        signal("solo", "acme/widgets#1", "fail"), // re-review after a new push — the latest vote wins
+      ],
+      [labeled("acme/widgets#1", "confirmed")],
+    );
+    const overall = records.find((r) => r.provider === "solo" && r.repoFullName === null)!;
+    // Before the fix this was signals: 2 / agreementRate: 0.5 (both raw rows counted); now one distinct pair,
+    // scored on the latest fail vote against the confirmed firing.
+    expect(overall).toMatchObject({ signals: 1, decided: 1, confirmed: 1, precision: 1, agreementRate: 1 });
+  });
+
   it("keeps a one-provider corpus's consensus/split rates null — no shared targets, no consensus to measure", () => {
     const records = computeProviderTrackRecords(
       [signal("solo", "acme/widgets#1", "fail"), signal("solo", "acme/widgets#2", "pass")],


### PR DESCRIPTION
## What

`computeProviderTrackRecords`
(`packages/loopover-engine/src/calibration/provider-track-record.ts`) builds a `stancesByTarget`
map that correctly collapses multiple same-provider signals for one `targetKey` to the latest vote,
but the main aggregation loop then iterated the **raw** `signals` array — incrementing
`signals`/`decided`/`shared`/`consensus`/`agreed` once per raw row rather than once per distinct
`(provider, targetKey)` pair. Since the real caller `loadLiveProviderTrackRecords` reads raw
audit-event rows with no dedup, a provider re-reviewing the same PR (common after a new push) had its
precision and agreement stats inflated proportionally to how many times it re-reviewed.

## Change

Collapse repeated `(provider, targetKey)` signals to the **latest** row before aggregating (a
`Map` keyed by `provider + targetKey`, keeping the last-seen row — matching `stancesByTarget`'s own
latest-vote `.set` dedup), then iterate that deduped set. One distinct pair counts once, scored on
its latest vote.

## Validation

- New test in `test/unit/provider-track-record-engine.test.ts` (imports the engine source, so Codecov
  grades it): a provider with two rows for the same target (`pass` then a re-review `fail`) now
  produces `signals: 1` scored on the latest `fail` vote — was `signals: 2` / `agreementRate: 0.5`
  before. Existing multi-provider consensus/split/precision assertions are unaffected.
- `npx vitest run test/unit/provider-track-record-engine.test.ts` → 8/8 pass; 100% line+branch
  coverage on every changed line.

Closes #8876
