### PR TITLE
fix(engine): redact blocklisted terms in chat-grounding tool_result events

### DIFF
--- a/packages/loopover-engine/src/miner/chat-grounding.ts
+++ b/packages/loopover-engine/src/miner/chat-grounding.ts
@@ -235,7 +235,10 @@ function* foldToolResultMessage(message: Record<string, unknown>): Generator<Cha
     const block = asRecord(rawBlock);
     if (!block || block.type !== "tool_result") continue;
     const tool = typeof block.tool_use_id === "string" ? block.tool_use_id : "";
-    yield { type: "tool_result", tool, output: block.content };
+    // Same PUBLIC_FIELD_BLOCKLIST backstop as foldAssistantMessage — MCP tool output is untrusted and must
+    // not leak blocklisted fields into the public chat-grounding stream (#8869).
+    const output = typeof block.content === "string" ? redactBlockedText(block.content) : block.content;
+    yield { type: "tool_result", tool, output };
   }
 }
 

--- a/packages/loopover-engine/test/chat-grounding.test.ts
+++ b/packages/loopover-engine/test/chat-grounding.test.ts
@@ -146,6 +146,24 @@ test("a blocked term in a text chunk is redacted, a clean chunk is forwarded ver
   assert.deepEqual(events, [{ type: "text", text: CHAT_REDACTED_TEXT }, { type: "done" }]);
 });
 
+test("a blocked term in a tool_result string is redacted (#8869)", async () => {
+  const events = await collect(
+    runChatGrounding(USER_ONLY, {
+      env: AGENT_SDK_ENV,
+      query: queryYielding([
+        {
+          type: "user",
+          message: { content: [{ type: "tool_result", tool_use_id: "loopover_miner_status", content: "your trust score is 9" }] },
+        },
+      ]),
+    }),
+  );
+  assert.deepEqual(events, [
+    { type: "tool_result", tool: "loopover_miner_status", output: CHAT_REDACTED_TEXT },
+    { type: "done" },
+  ]);
+});
+
 test("a thrown session becomes an error event still followed by done", async () => {
   const events = await collect(
     runChatGrounding(USER_ONLY, {

--- a/test/unit/chat-grounding-engine.test.ts
+++ b/test/unit/chat-grounding-engine.test.ts
@@ -269,6 +269,43 @@ describe("chat grounding privacy backstop (#6517)", () => {
     );
     expect(events).toEqual([{ type: "text", text: "your run state is idle" }, { type: "done" }]);
   });
+
+  it("redacts a tool_result string containing a blocked term (#8869)", async () => {
+    const events = await collect(
+      runChatGrounding(USER_ONLY, {
+        env: AGENT_SDK_ENV,
+        query: queryYielding([
+          {
+            type: "user",
+            message: { content: [{ type: "tool_result", tool_use_id: "loopover_miner_status", content: "your trust score is 9" }] },
+          },
+        ]),
+      }),
+    );
+    expect(events).toEqual([
+      { type: "tool_result", tool: "loopover_miner_status", output: CHAT_REDACTED_TEXT },
+      { type: "done" },
+    ]);
+  });
+
+  it("forwards a non-string tool_result payload unchanged (#8869)", async () => {
+    const payload = { ok: true, state: "idle" };
+    const events = await collect(
+      runChatGrounding(USER_ONLY, {
+        env: AGENT_SDK_ENV,
+        query: queryYielding([
+          {
+            type: "user",
+            message: { content: [{ type: "tool_result", tool_use_id: "loopover_miner_status", content: payload }] },
+          },
+        ]),
+      }),
+    );
+    expect(events).toEqual([
+      { type: "tool_result", tool: "loopover_miner_status", output: payload },
+      { type: "done" },
+    ]);
+  });
 });
 
 describe("chat message validation + prompt building (#6517)", () => {


### PR DESCRIPTION
## Summary

- Apply the same `PUBLIC_FIELD_BLOCKLIST` redaction used for assistant text chunks to string `tool_result` content in chat-grounding.
- Cover the new path in the vitest suite (codecov) and the mirrored engine `node:test` suite; non-string tool payloads still pass through unchanged.

Closes #8869

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Full suite not re-run locally (Node 24 vs engines Node 22). Diff is one redaction call site plus unit coverage for the string redaction and non-string passthrough branches; CI is source of truth.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — no visible UI changes.

## Notes

- Closes a privacy leak where MCP tool output could forward blocklisted fields into the public chat-grounding stream.