### PR TITLE
fix(github): self-heal stale installation tokens on PR freshness reads

### DIFF
--- a/src/github/app.ts
+++ b/src/github/app.ts
@@ -168,6 +168,11 @@ function isGitHubInstallationPermissionError(error: unknown): boolean {
   return githubErrorStatus(error) === 403 && /resource not accessible by integration|not have permission/i.test(errorMessage(error));
 }
 
+/** True when withInstallationTokenRetry should evict the cached token and retry once (#6191 / #8892). */
+export function isGitHubInstallationTokenRetryableError(error: unknown): boolean {
+  return isGitHubBadCredentialsError(error) || isGitHubInstallationPermissionError(error);
+}
+
 async function expireCachedInstallationToken(
   installationId: number,
   rejectedToken: string,
@@ -187,7 +192,7 @@ export async function withInstallationTokenRetry<T>(
     return await operation(token);
   } catch (error) {
     const refreshForPermission = isGitHubInstallationPermissionError(error);
-    if (!isGitHubBadCredentialsError(error) && !refreshForPermission) throw error;
+    if (!isGitHubInstallationTokenRetryableError(error)) throw error;
     await expireCachedInstallationToken(installationId, token).catch(
       () => undefined,
     );

--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -63,7 +63,7 @@ import type {
   RepositorySettings,
 } from "../types";
 import { errorMessage, nowIso, repoParts, strippedErrorMessage } from "../utils/json";
-import { createInstallationToken, getAppInstallation } from "./app";
+import { createInstallationToken, getAppInstallation, isGitHubInstallationTokenRetryableError, withInstallationTokenRetry } from "./app";
 import {
   GITTENSORY_LEGACY_CONTEXT_CHECK_NAME,
   GITTENSORY_LEGACY_GATE_CHECK_NAME,
@@ -3414,31 +3414,88 @@ export async function fetchLinkedIssueClosedByPullRequest(
  *  read `open` locally. The per-contributor open-issue cap (#2479 gate finding) confirms each counted sibling's
  *  live state before treating a newly opened issue as over cap, so a stale row never inflates the count and
  *  wrongly closes an issue that is within the real cap. Best-effort: returns undefined on any error so the
- *  caller fails open to the stored state (same fail-open contract as the PR-side helper). */
+ *  caller fails open to the stored state (same fail-open contract as the PR-side helper). When `installationId`
+ *  is set, a stale cached installation token self-heals once via {@link withInstallationTokenRetry} (#8892). */
 export async function fetchLiveIssueState(
   env: Env,
   repoFullName: string,
   issueNumber: number,
   token: string | undefined,
   admissionKey?: GitHubRateLimitAdmissionKey,
+  installationId?: number,
 ): Promise<string | undefined> {
-  const result = await githubJsonWithHeaders<{ state?: string | null }>(env, repoFullName, `/issues/${issueNumber}`, token, githubRateLimitOptions(admissionKey)).catch(() => undefined);
-  return result?.data.state ?? undefined;
+  if (installationId !== undefined) {
+    try {
+      return await withInstallationTokenRetry(env, installationId, async (freshToken) =>
+        fetchLiveIssueState(
+          env,
+          repoFullName,
+          issueNumber,
+          freshToken,
+          githubRateLimitAdmissionKeyForToken(env, freshToken, installationId),
+        ),
+      );
+    } catch {
+      return undefined;
+    }
+  }
+  try {
+    const result = await githubJsonWithHeaders<{ state?: string | null }>(
+      env,
+      repoFullName,
+      `/issues/${issueNumber}`,
+      token,
+      githubRateLimitOptions(admissionKey),
+    );
+    return result.data.state ?? undefined;
+  } catch (error) {
+    // Surface retryable token failures to withInstallationTokenRetry; soft-fail everything else.
+    if (isGitHubInstallationTokenRetryableError(error)) throw error;
+    return undefined;
+  }
 }
 
 /** The PR's LIVE head commit SHA via REST `GET /pulls/{n}`. The stored `pr.headSha` lags GitHub when a commit
  *  lands between a webhook and its processing; the gate-override command (#16 / audit) re-fetches the live head
  *  so the neutral check-run targets the commit a maintainer is actually looking at, not a phantom old SHA.
- *  Best-effort: returns undefined on any error so the caller fails open to the stored head. */
+ *  Best-effort: returns undefined on any error so the caller fails open to the stored head. When `installationId`
+ *  is set, a stale cached installation token self-heals once via {@link withInstallationTokenRetry} (#8892). */
 export async function fetchLivePullRequestHeadSha(
   env: Env,
   repoFullName: string,
   prNumber: number,
   token: string | undefined,
   admissionKey?: GitHubRateLimitAdmissionKey,
+  installationId?: number,
 ): Promise<string | undefined> {
-  const result = await githubJsonWithHeaders<{ head?: { sha?: string | null } | null }>(env, repoFullName, `/pulls/${prNumber}`, token, githubRateLimitOptions(admissionKey)).catch(() => undefined);
-  return result?.data.head?.sha ?? undefined;
+  if (installationId !== undefined) {
+    try {
+      return await withInstallationTokenRetry(env, installationId, async (freshToken) =>
+        fetchLivePullRequestHeadSha(
+          env,
+          repoFullName,
+          prNumber,
+          freshToken,
+          githubRateLimitAdmissionKeyForToken(env, freshToken, installationId),
+        ),
+      );
+    } catch {
+      return undefined;
+    }
+  }
+  try {
+    const result = await githubJsonWithHeaders<{ head?: { sha?: string | null } | null }>(
+      env,
+      repoFullName,
+      `/pulls/${prNumber}`,
+      token,
+      githubRateLimitOptions(admissionKey),
+    );
+    return result.data.head?.sha ?? undefined;
+  } catch (error) {
+    if (isGitHubInstallationTokenRetryableError(error)) throw error;
+    return undefined;
+  }
 }
 
 export type LivePullRequestFetchResult =
@@ -3451,11 +3508,35 @@ export async function fetchLivePullRequestResult(
   prNumber: number,
   token: string | undefined,
   admissionKey?: GitHubRateLimitAdmissionKey,
+  installationId?: number,
 ): Promise<LivePullRequestFetchResult> {
+  if (installationId !== undefined) {
+    try {
+      return await withInstallationTokenRetry(env, installationId, async (freshToken) =>
+        fetchLivePullRequestResult(
+          env,
+          repoFullName,
+          prNumber,
+          freshToken,
+          githubRateLimitAdmissionKeyForToken(env, freshToken, installationId),
+        ),
+      );
+    } catch (error) {
+      return { status: "error", error: strippedErrorMessage(error, "GitHub live PR fetch failed").slice(0, 240) };
+    }
+  }
   try {
-    const result = await githubJsonWithHeaders<GitHubPullRequestPayload>(env, repoFullName, `/pulls/${prNumber}`, token, githubRateLimitOptions(admissionKey));
+    const result = await githubJsonWithHeaders<GitHubPullRequestPayload>(
+      env,
+      repoFullName,
+      `/pulls/${prNumber}`,
+      token,
+      githubRateLimitOptions(admissionKey),
+    );
     return { status: "ok", data: result.data };
   } catch (error) {
+    // Rethrow so withInstallationTokenRetry can clear a stale cached token and remint (#8892).
+    if (isGitHubInstallationTokenRetryableError(error)) throw error;
     return { status: "error", error: strippedErrorMessage(error, "GitHub live PR fetch failed").slice(0, 240) };
   }
 }
@@ -3472,8 +3553,14 @@ export async function fetchLivePullRequest(
   token: string | undefined,
   admissionKey?: GitHubRateLimitAdmissionKey,
 ): Promise<GitHubPullRequestPayload | undefined> {
-  const result = await fetchLivePullRequestResult(env, repoFullName, prNumber, token, admissionKey);
-  return result.status === "ok" ? result.data : undefined;
+  try {
+    const result = await fetchLivePullRequestResult(env, repoFullName, prNumber, token, admissionKey);
+    return result.status === "ok" ? result.data : undefined;
+  } catch {
+    // fetchLivePullRequestResult rethrows retryable token failures for withInstallationTokenRetry (#8892);
+    // this soft wrapper keeps the historical fail-open contract for every call site that only wants a payload.
+    return undefined;
+  }
 }
 
 // Bounded at 1000 open PRs (10 pages of 100) — far beyond any real repo's open-PR count; a pathological repo

--- a/src/github/pr-freshness.ts
+++ b/src/github/pr-freshness.ts
@@ -1,6 +1,6 @@
-import { createInstallationToken } from "./app";
+import { withInstallationTokenRetry } from "./app";
 import { fetchLivePullRequestResult } from "./backfill";
-import { githubRateLimitAdmissionKeyForToken } from "./client";
+import { githubRateLimitAdmissionKeyForPublicToken, githubRateLimitAdmissionKeyForToken } from "./client";
 import type { GitHubPullRequestPayload } from "../types";
 import { strippedErrorMessage } from "../utils/json";
 
@@ -107,29 +107,49 @@ export async function fetchPullRequestFreshness(
 ): Promise<PullRequestFreshness> {
   const options: PullRequestFreshnessOptions =
     args.requireDraft !== undefined ? { requireDraft: args.requireDraft } : {};
-  let tokenError: unknown;
-  const token =
-    (await createInstallationToken(env, args.installationId).catch((error) => {
-      tokenError = error;
-      return undefined;
-    })) ?? env.GITHUB_PUBLIC_TOKEN;
-  if (!token) {
-    return classifyPullRequestFreshness(undefined, args.expectedHeadSha, {
-      ...options,
-      unavailableSource: "token",
-      unavailableDetail: strippedErrorMessage(tokenError, "no token available").slice(0, 240),
-    });
+
+  const classifyLive = async (
+    token: string,
+    admissionKey: ReturnType<typeof githubRateLimitAdmissionKeyForToken> | ReturnType<typeof githubRateLimitAdmissionKeyForPublicToken>,
+  ): Promise<PullRequestFreshness> => {
+    const live = await fetchLivePullRequestResult(env, args.repoFullName, args.pullNumber, token, admissionKey);
+    if (live.status === "error") {
+      return classifyPullRequestFreshness(undefined, args.expectedHeadSha, {
+        ...options,
+        unavailableSource: "pull_request_fetch",
+        unavailableDetail: live.error,
+      });
+    }
+    return classifyPullRequestFreshness(live.data, args.expectedHeadSha, options);
+  };
+
+  try {
+    // Same self-heal as write-path GitHub helpers (#6191 / #8892): one cache eviction + remint on
+    // 401 / permission-scope, then retry the live PR GET before treating the PR as unavailable/stale.
+    return await withInstallationTokenRetry(env, args.installationId, async (token) =>
+      classifyLive(token, githubRateLimitAdmissionKeyForToken(env, token, args.installationId)),
+    );
+  } catch (error) {
+    // Mint failure (or exhausted retryable failure that escaped): fall back to the public token when
+    // configured — same fail-over as the prior createInstallationToken().catch → GITHUB_PUBLIC_TOKEN path.
+    const publicToken = env.GITHUB_PUBLIC_TOKEN;
+    if (!publicToken) {
+      return classifyPullRequestFreshness(undefined, args.expectedHeadSha, {
+        ...options,
+        unavailableSource: "token",
+        unavailableDetail: strippedErrorMessage(error, "installation token unavailable").slice(0, 240),
+      });
+    }
+    try {
+      return await classifyLive(publicToken, githubRateLimitAdmissionKeyForPublicToken());
+    } catch (publicError) {
+      return classifyPullRequestFreshness(undefined, args.expectedHeadSha, {
+        ...options,
+        unavailableSource: "pull_request_fetch",
+        unavailableDetail: strippedErrorMessage(publicError, "GitHub live PR fetch failed").slice(0, 240),
+      });
+    }
   }
-  const admissionKey = githubRateLimitAdmissionKeyForToken(env, token, args.installationId);
-  const live = await fetchLivePullRequestResult(env, args.repoFullName, args.pullNumber, token, admissionKey);
-  if (live.status === "error") {
-    return classifyPullRequestFreshness(undefined, args.expectedHeadSha, {
-      ...options,
-      unavailableSource: "pull_request_fetch",
-      unavailableDetail: live.error,
-    });
-  }
-  return classifyPullRequestFreshness(live.data, args.expectedHeadSha, options);
 }
 
 export function pullRequestFreshnessDetail(result: PullRequestFreshness): string {

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -11834,7 +11834,7 @@ export async function resolveOverrideHeadSha(
     pr.number,
     token,
     admissionKey,
-  );
+  ).catch(() => undefined);
   return liveHeadSha ?? pr.headSha;
 }
 

--- a/test/unit/fetch-live-pull-request.test.ts
+++ b/test/unit/fetch-live-pull-request.test.ts
@@ -30,4 +30,10 @@ describe("fetchLivePullRequest (#sweep-resync)", () => {
       await fetchLivePullRequest(env, "owner/repo", 7, "tok"),
     ).toBeUndefined();
   });
+
+  it("returns undefined (fail-open) when a retryable stale-token 401 escapes fetchLivePullRequestResult (#8892)", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+    vi.stubGlobal("fetch", async () => Response.json({ message: "Bad credentials" }, { status: 401 }));
+    expect(await fetchLivePullRequest(env, "owner/repo", 7, "tok")).toBeUndefined();
+  });
 });

--- a/test/unit/pr-freshness.test.ts
+++ b/test/unit/pr-freshness.test.ts
@@ -5,11 +5,19 @@ import {
   pullRequestFreshnessDetail,
   reviewedPullRequestHeadSha,
 } from "../../src/github/pr-freshness";
+import {
+  fetchLiveIssueState,
+  fetchLivePullRequestHeadSha,
+  fetchLivePullRequestResult,
+} from "../../src/github/backfill";
+import { clearInstallationTokenCacheForTest } from "../../src/github/app";
 import { createTestEnv } from "../helpers/d1";
+import { generatePrivateKeyPem } from "../helpers/github-app-key";
 
 describe("PR freshness guards", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+    clearInstallationTokenCacheForTest();
   });
 
   it("classifies a matching open head as current", () => {
@@ -233,6 +241,183 @@ describe("PR freshness guards", () => {
       reason: "unavailable",
       unavailableSource: "token",
       unavailableDetail: expect.any(String),
+    });
+  });
+
+  it("REGRESSION (#8892): evicts a stale installation token and retries the live PR GET once on 401", async () => {
+    clearInstallationTokenCacheForTest();
+    let tokenMints = 0;
+    let pullGetAttempts = 0;
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/access_tokens")) {
+        tokenMints += 1;
+        return Response.json({ token: `token-${tokenMints}`, expires_at: "2099-01-01T00:00:00Z" });
+      }
+      if (url.includes("/repos/owner/repo/pulls/7") && (init?.method ?? "GET") === "GET") {
+        pullGetAttempts += 1;
+        if (pullGetAttempts === 1) return Response.json({ message: "Bad credentials" }, { status: 401 });
+        return Response.json({ state: "open", head: { sha: "sha7" }, labels: [] });
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+
+    await expect(
+      fetchPullRequestFreshness(env, {
+        installationId: 998877,
+        repoFullName: "owner/repo",
+        pullNumber: 7,
+        expectedHeadSha: "sha7",
+      }),
+    ).resolves.toMatchObject({ status: "current", liveHeadSha: "sha7", liveState: "open" });
+    expect(pullGetAttempts).toBe(2);
+    expect(tokenMints).toBe(2);
+  });
+
+  it("fetchLivePullRequestResult: self-heals a stale installation token on 401 when installationId is set (#8892)", async () => {
+    clearInstallationTokenCacheForTest();
+    let tokenMints = 0;
+    let pullGetAttempts = 0;
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/access_tokens")) {
+        tokenMints += 1;
+        return Response.json({ token: `token-${tokenMints}`, expires_at: "2099-01-01T00:00:00Z" });
+      }
+      if (url.includes("/repos/owner/repo/pulls/9") && (init?.method ?? "GET") === "GET") {
+        pullGetAttempts += 1;
+        if (pullGetAttempts === 1) return Response.json({ message: "Bad credentials" }, { status: 401 });
+        return Response.json({ state: "open", head: { sha: "abc" } });
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+
+    await expect(fetchLivePullRequestResult(env, "owner/repo", 9, undefined, undefined, 42)).resolves.toMatchObject({
+      status: "ok",
+      data: { state: "open", head: { sha: "abc" } },
+    });
+    expect(pullGetAttempts).toBe(2);
+    expect(tokenMints).toBe(2);
+  });
+
+  it("fetchLiveIssueState: self-heals a stale installation token on 401 when installationId is set (#8892)", async () => {
+    clearInstallationTokenCacheForTest();
+    let tokenMints = 0;
+    let issueGetAttempts = 0;
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/access_tokens")) {
+        tokenMints += 1;
+        return Response.json({ token: `token-${tokenMints}`, expires_at: "2099-01-01T00:00:00Z" });
+      }
+      if (url.includes("/repos/owner/repo/issues/3") && (init?.method ?? "GET") === "GET") {
+        issueGetAttempts += 1;
+        if (issueGetAttempts === 1) return Response.json({ message: "Bad credentials" }, { status: 401 });
+        return Response.json({ state: "open" });
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+
+    await expect(fetchLiveIssueState(env, "owner/repo", 3, undefined, undefined, 42)).resolves.toBe("open");
+    expect(issueGetAttempts).toBe(2);
+    expect(tokenMints).toBe(2);
+  });
+
+  it("fetchLivePullRequestHeadSha: self-heals a stale installation token on 401 when installationId is set (#8892)", async () => {
+    clearInstallationTokenCacheForTest();
+    let tokenMints = 0;
+    let pullGetAttempts = 0;
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/access_tokens")) {
+        tokenMints += 1;
+        return Response.json({ token: `token-${tokenMints}`, expires_at: "2099-01-01T00:00:00Z" });
+      }
+      if (url.includes("/repos/owner/repo/pulls/11") && (init?.method ?? "GET") === "GET") {
+        pullGetAttempts += 1;
+        if (pullGetAttempts === 1) return Response.json({ message: "Bad credentials" }, { status: 401 });
+        return Response.json({ head: { sha: "deadbeef" } });
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+
+    await expect(fetchLivePullRequestHeadSha(env, "owner/repo", 11, undefined, undefined, 42)).resolves.toBe("deadbeef");
+    expect(pullGetAttempts).toBe(2);
+    expect(tokenMints).toBe(2);
+  });
+
+  it("fetchLive helpers soft-fail non-retryable errors when installationId is set", async () => {
+    clearInstallationTokenCacheForTest();
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/access_tokens")) {
+        return Response.json({ token: "token-1", expires_at: "2099-01-01T00:00:00Z" });
+      }
+      return new Response("temporary outage", { status: 503 });
+    });
+
+    await expect(fetchLiveIssueState(env, "owner/repo", 1, undefined, undefined, 7)).resolves.toBeUndefined();
+    await expect(fetchLivePullRequestHeadSha(env, "owner/repo", 1, undefined, undefined, 7)).resolves.toBeUndefined();
+    await expect(fetchLivePullRequestResult(env, "owner/repo", 1, undefined, undefined, 7)).resolves.toMatchObject({
+      status: "error",
+      error: expect.stringContaining("503"),
+    });
+  });
+
+  it("fetchLive helpers soft-fail when installation token minting fails with installationId set", async () => {
+    clearInstallationTokenCacheForTest();
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: "not-a-real-key" });
+    await expect(fetchLiveIssueState(env, "owner/repo", 1, undefined, undefined, 7)).resolves.toBeUndefined();
+    await expect(fetchLivePullRequestHeadSha(env, "owner/repo", 1, undefined, undefined, 7)).resolves.toBeUndefined();
+    await expect(fetchLivePullRequestResult(env, "owner/repo", 1, undefined, undefined, 7)).resolves.toMatchObject({
+      status: "error",
+    });
+  });
+
+  it("falls back to the public token when installation minting fails but GITHUB_PUBLIC_TOKEN is set", async () => {
+    clearInstallationTokenCacheForTest();
+    const env = createTestEnv({
+      GITHUB_APP_PRIVATE_KEY: "not-a-real-key",
+      GITHUB_PUBLIC_TOKEN: "public-token",
+    });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      expect(String(input)).toContain("/repos/owner/repo/pulls/7");
+      return Response.json({ state: "open", head: { sha: "sha7" } });
+    });
+    await expect(
+      fetchPullRequestFreshness(env, {
+        installationId: 123,
+        repoFullName: "owner/repo",
+        pullNumber: 7,
+        expectedHeadSha: "sha7",
+      }),
+    ).resolves.toMatchObject({ status: "current", liveHeadSha: "sha7" });
+  });
+
+  it("classifies a public-token 401 after mint failure as unavailable freshness", async () => {
+    clearInstallationTokenCacheForTest();
+    const env = createTestEnv({
+      GITHUB_APP_PRIVATE_KEY: "not-a-real-key",
+      GITHUB_PUBLIC_TOKEN: "public-token",
+    });
+    vi.stubGlobal("fetch", async () => Response.json({ message: "Bad credentials" }, { status: 401 }));
+    await expect(
+      fetchPullRequestFreshness(env, {
+        installationId: 123,
+        repoFullName: "owner/repo",
+        pullNumber: 7,
+        expectedHeadSha: "sha7",
+      }),
+    ).resolves.toMatchObject({
+      status: "stale",
+      reason: "unavailable",
+      unavailableSource: "pull_request_fetch",
+      unavailableDetail: expect.stringMatching(/401|Bad credentials/i),
     });
   });
 });

