### PR TITLE
fix(engine): capture cost/token usage on the CLI driver's failure paths

### DIFF
--- a/packages/loopover-engine/src/miner/cli-subprocess-driver.ts
+++ b/packages/loopover-engine/src/miner/cli-subprocess-driver.ts
@@ -277,6 +277,17 @@ export function createCliSubprocessCodingAgentDriver(options: CliSubprocessDrive
       });
       const transcript = redactSecrets(spawned.stdout, knownSecrets).slice(0, MAX_TRANSCRIPT_CHARS);
 
+      // The JSON usage envelope is present on every result, success or not (a failed-but-billed attempt — e.g. a
+      // mid-session API error — still carries real cost/token usage). Extract it once here so the failure branches
+      // below report spend symmetrically with the success path and with agent-sdk-driver.ts, preventing
+      // attempt-metering budget-ceiling undercounting (#8871). extractCliUsage tolerates unparseable/empty stdout.
+      const usage = extractCliUsage(spawned.stdout);
+      const tokensUsed = totalTokensFromUsage(usage);
+      const usageFields = {
+        ...(usage.costUsd !== undefined ? { costUsd: usage.costUsd } : {}),
+        ...(tokensUsed !== undefined ? { tokensUsed } : {}),
+      };
+
       if (spawned.timedOut && spawned.stalledNoOutput) {
         // Fast-fail path (#4994/#5053): killed at firstOutputTimeoutMs, well before the full timeoutMs, because
         // stdout produced no bytes at all. A distinct error (never reusing `${command}_timeout_...`) so this
@@ -288,6 +299,7 @@ export function createCliSubprocessCodingAgentDriver(options: CliSubprocessDrive
           summary: `${options.command} stalled with no stdout within ${options.firstOutputTimeoutMs}ms`,
           transcript,
           error: `${options.command}_stalled_no_output`,
+          ...usageFields,
         };
       }
       if (spawned.timedOut) {
@@ -297,6 +309,7 @@ export function createCliSubprocessCodingAgentDriver(options: CliSubprocessDrive
           summary: `${options.command} timed out after ${timeoutMs}ms`,
           transcript,
           error: `${options.command}_timeout_${timeoutMs}ms`,
+          ...usageFields,
         };
       }
       if (spawned.code !== 0) {
@@ -309,6 +322,7 @@ export function createCliSubprocessCodingAgentDriver(options: CliSubprocessDrive
               summary: `${options.command} exited non-zero`,
               transcript,
               error: redactSecrets(`claude_code_error_${errStatus}`, knownSecrets),
+              ...usageFields,
             };
           }
         }
@@ -328,6 +342,7 @@ export function createCliSubprocessCodingAgentDriver(options: CliSubprocessDrive
                 "codex_no_auth: auth.json missing or expired -- run `codex auth` to authenticate",
                 knownSecrets,
               ),
+              ...usageFields,
             };
           }
           if (jsonlDetail) {
@@ -340,6 +355,7 @@ export function createCliSubprocessCodingAgentDriver(options: CliSubprocessDrive
               summary: `${options.command} exited non-zero`,
               transcript,
               error: `${options.command}_exit_${spawned.code}: ${detail}`,
+              ...usageFields,
             };
           }
         }
@@ -351,6 +367,7 @@ export function createCliSubprocessCodingAgentDriver(options: CliSubprocessDrive
           summary: `${options.command} exited non-zero`,
           transcript,
           error: `${options.command}_exit_${spawned.code}: ${detail}`,
+          ...usageFields,
         };
       }
       // Claude Code's own documented behavior: `--output-format json` "sometimes exits non-zero", implying
@@ -369,18 +386,16 @@ export function createCliSubprocessCodingAgentDriver(options: CliSubprocessDrive
             summary: `${options.command} exited 0 but reported an error envelope`,
             transcript,
             error: redactSecrets(`claude_code_error_${errStatus}`, knownSecrets),
+            ...usageFields,
           };
         }
       }
-      const usage = extractCliUsage(spawned.stdout);
-      const tokensUsed = totalTokensFromUsage(usage);
       return {
         ok: true,
         changedFiles: [],
         summary: `${options.command} completed for ${task.attemptId}`,
         transcript,
-        ...(usage.costUsd !== undefined ? { costUsd: usage.costUsd } : {}),
-        ...(tokensUsed !== undefined ? { tokensUsed } : {}),
+        ...usageFields,
       };
     },
   };

--- a/test/contract/coding-agent-driver-parity.test.ts
+++ b/test/contract/coding-agent-driver-parity.test.ts
@@ -245,4 +245,20 @@ describe("documented divergences, locked in explicitly", () => {
     const result = await driver.run(task);
     expect(result.costUsd).toBe(0.15);
   });
