### PR TITLE
fix(engine): key chokepoint ledger paused off kill_switch eventType

### DIFF
--- a/packages/loopover-engine/src/governor/chokepoint.ts
+++ b/packages/loopover-engine/src/governor/chokepoint.ts
@@ -130,7 +130,9 @@ function denyResult(input: {
       eventType: input.eventType,
       repoFullName: input.repoFullName,
       actionClass: input.actionClass,
-      decision: input.stage === "kill_switch" ? "paused" : input.eventType === "throttled" ? "throttle" : "deny",
+      // Key off eventType, not stage: budget-cap termination fires stage "budget_cap" with
+      // eventType "kill_switch" and must still ledger as "paused" (#8864).
+      decision: input.eventType === "kill_switch" ? "paused" : input.eventType === "throttled" ? "throttle" : "deny",
       reason: input.reason,
       payload: { stage: input.stage, ...input.extraPayload },
     },

--- a/packages/loopover-engine/test/chokepoint.test.ts
+++ b/packages/loopover-engine/test/chokepoint.test.ts
@@ -94,6 +94,8 @@ test("budget cap: the termination ceiling denies with a kill_switch eventType (h
   );
   assert.equal(decision.stage, "budget_cap");
   assert.equal(decision.ledgerEvent.eventType, "kill_switch");
+  // eventType (not stage) drives ledger decision — termination is a kill_switch, so "paused" (#8864)
+  assert.equal(decision.ledgerEvent.decision, "paused");
 });
 
 test("non-convergence: a stuck item denies before reputation/self-plagiarism run", () => {

--- a/test/unit/engine-governor-chokepoint-kill-switch-decision.test.ts
+++ b/test/unit/engine-governor-chokepoint-kill-switch-decision.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  evaluateGovernorChokepoint,
+  type GovernorChokepointInput,
+} from "../../packages/loopover-engine/src/governor/chokepoint";
+
+function baseInput(overrides: Partial<GovernorChokepointInput> = {}): GovernorChokepointInput {
+  return {
+    actionClass: "open_pr",
+    repoFullName: "acme/widgets",
+    nowMs: 10_000,
+    wouldBeAction: { action: "open_pr", title: "Fix bug" },
+    killSwitchGlobal: false,
+    killSwitchRepoPaused: false,
+    liveModeGlobalOptIn: true,
+    liveModeRepoOptIn: "live",
+    rateLimitBuckets: { global: {}, perRepo: {} },
+    rateLimitBackoffAttempts: {},
+    capUsage: { budgetSpent: 0, turnsTaken: 0, elapsedMs: 0 },
+    capLimits: { budget: 100, turns: 100, elapsedMs: 1_000_000 },
+    convergenceInput: { attempts: 0, consecutiveFailures: 0, reenqueues: 0, reachedDone: false },
+    ...overrides,
+  };
+}
+
+describe("denyResult ledger decision keys off eventType (#8864)", () => {
+  it("budget-cap termination ceiling ledgers decision paused (kill_switch eventType, budget_cap stage)", () => {
+    const decision = evaluateGovernorChokepoint(
+      baseInput({
+        capUsage: { budgetSpent: 0, turnsTaken: 0, elapsedMs: 2_000_000 },
+        capLimits: { budget: 100, turns: 100, elapsedMs: 1_000_000 },
+      }),
+    );
+    expect(decision.stage).toBe("budget_cap");
+    expect(decision.ledgerEvent.eventType).toBe("kill_switch");
+    expect(decision.ledgerEvent.decision).toBe("paused");
+  });
+
+  it("top-level kill_switch stage still ledgers paused", () => {
+    const decision = evaluateGovernorChokepoint(baseInput({ killSwitchGlobal: true }));
+    expect(decision.stage).toBe("kill_switch");
+    expect(decision.ledgerEvent.eventType).toBe("kill_switch");
+    expect(decision.ledgerEvent.decision).toBe("paused");
+  });
+
+  it("budget-cap soft deny (non-termination) still ledgers deny", () => {
+    const decision = evaluateGovernorChokepoint(
+      baseInput({
+        capUsage: { budgetSpent: 100, turnsTaken: 0, elapsedMs: 0 },
+        capLimits: { budget: 100, turns: 100, elapsedMs: 1_000_000 },
+      }),
+    );
+    expect(decision.stage).toBe("budget_cap");
+    expect(decision.ledgerEvent.eventType).toBe("denied");
+    expect(decision.ledgerEvent.decision).toBe("deny");
+  });
+});


### PR DESCRIPTION
## Summary

- Key `denyResult`'s ledger `decision` ternary off `eventType === kill_switch` instead of `stage === kill_switch`, so budget-cap termination (stage `budget_cap`, eventType `kill_switch`) records `paused` like the top-level kill-switch path.
- Extend the existing termination-ceiling package test to assert `ledgerEvent.decision === paused`, and add a vitest suite that covers the kill-switch / soft-deny / termination branches for codecov patch coverage.

Closes #8864

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Engine-only change: ran `packages/loopover-engine` build + `chokepoint.test.js` (27 pass) and `vitest run test/unit/engine-governor-chokepoint-kill-switch-decision.test.ts` (3 pass). Unrelated UI/MCP/workers/actionlint checks not exercised.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — engine-only governor ledger decision fix; no visible UI.

## Notes

-