### PR TITLE
fix(scenarios): wire assertScenarioLocalBranchInputSafe into MCP local-branch collection

### DIFF
--- a/packages/loopover-mcp/lib/local-branch.ts
+++ b/packages/loopover-mcp/lib/local-branch.ts
@@ -4,6 +4,7 @@ import { isAbsolute, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { isCodeFile, isTestPath as isTestFile } from "@loopover/engine/signals/test-evidence";
 import { redactLocalPath } from "./redact-local-path.js";
+import { assertScenarioLocalBranchInputSafe } from "./scenario-local-branch-input-safe.js";
 
 export { isCodeFile, isTestFile };
 export { redactLocalPath };
@@ -122,7 +123,9 @@ export function collectLocalDiff(cwd: string, baseRef: string, workspaceRoots?: 
 }
 
 export function collectLocalBranchMetadata(input: CollectLocalBranchMetadataInput): LocalBranchMetadata {
-  assertSourceUploadDisabled();
+  // Production entry point for the scenario local-branch safety guard (#8884) — scans forbidden source-upload
+  // keys / oversized changedFiles in addition to the LOOPOVER_UPLOAD_SOURCE env check.
+  assertScenarioLocalBranchInputSafe({ ...input } as Record<string, unknown>);
   const workspace = resolveWorkspaceCwd(input);
   const cwd = workspace.cwd;
   const baseRef = input.baseRef ?? defaultBaseRef(cwd);
@@ -702,12 +705,6 @@ function truncateText(value: unknown, maxLength = 240): string | undefined {
 
 function splitCommand(command: unknown): string[] {
   return String(command).match(/(?:[^\s"]+|"[^"]*")+/g)?.map((part) => part.replace(/^"|"$/g, "")) ?? [];
-}
-
-function assertSourceUploadDisabled(): void {
-  if (/^(1|true|yes)$/i.test(process.env.LOOPOVER_UPLOAD_SOURCE ?? "false")) {
-    throw new Error("LOOPOVER_UPLOAD_SOURCE=true is not supported in v1; local MCP sends metadata only.");
-  }
 }
 
 // Word-boundary the closing keywords (as the server-side extractors in src/db/repositories.ts and

--- a/packages/loopover-mcp/lib/scenario-local-branch-input-safe.ts
+++ b/packages/loopover-mcp/lib/scenario-local-branch-input-safe.ts
@@ -1,0 +1,37 @@
+/** Forbidden keys that indicate source-content upload in scenario / local-branch payloads. */
+const FORBIDDEN_SOURCE_UPLOAD_KEYS =
+  /^(?:sourceContent|sourceContents|fileContent|fileContents|rawSource|rawSourceContent|content|contents|diff|patch|rawDiff)$/i;
+
+/**
+ * Production safety guard for local-branch / scenario inputs: refuse source-content uploads and oversized
+ * changedFiles metadata. Shared by `src/scenarios/input-model.ts` and the MCP local-branch collector (#8884).
+ */
+export function assertScenarioLocalBranchInputSafe(payload: Record<string, unknown>): void {
+  if (/^(1|true|yes)$/i.test(String(process.env.LOOPOVER_UPLOAD_SOURCE ?? "false"))) {
+    throw new Error("LOOPOVER_UPLOAD_SOURCE=true is not supported; scenario inputs remain metadata-only.");
+  }
+  for (const key of Object.keys(payload)) {
+    if (FORBIDDEN_SOURCE_UPLOAD_KEYS.test(key)) {
+      throw new Error(`Refusing scenario local-branch field ${key}; source contents are never uploaded.`);
+    }
+  }
+  const changedFiles = payload.changedFiles;
+  // #8328: a present-but-non-array changedFiles must be rejected so the nested scan cannot be skipped.
+  if (changedFiles !== undefined && !Array.isArray(changedFiles)) {
+    throw new Error("Refusing non-array changedFiles; an array of file entries is required.");
+  }
+  if (Array.isArray(changedFiles)) {
+    for (const entry of changedFiles) {
+      if (!entry || typeof entry !== "object") continue;
+      for (const nestedKey of Object.keys(entry as Record<string, unknown>)) {
+        if (FORBIDDEN_SOURCE_UPLOAD_KEYS.test(nestedKey)) {
+          throw new Error(`Refusing changedFiles.${nestedKey}; source contents are never uploaded.`);
+        }
+        const value = (entry as Record<string, unknown>)[nestedKey];
+        if (typeof value === "string" && value.length > 4000) {
+          throw new Error("Refusing oversized changedFiles payload; metadata-only paths are required.");
+        }
+      }
+    }
+  }
+}

--- a/src/scenarios/input-model.ts
+++ b/src/scenarios/input-model.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
 import { sanitizePublicComment } from "../github/commands";
+import { assertScenarioLocalBranchInputSafe } from "../../packages/loopover-mcp/lib/scenario-local-branch-input-safe.js";
+
+export { assertScenarioLocalBranchInputSafe };
 
 export const SCENARIO_INPUT_VERSION = 1 as const;
 export const SCENARIO_MAX_REPO_FULL_NAME_CHARS = 200;
@@ -32,9 +35,6 @@ export type ScenarioSignalSource = (typeof scenarioSignalSources)[number];
 /** Shared public-safety term set for scenario input + public summary guards (#8885 / #913). */
 export const FORBIDDEN_PUBLIC_LANGUAGE =
   /wallet|hotkey|coldkey|mnemonic|seed phrase|payout|estimated[-\s]?rewards?|rewards?|reward[-\s]?estimate|rankings?|farming|raw trust|trust[-\s]?score|scoreability|private[-\s]?reviewability|public[-\s]?score[-\s]?(?:estimate|prediction)/i;
-
-const FORBIDDEN_SOURCE_UPLOAD_KEYS =
-  /^(?:sourceContent|sourceContents|fileContent|fileContents|rawSource|rawSourceContent|content|contents|diff|patch|rawDiff)$/i;
 
 const scenarioSignalEntrySchema = z
   .object({
@@ -185,39 +185,6 @@ export function buildScenarioInput(args: {
     notAutonomousPrBot: true,
     notPublicScoring: true,
   });
-}
-
-export function assertScenarioLocalBranchInputSafe(payload: Record<string, unknown>): void {
-  if (/^(1|true|yes)$/i.test(String(process.env.LOOPOVER_UPLOAD_SOURCE ?? "false"))) {
-    throw new Error("LOOPOVER_UPLOAD_SOURCE=true is not supported; scenario inputs remain metadata-only.");
-  }
-  for (const key of Object.keys(payload)) {
-    if (FORBIDDEN_SOURCE_UPLOAD_KEYS.test(key)) {
-      throw new Error(`Refusing scenario local-branch field ${key}; source contents are never uploaded.`);
-    }
-  }
-  const changedFiles = payload.changedFiles;
-  // #8328: a present-but-non-array changedFiles (a plain object like { diff: "…source…" }, a string, a number)
-  // is not the documented array-of-entries shape, and the Array.isArray guard below would silently skip the
-  // entire forbidden-key/oversize scan for it — letting exactly the source content this validator exists to
-  // refuse slip through unchecked. Reject it outright; an omitted / undefined changedFiles stays allowed.
-  if (changedFiles !== undefined && !Array.isArray(changedFiles)) {
-    throw new Error("Refusing non-array changedFiles; an array of file entries is required.");
-  }
-  if (Array.isArray(changedFiles)) {
-    for (const entry of changedFiles) {
-      if (!entry || typeof entry !== "object") continue;
-      for (const nestedKey of Object.keys(entry as Record<string, unknown>)) {
-        if (FORBIDDEN_SOURCE_UPLOAD_KEYS.test(nestedKey)) {
-          throw new Error(`Refusing changedFiles.${nestedKey}; source contents are never uploaded.`);
-        }
-        const value = (entry as Record<string, unknown>)[nestedKey];
-        if (typeof value === "string" && value.length > 4000) {
-          throw new Error("Refusing oversized changedFiles payload; metadata-only paths are required.");
-        }
-      }
-    }
-  }
 }
 
 export function scenarioInputFromLocalBranchMetadata(args: {

--- a/test/unit/local-branch.test.ts
+++ b/test/unit/local-branch.test.ts
@@ -1980,6 +1980,29 @@ describe("local MCP git metadata collection", () => {
     expect(() => collectLocalBranchMetadata({ cwd: tempDir, baseRef: "HEAD", login: "oktofeesh1" })).toThrow(/not supported/);
   });
 
+  it("rejects forbidden source-upload keys on the production collectLocalBranchMetadata entry point (#8884)", async () => {
+    const { collectLocalBranchMetadata } = await import("../../packages/loopover-mcp/lib/local-branch.js");
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-local-"));
+    git(tempDir, "init");
+    git(tempDir, "config", "user.email", "test@example.com");
+    git(tempDir, "config", "user.name", "LoopOver Test");
+    git(tempDir, "config", "commit.gpgsign", "false");
+    git(tempDir, "remote", "add", "origin", "git@github.com:acme/widgets.git");
+    writeFileSync(join(tempDir, "README.md"), "fixture\n");
+    git(tempDir, "add", "README.md");
+    git(tempDir, "commit", "-m", "initial");
+
+    expect(() =>
+      collectLocalBranchMetadata({
+        cwd: tempDir,
+        baseRef: "HEAD",
+        login: "oktofeesh1",
+        // Forbidden top-level key — must be refused by assertScenarioLocalBranchInputSafe on the production path.
+        ...({ sourceContent: "export const leak = true" } as object),
+      } as Parameters<typeof collectLocalBranchMetadata>[0]),
+    ).toThrow(/source contents are never uploaded/i);
+  });
+
   it("selects and validates cwd from MCP roots without leaking local paths", async () => {
     const { collectLocalBranchMetadata, normalizeMcpWorkspaceRoots, resolveWorkspaceCwd } = await import("../../packages/loopover-mcp/lib/local-branch.js");
     tempDir = mkdtempSync(join(tmpdir(), "loopover-local-"));


### PR DESCRIPTION
## Summary

- Move `assertScenarioLocalBranchInputSafe` into the MCP package and re-export it from `src/scenarios/input-model.ts`.
- Call it from `collectLocalBranchMetadata` (production entry point) so forbidden source-upload keys are refused there, not only in isolated unit tests.
- Add a regression test on the production collector path.

Closes #8884

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Full suite not re-run locally (Node 24 vs engines Node 22). Diff wires an existing guard into the MCP collector + unit coverage; CI is source of truth.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — no visible UI changes.

## Notes

- Non-engine aspect (`fix(scenarios)` / MCP).