+
+  it("CLI driver captures cost/token usage on a failed-but-billed attempt, symmetric with the Agent-SDK driver (#8871)", async () => {
+    // A non-zero exit whose JSON envelope still carries real spend (e.g. a mid-session API error) must report
+    // that cost so attempt-metering's budget ceiling is not undercounted — matching agent-sdk-driver.ts.
+    const driver = createCliSubprocessCodingAgentDriver({
+      command: "claude",
+      spawn: async () => ({
+        stdout: JSON.stringify({ type: "result", is_error: true, total_cost_usd: 0.09, input_tokens: 80, output_tokens: 20 }),
+        code: 1,
+      }),
+    });
+    const result = await driver.run(task);
+    expect(result.ok).toBe(false);
+    expect(result.costUsd).toBe(0.09);
+    expect(result.tokensUsed).toBe(100);
+  });
 });

--- a/test/unit/cli-subprocess-driver.test.ts
+++ b/test/unit/cli-subprocess-driver.test.ts
@@ -99,6 +99,46 @@ describe("createCliSubprocessCodingAgentDriver (#4266)", () => {
     expect(result.error).not.toContain("sk-ant-abcdefghijklmnop12345");
   });
 
+  it("still reports cost/token usage on a non-zero exit that billed real spend (#8871)", async () => {
+    const { spawn } = fakeSpawn({
+      stdout: JSON.stringify({ type: "result", is_error: true, total_cost_usd: 0.05, input_tokens: 100, output_tokens: 50 }),
+      code: 1,
+    });
+    const driver = createCliSubprocessCodingAgentDriver({ command: "codex", spawn });
+    const result = await driver.run(TASK);
+    expect(result.ok).toBe(false);
+    // A failed-but-billed attempt must not undercount spend against the metering budget ceiling.
+    expect(result.costUsd).toBe(0.05);
+    expect(result.tokensUsed).toBe(150);
+  });
+
+  it("still reports cost/token usage on a timeout that billed real spend (#8871)", async () => {
+    const { spawn } = fakeSpawn({
+      stdout: JSON.stringify({ total_cost_usd: 0.02, input_tokens: 10, output_tokens: 5 }),
+      code: null,
+      timedOut: true,
+    });
+    const driver = createCliSubprocessCodingAgentDriver({ command: "claude", spawn, timeoutMs: 5000 });
+    const result = await driver.run(TASK);
+    expect(result.ok).toBe(false);
+    expect(result.summary).toBe("claude timed out after 5000ms");
+    expect(result.costUsd).toBe(0.02);
+    expect(result.tokensUsed).toBe(15);
+  });
+
+  it("still reports cost/token usage on a code-0 claude error envelope that billed real spend (#8871)", async () => {
+    const { spawn } = fakeSpawn({
+      stdout: JSON.stringify({ type: "result", subtype: "success", is_error: true, api_error_status: "overloaded_error", total_cost_usd: 0.03, input_tokens: 20, output_tokens: 10 }),
+      code: 0,
+    });
+    const driver = createCliSubprocessCodingAgentDriver({ command: "claude", spawn });
+    const result = await driver.run(TASK);
+    expect(result.ok).toBe(false);
+    expect(result.summary).toBe("claude exited 0 but reported an error envelope");
+    expect(result.costUsd).toBe(0.03);
+    expect(result.tokensUsed).toBe(30);
+  });
+
   it("falls back to 'exit <code>' when a failing subprocess wrote no stderr (incl. a null code)", async () => {
     const { spawn } = fakeSpawn({ stdout: "", code: null });
     const driver = createCliSubprocessCodingAgentDriver({ command: "claude", spawn });


### PR DESCRIPTION
## What & why

Closes #8871.

`packages/loopover-engine/src/miner/cli-subprocess-driver.ts`'s `run()` only called
`extractCliUsage` on the **success** return path, even though the file's own comment confirms the
JSON usage envelope is present "on every result, success or not." A failed-but-billed CLI attempt
(a mid-session API error surfacing on the timeout, non-zero-exit, or code-0 error-envelope branch)
silently reported `costUsd: undefined`, undercounting real spend against `attempt-metering.ts`'s
budget ceiling — asymmetric with the sibling `agent-sdk-driver.ts`, whose failure branch already
populates cost/token usage.

## Change

Extract usage once from `spawned.stdout` and spread the cost/token fields into **every** failure
return as well as the success one, so spend is captured symmetrically with the success path and with
`agent-sdk-driver.ts`. The success path stays byte-identical (same fields, now computed once and
reused). `extractCliUsage` already tolerates unparseable/empty stdout, so a stall with no output
simply adds nothing.

## Validation

- Unit tests for the non-zero-exit, timeout, and code-0 error-envelope failure branches, each
  asserting a billed failure now reports `costUsd`/`tokensUsed`.
- A `coding-agent-driver-parity.test.ts` contract test asserting a failed-but-billed CLI attempt
  captures its cost, symmetric with the Agent-SDK driver.
- Bug-catch verified: reverting the source fails exactly the new failure-usage assertions.
- 100% patch coverage on the changed lines.
