### PR TITLE
fix(github): self-heal stale installation tokens on PR freshness reads

### DIFF
--- a/src/github/app.ts
+++ b/src/github/app.ts
@@ -154,9 +154,11 @@ export async function createInstallationToken(
 export function githubErrorStatus(error: unknown): number | null {
   const err = error as {
     status?: number;
+    statusCode?: number;
     response?: { status?: number } | null;
   };
-  return err.status ?? err.response?.status ?? null;
+  // GitHubApiError (backfill.ts) exposes `statusCode`; Octokit errors expose `status` / `response.status`.
+  return err.status ?? err.statusCode ?? err.response?.status ?? null;
 }
 
 export function isGitHubBadCredentialsError(error: unknown): boolean {
@@ -167,6 +169,8 @@ export function isGitHubBadCredentialsError(error: unknown): boolean {
 function isGitHubInstallationPermissionError(error: unknown): boolean {
   return githubErrorStatus(error) === 403 && /resource not accessible by integration|not have permission/i.test(errorMessage(error));
 }
+
+export { isGitHubInstallationPermissionError };
 
 async function expireCachedInstallationToken(
   installationId: number,

--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -63,7 +63,7 @@ import type {
   RepositorySettings,
 } from "../types";
 import { errorMessage, nowIso, repoParts, strippedErrorMessage } from "../utils/json";
-import { createInstallationToken, getAppInstallation } from "./app";
+import { createInstallationToken, getAppInstallation, isGitHubBadCredentialsError, isGitHubInstallationPermissionError, withInstallationTokenRetry } from "./app";
 import {
   GITTENSORY_LEGACY_CONTEXT_CHECK_NAME,
   GITTENSORY_LEGACY_GATE_CHECK_NAME,
@@ -3456,9 +3456,26 @@ export async function fetchLiveIssueState(
   issueNumber: number,
   token: string | undefined,
   admissionKey?: GitHubRateLimitAdmissionKey,
+  options?: { installationId?: number },
 ): Promise<string | undefined> {
-  const result = await githubJsonWithHeaders<{ state?: string | null }>(env, repoFullName, `/issues/${issueNumber}`, token, githubRateLimitOptions(admissionKey)).catch(() => undefined);
-  return result?.data.state ?? undefined;
+  const run = async (activeToken: string | undefined): Promise<string | undefined> => {
+    try {
+      const result = await githubJsonWithHeaders<{ state?: string | null }>(env, repoFullName, `/issues/${issueNumber}`, activeToken, githubRateLimitOptions(admissionKey));
+      return result?.data.state ?? undefined;
+    } catch (error) {
+      // Auth failures must propagate so withInstallationTokenRetry can self-heal (#8892); other errors stay fail-open.
+      if (options?.installationId != null && (isGitHubBadCredentialsError(error) || isGitHubInstallationPermissionError(error))) throw error;
+      return undefined;
+    }
+  };
+  if (options?.installationId != null) {
+    try {
+      return await withInstallationTokenRetry(env, options.installationId, (freshToken) => run(freshToken));
+    } catch {
+      return undefined;
+    }
+  }
+  return run(token);
 }
 
 /** The PR's LIVE head commit SHA via REST `GET /pulls/{n}`. The stored `pr.headSha` lags GitHub when a commit
@@ -3471,9 +3488,25 @@ export async function fetchLivePullRequestHeadSha(
   prNumber: number,
   token: string | undefined,
   admissionKey?: GitHubRateLimitAdmissionKey,
+  options?: { installationId?: number },
 ): Promise<string | undefined> {
-  const result = await githubJsonWithHeaders<{ head?: { sha?: string | null } | null }>(env, repoFullName, `/pulls/${prNumber}`, token, githubRateLimitOptions(admissionKey)).catch(() => undefined);
-  return result?.data.head?.sha ?? undefined;
+  const run = async (activeToken: string | undefined): Promise<string | undefined> => {
+    try {
+      const result = await githubJsonWithHeaders<{ head?: { sha?: string | null } | null }>(env, repoFullName, `/pulls/${prNumber}`, activeToken, githubRateLimitOptions(admissionKey));
+      return result?.data.head?.sha ?? undefined;
+    } catch (error) {
+      if (options?.installationId != null && (isGitHubBadCredentialsError(error) || isGitHubInstallationPermissionError(error))) throw error;
+      return undefined;
+    }
+  };
+  if (options?.installationId != null) {
+    try {
+      return await withInstallationTokenRetry(env, options.installationId, (freshToken) => run(freshToken));
+    } catch {
+      return undefined;
+    }
+  }
+  return run(token);
 }
 
 export type LivePullRequestFetchResult =
@@ -3486,11 +3519,30 @@ export async function fetchLivePullRequestResult(
   prNumber: number,
   token: string | undefined,
   admissionKey?: GitHubRateLimitAdmissionKey,
+  options?: { installationId?: number; rethrowAuth?: boolean },
 ): Promise<LivePullRequestFetchResult> {
+  const run = async (activeToken: string | undefined): Promise<LivePullRequestFetchResult> => {
+    try {
+      const result = await githubJsonWithHeaders<GitHubPullRequestPayload>(env, repoFullName, `/pulls/${prNumber}`, activeToken, githubRateLimitOptions(admissionKey));
+      return { status: "ok", data: result.data };
+    } catch (error) {
+      // Propagate auth failures so withInstallationTokenRetry can mint a fresh token (#8892 / #6191).
+      if (isGitHubBadCredentialsError(error) || isGitHubInstallationPermissionError(error)) throw error;
+      return { status: "error", error: strippedErrorMessage(error, "GitHub live PR fetch failed").slice(0, 240) };
+    }
+  };
+  if (options?.installationId != null) {
+    try {
+      return await withInstallationTokenRetry(env, options.installationId, (freshToken) => run(freshToken));
+    } catch (error) {
+      return { status: "error", error: strippedErrorMessage(error, "GitHub live PR fetch failed").slice(0, 240) };
+    }
+  }
   try {
-    const result = await githubJsonWithHeaders<GitHubPullRequestPayload>(env, repoFullName, `/pulls/${prNumber}`, token, githubRateLimitOptions(admissionKey));
-    return { status: "ok", data: result.data };
+    return await run(token);
   } catch (error) {
+    // Optional rethrow so an outer withInstallationTokenRetry (e.g. fetchPullRequestFreshness) can self-heal.
+    if (options?.rethrowAuth) throw error;
     return { status: "error", error: strippedErrorMessage(error, "GitHub live PR fetch failed").slice(0, 240) };
   }
 }

--- a/src/github/pr-freshness.ts
+++ b/src/github/pr-freshness.ts
@@ -1,4 +1,4 @@
-import { createInstallationToken } from "./app";
+import { withInstallationTokenRetry } from "./app";
 import { fetchLivePullRequestResult } from "./backfill";
 import { githubRateLimitAdmissionKeyForToken } from "./client";
 import type { GitHubPullRequestPayload } from "../types";
@@ -107,29 +107,41 @@ export async function fetchPullRequestFreshness(
 ): Promise<PullRequestFreshness> {
   const options: PullRequestFreshnessOptions =
     args.requireDraft !== undefined ? { requireDraft: args.requireDraft } : {};
-  let tokenError: unknown;
-  const token =
-    (await createInstallationToken(env, args.installationId).catch((error) => {
-      tokenError = error;
-      return undefined;
-    })) ?? env.GITHUB_PUBLIC_TOKEN;
-  if (!token) {
-    return classifyPullRequestFreshness(undefined, args.expectedHeadSha, {
-      ...options,
-      unavailableSource: "token",
-      unavailableDetail: strippedErrorMessage(tokenError, "no token available").slice(0, 240),
+
+  const classifyLive = (live: Awaited<ReturnType<typeof fetchLivePullRequestResult>>): PullRequestFreshness => {
+    if (live.status === "error") {
+      return classifyPullRequestFreshness(undefined, args.expectedHeadSha, {
+        ...options,
+        unavailableSource: "pull_request_fetch",
+        unavailableDetail: live.error,
+      });
+    }
+    return classifyPullRequestFreshness(live.data, args.expectedHeadSha, options);
+  };
+
+  // Self-heal a stale cached installation token once before giving up (#8892 / #6191), matching write-path helpers.
+  try {
+    return await withInstallationTokenRetry(env, args.installationId, async (token) => {
+      const admissionKey = githubRateLimitAdmissionKeyForToken(env, token, args.installationId);
+      const live = await fetchLivePullRequestResult(env, args.repoFullName, args.pullNumber, token, admissionKey, {
+        rethrowAuth: true,
+      });
+      return classifyLive(live);
     });
+  } catch (tokenError) {
+    // Installation mint failed entirely — fall back to the public token path (pre-#8892 behavior).
+    const token = env.GITHUB_PUBLIC_TOKEN;
+    if (!token) {
+      return classifyPullRequestFreshness(undefined, args.expectedHeadSha, {
+        ...options,
+        unavailableSource: "token",
+        unavailableDetail: strippedErrorMessage(tokenError, "no token available").slice(0, 240),
+      });
+    }
+    const admissionKey = githubRateLimitAdmissionKeyForToken(env, token, args.installationId);
+    const live = await fetchLivePullRequestResult(env, args.repoFullName, args.pullNumber, token, admissionKey);
+    return classifyLive(live);
   }
-  const admissionKey = githubRateLimitAdmissionKeyForToken(env, token, args.installationId);
-  const live = await fetchLivePullRequestResult(env, args.repoFullName, args.pullNumber, token, admissionKey);
-  if (live.status === "error") {
-    return classifyPullRequestFreshness(undefined, args.expectedHeadSha, {
-      ...options,
-      unavailableSource: "pull_request_fetch",
-      unavailableDetail: live.error,
-    });
-  }
-  return classifyPullRequestFreshness(live.data, args.expectedHeadSha, options);
 }
 
 export function pullRequestFreshnessDetail(result: PullRequestFreshness): string {

--- a/test/unit/pr-freshness.test.ts
+++ b/test/unit/pr-freshness.test.ts
@@ -235,4 +235,40 @@ describe("PR freshness guards", () => {
       unavailableDetail: expect.any(String),
     });
   });
+
+  it("retries once on a stale installation-token 401 and succeeds (#8892)", async () => {
+    const env = createTestEnv({ ORB_ENROLLMENT_SECRET: "orbsec_test" });
+    let brokerCalls = 0;
+    let prCalls = 0;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/v1/orb/token")) {
+        brokerCalls += 1;
+        return Response.json({
+          token: brokerCalls === 1 ? "stale-token" : "fresh-token",
+          installationId: 123,
+          expiresAt: new Date(Date.now() + 60 * 60_000).toISOString(),
+          permissions: { contents: "read", pull_requests: "read" },
+        });
+      }
+      if (url.includes("/repos/owner/repo/pulls/7")) {
+        prCalls += 1;
+        if (prCalls === 1) return new Response("Bad credentials", { status: 401 });
+        return Response.json({ state: "open", head: { sha: "sha7" } });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    await expect(
+      fetchPullRequestFreshness(env, {
+        installationId: 123,
+        repoFullName: "owner/repo",
+        pullNumber: 7,
+        expectedHeadSha: "sha7",
+      }),
+    ).resolves.toMatchObject({ status: "current", liveHeadSha: "sha7" });
+
+    expect(prCalls).toBe(2);
+    expect(brokerCalls).toBeGreaterThanOrEqual(2);
+  });
 });


### PR DESCRIPTION
## Summary

- Route `fetchPullRequestFreshness` through `withInstallationTokenRetry` so a stale cached installation token self-heals once on 401/permission errors (matching write-path helpers).
- Teach `fetchLivePullRequestResult` / `fetchLiveIssueState` / `fetchLivePullRequestHeadSha` to propagate auth failures for retry, and teach `githubErrorStatus` to read `GitHubApiError.statusCode`.
- Cover the 401→retry→success path in `pr-freshness.test.ts`.

Closes #8892

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Full suite not re-run locally (Node 24 vs engines Node 22). Diff is github read-path token retry + unit coverage; CI is source of truth.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — no visible UI changes.

## Notes

- Non-engine aspect (`fix(github)`). Public-token fallback when installation mint fails is preserved.