### PR TITLE
fix(engine): weight local-scorer totalTokenScore with TEST_FILE_CONTRIBUTION_WEIGHT

### DIFF
--- a/packages/loopover-engine/src/local-scorer.ts
+++ b/packages/loopover-engine/src/local-scorer.ts
@@ -10,6 +10,7 @@
 // definitions. isCodeFile/isTestPath are the same portable classifiers local-branch.ts already delegates to.
 
 import { isCodeFile, isTestPath } from "./signals/test-evidence.js";
+import { DEFAULT_SCORING_CONSTANTS } from "./scoring/model.js";
 
 export type LocalScorerChangedFile = {
   path: string;
@@ -50,8 +51,12 @@ export function computeLocalScorerTokens(input: { changedFiles: LocalScorerChang
   const files = input.changedFiles.filter((file) => !file.binary);
   const testTokenScore = files.filter((file) => isTestPath(file.path)).reduce((sum, file) => sum + fileLines(file), 0);
   const sourceTokenScore = files.filter((file) => isCodeFile(file.path)).reduce((sum, file) => sum + fileLines(file), 0);
-  const totalTokenScore = files.reduce((sum, file) => sum + fileLines(file), 0);
-  const nonCodeTokenScore = Math.max(0, totalTokenScore - sourceTokenScore - testTokenScore);
+  const rawLineTotal = files.reduce((sum, file) => sum + fileLines(file), 0);
+  const nonCodeTokenScore = Math.max(0, rawLineTotal - sourceTokenScore - testTokenScore);
+  // Mirror preview.ts's derivedTotalTokenScore: test lines are discounted by TEST_FILE_CONTRIBUTION_WEIGHT
+  // so feeding this total back as `localScorer.totalTokenScore` does not bypass the gate's own weighting (#8875).
+  const testFileWeight = DEFAULT_SCORING_CONSTANTS.TEST_FILE_CONTRIBUTION_WEIGHT ?? 0.05;
+  const totalTokenScore = sourceTokenScore + testFileWeight * testTokenScore + nonCodeTokenScore;
   const failed = (input.validation ?? []).some((entry) => entry.status === "failed");
   const warnings = failed ? ["Local validation reported failures — token scores describe the diff, not a passing build."] : [];
   return {

--- a/packages/loopover-engine/test/local-scorer.test.ts
+++ b/packages/loopover-engine/test/local-scorer.test.ts
@@ -20,7 +20,8 @@ test("classifies source / test / non-code disjointly from changed-file metadata"
   assert.equal(r.sourceTokenScore, 12);
   assert.equal(r.testTokenScore, 6);
   assert.equal(r.nonCodeTokenScore, 4);
-  assert.equal(r.totalTokenScore, 22);
+  // TEST_FILE_CONTRIBUTION_WEIGHT (0.05): 12 + 0.05*6 + 4 = 16.3 (#8875)
+  assert.equal(r.totalTokenScore, 12 + 0.05 * 6 + 4);
   assert.equal(r.warnings, undefined);
 });
 

--- a/test/unit/local-scorer.test.ts
+++ b/test/unit/local-scorer.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { computeLocalScorerTokens } from "../../src/signals/local-scorer";
+import { DEFAULT_SCORING_CONSTANTS } from "../../packages/loopover-engine/src/scoring/model";
+import { buildScorePreview } from "../../src/scoring/preview";
+import type { RepositoryRecord, ScoringModelSnapshotRecord } from "../../src/types";
+
+const testWeight = DEFAULT_SCORING_CONSTANTS.TEST_FILE_CONTRIBUTION_WEIGHT ?? 0.05;
 
 describe("computeLocalScorerTokens (#782)", () => {
   it("classifies source / test / non-code from metadata and sums additions + deletions", () => {
@@ -16,7 +21,8 @@ describe("computeLocalScorerTokens (#782)", () => {
       sourceTokenScore: 12,
       testTokenScore: 8,
       nonCodeTokenScore: 6,
-      totalTokenScore: 26,
+      // Weighted total mirrors preview.ts (test lines at TEST_FILE_CONTRIBUTION_WEIGHT) (#8875)
+      totalTokenScore: 12 + testWeight * 8 + 6,
       sourceLines: 12,
     });
     expect(scorer.warnings).toBeUndefined();
@@ -70,5 +76,67 @@ describe("computeLocalScorerTokens (#782)", () => {
   it("emits no warning when validation passed or was not supplied", () => {
     expect(computeLocalScorerTokens({ changedFiles: [{ path: "src/a.ts", additions: 1 }], validation: [{ command: "t", status: "passed" }] }).warnings).toBeUndefined();
     expect(computeLocalScorerTokens({ changedFiles: [{ path: "src/a.ts", additions: 1 }] }).warnings).toBeUndefined();
+  });
+
+  it("applies TEST_FILE_CONTRIBUTION_WEIGHT so a test-heavy total agrees with preview.ts (#8875)", () => {
+    const scorer = computeLocalScorerTokens({
+      changedFiles: [
+        { path: "src/a.ts", additions: 20 },
+        { path: "src/a.test.ts", additions: 200 },
+        { path: "README.md", additions: 10 },
+      ],
+    });
+    const expectedWeighted = 20 + testWeight * 200 + 10;
+    expect(scorer.sourceTokenScore).toBe(20);
+    expect(scorer.testTokenScore).toBe(200);
+    expect(scorer.nonCodeTokenScore).toBe(10);
+    expect(scorer.totalTokenScore).toBe(expectedWeighted);
+
+    const repo = {
+      fullName: "acme/widgets",
+      registryConfig: { emissionShare: 0.1, issueDiscoveryShare: 0, labelMultipliers: {}, defaultLabelMultiplier: 1 },
+    } as RepositoryRecord;
+    const snapshot = {
+      id: "snap-1",
+      activeModel: "pending_saturation_model",
+      constants: { ...DEFAULT_SCORING_CONSTANTS },
+      fetchedAt: new Date().toISOString(),
+      sourceKind: "fallback",
+      sourceUrl: "fixture://constants.py",
+      programmingLanguages: {},
+      warnings: [],
+      payload: {},
+    } as ScoringModelSnapshotRecord;
+
+    const withExplicitTotal = buildScorePreview({
+      repo,
+      snapshot,
+      input: {
+        repoFullName: "acme/widgets",
+        sourceTokenScore: scorer.sourceTokenScore,
+        testTokenScore: scorer.testTokenScore,
+        nonCodeTokenScore: scorer.nonCodeTokenScore,
+        totalTokenScore: scorer.totalTokenScore,
+        sourceLines: scorer.sourceLines,
+        openPrCount: 0,
+        credibility: 1,
+      },
+    });
+    const derivedTotal = buildScorePreview({
+      repo,
+      snapshot,
+      input: {
+        repoFullName: "acme/widgets",
+        sourceTokenScore: scorer.sourceTokenScore,
+        testTokenScore: scorer.testTokenScore,
+        nonCodeTokenScore: scorer.nonCodeTokenScore,
+        sourceLines: scorer.sourceLines,
+        openPrCount: 0,
+        credibility: 1,
+      },
+    });
+    // Feeding the weighted local-scorer total must match preview's own derived total path.
+    expect(withExplicitTotal.scoreEstimate.contributionBonus).toBe(derivedTotal.scoreEstimate.contributionBonus);
+    expect(withExplicitTotal.scoreEstimate.estimatedMergedScore).toBe(derivedTotal.scoreEstimate.estimatedMergedScore);
   });
 });

--- a/test/unit/mcp-run-local-scorer.test.ts
+++ b/test/unit/mcp-run-local-scorer.test.ts
@@ -28,7 +28,7 @@ describe("MCP loopover_run_local_scorer (#782)", () => {
     });
     expect(result.isError).toBeFalsy();
     const data = result.structuredContent as { tokenScores: { mode: string; sourceTokenScore: number; testTokenScore: number; nonCodeTokenScore: number; totalTokenScore: number }; usage: string };
-    expect(data.tokenScores).toMatchObject({ mode: "external_command", sourceTokenScore: 12, testTokenScore: 8, nonCodeTokenScore: 5, totalTokenScore: 25 });
+    expect(data.tokenScores).toMatchObject({ mode: "external_command", sourceTokenScore: 12, testTokenScore: 8, nonCodeTokenScore: 5, totalTokenScore: 12 + 0.05 * 8 + 5 });
     expect(data.usage).toMatch(/localScorer/);
     expect(JSON.stringify(data)).not.toMatch(/wallet|hotkey|reward|payout|trust score/i);
   });


### PR DESCRIPTION
﻿## Problem

Closes #8875.

`computeLocalScorerTokens` returned a raw unweighted line sum as `totalTokenScore`. When that value is fed back into `buildScorePreview` as an explicit total, preview honors it as-is and skips the `TEST_FILE_CONTRIBUTION_WEIGHT` (0.05×) discount it applies when deriving its own total — so a test-heavy local scorer preview over-counts test lines in the contribution-bonus ramp.

Re-filed after #8970: this repo is one-shot (follow-up commits auto-close). This PR includes the weight fix and the TS18048 `?? 0.05` typecheck narrowing in a single commit.

## Fix

Compute `totalTokenScore` as `source + TEST_FILE_CONTRIBUTION_WEIGHT * test + nonCode`, matching `preview.ts`'s `derivedTotalTokenScore`, using the shared `DEFAULT_SCORING_CONSTANTS` constant.

## Tests

- Existing classification fixtures updated to expect the weighted total.
- New test-heavy fixture: local-scorer total equals the weighted formula, and feeding that total into `buildScorePreview` matches the derived-total path for contribution bonus / estimated merged score.
- MCP `loopover_run_local_scorer` expectation updated.
- Test reads the weight with `?? 0.05` so `Record<string, number>` indexing typechecks cleanly.

Reverting the weight fails the agreement test. `git diff --check` clean.

## Scope

- [x] Conventional Commit title
- [x] Focused change
- [x] Follows CONTRIBUTING.md
- [x] Closes #8875

## Validation

- [x] `git diff --check`
- [x] `vitest run test/unit/local-scorer.test.ts` (7 pass)
- [x] `vitest run test/unit/mcp-run-local-scorer.test.ts` (2 pass)
- Engine/scorer-only; unrelated UI/workers checks not exercised.

## Safety

- [x] No secrets / private scores exposed
- [x] No UI changes (N/A evidence)
