### PR TITLE
fix(scoring): skip unmodeled-drift sync on garbage upstream constants bodies

### DIFF
--- a/src/scoring/model.ts
+++ b/src/scoring/model.ts
@@ -134,7 +134,9 @@ export async function refreshScoringModelSnapshot(env: Env): Promise<ScoringMode
     },
   };
   await persistScoringModelSnapshot(env, snapshot);
-  if (constantsResult.ok) {
+  // Only sync unmodeled-constant drift against a usable constants.py body — a 200-with-garbage
+  // response (no valid lastGood) must not open a spurious upstream_drift_reports row (#8902).
+  if (constantsUsable) {
     await syncUnmodeledScoringConstantDrift(env, {
       unmodeledConstants: findUnmodeledUpstreamConstants(constantsResult.value),
       source: { repo: upstream.repo, ref: fetchRef, commitSha: upstreamSourceSha },

--- a/test/unit/scoring.test.ts
+++ b/test/unit/scoring.test.ts
@@ -603,7 +603,12 @@ NOVELTY_BONUS_SCALAR = 3
     const env = createTestEnv();
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
       const url = input.toString();
-      if (url.includes("constants.py")) return new Response("<!DOCTYPE html><html><body>rate limited</body></html>");
+      // HTML garbage that still parses a few IDENT = number lines (or none) — below the recognized floor.
+      // Include a fake "unmodeled" CONSTANT so findUnmodeledUpstreamConstants would fire if the drift
+      // sync still ran on garbage (#8902).
+      if (url.includes("constants.py")) {
+        return new Response("<!DOCTYPE html><html><body>rate limited</body></html>\nFAKE_UNMODELED_CONSTANT = 1\n");
+      }
       if (url.includes("programming_languages.json")) return Response.json({});
       return new Response("not found", { status: 404 });
     });
@@ -611,6 +616,8 @@ NOVELTY_BONUS_SCALAR = 3
     expect(refreshed.sourceKind).toBe("fallback"); // labeled fallback, NOT a deceptive raw-github
     expect(refreshed.warnings.join(" ")).toMatch(/parsed only \d+ recognized constant/i);
     expect(refreshed.constants.MERGED_PR_BASE_SCORE).toBe(25); // the hardcoded default
+    // Guard must check constantsUsable, not merely HTTP-ok — no spurious drift report (#8902).
+    await expect(listUpstreamDriftReports(env)).resolves.toEqual([]);
   });
 
   it("bootstraps to defaults (fallback) on a failed fetch ONLY when there is no verified last-good", async () => {


### PR DESCRIPTION
﻿## Problem

Closes #8902.

`refreshScoringModelSnapshot` correctly fails closed when a 200 `constants.py` body is semantically garbage *and* a verified last-good exists — but with no last-good (first run / prior fallback), execution continues and the drift-sync guard was only `if (constantsResult.ok)`. That still ran `findUnmodeledUpstreamConstants` against HTML/LFS junk and could open a spurious `upstream_drift_reports` row.

## Fix

Gate `syncUnmodeledScoringConstantDrift` on `constantsUsable` (the same recognized-count floor the fail-closed path already uses), not merely HTTP-ok.

## Tests

- Existing no-last-good garbage bootstrap test now asserts `listUpstreamDriftReports` stays empty even when the junk body contains a parseable fake unmodeled constant name.
- Existing real-unmodeled path still opens a drift report (regression).

Reverting the guard fails the empty-reports assertion. `git diff --check` clean.

## Scope

- [x] Conventional Commit title
- [x] Focused change
- [x] Follows CONTRIBUTING.md
- [x] Closes #8902

## Validation

- [x] `git diff --check`
- [x] Targeted vitest for garbage bootstrap + unmodeled scoring dimension paths (2 pass)
- Scoring-only; unrelated UI/MCP checks not exercised.

## Safety

- [x] No secrets / private scores exposed
- [x] No UI changes (N/A evidence)
