### PR TITLE
fix(engine): include experimental and fairnessAnalytics in the manifest preview

### DIFF
--- a/packages/loopover-engine/src/focus-manifest-validation.ts
+++ b/packages/loopover-engine/src/focus-manifest-validation.ts
@@ -16,6 +16,8 @@ import {
   activeReviewReconciliationConfigToJson,
   loopEscalationConfigToJson,
   federatedIntelligenceConfigToJson,
+  experimentalConfigToJson,
+  fairnessAnalyticsConfigToJson,
   settingsOverrideToJson,
   type FocusManifest,
   type FocusManifestSource,
@@ -103,6 +105,10 @@ function focusManifestToNormalizedJson(manifest: FocusManifest): Record<string, 
   if (loopEscalation !== null) normalized.loopEscalation = loopEscalation;
   const federatedIntelligence = federatedIntelligenceConfigToJson(manifest.federatedIntelligence);
   if (federatedIntelligence !== null) normalized.federatedIntelligence = federatedIntelligence;
+  const experimental = experimentalConfigToJson(manifest.experimental);
+  if (experimental !== null) normalized.experimental = experimental;
+  const fairnessAnalytics = fairnessAnalyticsConfigToJson(manifest.fairnessAnalytics);
+  if (fairnessAnalytics !== null) normalized.fairnessAnalytics = fairnessAnalytics;
 
   return normalized;
 }

--- a/test/unit/focus-manifest-validation.test.ts
+++ b/test/unit/focus-manifest-validation.test.ts
@@ -155,6 +155,8 @@ loopEscalation:
     expect(result.normalized).not.toHaveProperty("activeReviewReconciliation");
     expect(result.normalized).not.toHaveProperty("loopEscalation");
     expect(result.normalized).not.toHaveProperty("federatedIntelligence");
+    expect(result.normalized).not.toHaveProperty("experimental");
+    expect(result.normalized).not.toHaveProperty("fairnessAnalytics");
   });
 
   it("includes a configured activeReviewReconciliation block in the normalized settings-preview output (#webhook-reorder-clobber)", () => {
@@ -167,6 +169,18 @@ loopEscalation:
     const result = buildFocusManifestValidation({ content: "federatedIntelligence:\n  enabled: true\n" });
     expect(result.warnings).toEqual([]);
     expect(result.normalized).toMatchObject({ federatedIntelligence: { enabled: true } });
+  });
+
+  it("includes a configured experimental block in the normalized settings-preview output (#8867)", () => {
+    const result = buildFocusManifestValidation({ content: "experimental:\n  gittensor: true\n" });
+    expect(result.warnings).toEqual([]);
+    expect(result.normalized).toMatchObject({ experimental: { gittensor: true } });
+  });
+
+  it("includes a configured fairnessAnalytics block in the normalized settings-preview output (#8867)", () => {
+    const result = buildFocusManifestValidation({ content: "fairnessAnalytics:\n  enabled: true\n" });
+    expect(result.warnings).toEqual([]);
+    expect(result.normalized).toMatchObject({ fairnessAnalytics: { enabled: true } });
   });
 
   it("returns error when manifest content is not a mapping", () => {


### PR DESCRIPTION
## What & why

Closes #8867.

`packages/loopover-engine/src/focus-manifest-validation.ts`'s `focusManifestToNormalizedJson` was
missing the `experimentalConfigToJson`/`fairnessAnalyticsConfigToJson` calls, even though both blocks
carry a `.present` flag like the other 17 wired blocks and `config-lint.ts`'s `TOP_LEVEL_FIELDS`
already lists them (so no "unrecognized field" warning fired). A configured `experimental:` or
`fairnessAnalytics:` block therefore silently never appeared in the `.loopover.yml` validation
preview — the same two-sibling-enumeration-site omission already fixed once for
`federatedIntelligence` (commit `1c80fb84b`).

## Change

Add the two missing serializer calls to `focusManifestToNormalizedJson`, matching the existing
per-block `!== null` pattern used for all 17 other blocks.

## Validation

- New regression tests mirroring the `federatedIntelligence` block: a configured `experimental`
  (`gittensor: true`) and `fairnessAnalytics` (`enabled: true`) block each now appears in the
  normalized preview with no warnings, and both are asserted absent when unconfigured.
- Bug-catch verified: removing the two calls fails exactly the two new assertions.
- 100% patch coverage on both new serializer call sites (present and absent branches).