--- a/test/unit/pr-freshness.test.ts
+++ b/test/unit/pr-freshness.test.ts
@@ -302,6 +302,15 @@ describe("PR freshness guards", () => {
     expect(tokenMints).toBe(2);
   });
 
+  it("fetchLiveIssueState: returns undefined when GitHub omits issue state (#8892)", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      expect(String(input)).toContain("/repos/owner/repo/issues/5");
+      return Response.json({ title: "missing state field" });
+    });
+    await expect(fetchLiveIssueState(env, "owner/repo", 5, "public-token")).resolves.toBeUndefined();
+  });
+
   it("fetchLiveIssueState: self-heals a stale installation token on 401 when installationId is set (#8892)", async () => {
     clearInstallationTokenCacheForTest();
     let tokenMints = 0;

--- a/test/unit/resolve-override-head-sha.test.ts
+++ b/test/unit/resolve-override-head-sha.test.ts
@@ -54,6 +54,13 @@ describe("resolveOverrideHeadSha (#16 / gate-override stale head)", () => {
     expect(await resolveOverrideHeadSha(env, 123, "owner/repo", makePr("stale-sha"))).toBe("stale-sha");
   });
 
+  it("fails OPEN to the cached head when the live fetch returns a stale-token 401 (#8892 rethrow contract)", async () => {
+    const env = createTestEnv();
+    mockedToken.mockResolvedValue("inst-tok");
+    vi.stubGlobal("fetch", async () => Response.json({ message: "Bad credentials" }, { status: 401 }));
+    expect(await resolveOverrideHeadSha(env, 123, "owner/repo", makePr("stale-sha"))).toBe("stale-sha");
+  });
+
   it("returns the cached head when the live payload omits head.sha (fail-open)", async () => {
     const env = createTestEnv();
     mockedToken.mockResolvedValue("inst-tok");


### PR DESCRIPTION

## Summary

- Closes #8892
- Routes `fetchPullRequestFreshness` through `withInstallationTokenRetry` (same self-heal as write-path helpers / #6191) so a stale cached installation token remints once on 401 instead of classifying the PR as `status: "stale", reason: "unavailable"`.
- Extends `fetchLivePullRequestResult`, `fetchLiveIssueState`, and `fetchLivePullRequestHeadSha` with the same optional `installationId` retry wrapper; retryable token errors rethrow so the wrapper can recover, while non-retryable failures keep the historical soft-fail contract.
- Preserves the public-token fail-over when installation minting fails, and keeps `fetchLivePullRequest` / `resolveOverrideHeadSha` fail-open when a bare-token 401 escapes.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npx vitest run test/unit/pr-freshness.test.ts test/unit/resolve-override-head-sha.test.ts test/unit/fetch-live-pull-request.test.ts` — 39 passed
- [x] CI-scoped Codecov simulation: `npx vitest run --coverage …` + `npx diff-cover coverage/lcov.info --compare-branch=origin/main` — **100%** patch lines (48/48) on changed `src/**` files
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

Narrow GitHub read-path retry wiring; full `test:ci` left for the opener before push. Targeted freshness / live-PR / override-head tests cover the 401 remint success path and fail-open contracts.

## Notes for reviewers / gate

- No secrets, wallets, hotkeys, trust scores, or reward values.
- Does not touch `site/`, `CNAME`, `**/lovable/**`, or `CHANGELOG.md`.
- No UI Evidence (backend-only).
