### PR TITLE
fix(db): drop stale migration-90 grandfather entry

### DIFF
--- a/scripts/check-migrations.ts
+++ b/scripts/check-migrations.ts
@@ -23,12 +23,12 @@
 //   • 0074 — both 0074_ai_review_cache (#1462) and 0074_orb_self_enrollment_disabled (#1465, a bare ADD COLUMN)
 //     merged + deployed before the collision surfaced; the column already exists in prod, so a rename would
 //     re-run the ALTER and fail. Grandfathered for the same reason as 0015/0017.
-//   • 0090 — both 0090_contributor_cap_label (#2479) and 0090_pull_request_detail_sync_head_sha (#2527)
-//     merged with bare ADD COLUMN statements. Preserve both filenames so already-applied databases never
-//     replay either ALTER under a new migration name.
+//   • 0090 — historically both 0090_contributor_cap_label (#2479) and 0090_pull_request_detail_sync_head_sha
+//     (#2527) collided; the latter was renumbered to 0092, so only contributor_cap_label remains at 90 and
+//     the grandfather entry was removed (#8897).
 //   • 0156 — both 0156_draft_pr_close_policy and 0156_pull_request_screenshot_table_presence_satisfied
 //     merged independently from the same base and were both applied to production before the collision
-//     surfaced; bare ADD COLUMN statements, same grandfather reasoning as 0074/0090.
+//     surfaced; bare ADD COLUMN statements, same grandfather reasoning as 0074.
 import { readdirSync, readFileSync } from "node:fs";
 import { detectMigrationCollisions, extractMigrationNumber, KNOWN_MIGRATION_DUPLICATES, MIGRATION_FILENAME_PATTERN } from "../src/db/migration-collisions.js";
 import { detectColumnCollisions } from "../src/db/migration-column-extraction.js";

--- a/src/db/migration-collisions.ts
+++ b/src/db/migration-collisions.ts
@@ -26,7 +26,6 @@ export const KNOWN_MIGRATION_DUPLICATES: ReadonlyMap<number, ReadonlySet<string>
   [15, new Set(["0015_github_agent_command_feedback.sql", "0015_product_usage_events.sql"])],
   [17, new Set(["0017_agent_recommendation_outcomes.sql", "0017_product_usage_role_retention_rollups.sql"])],
   [74, new Set(["0074_ai_review_cache.sql", "0074_orb_self_enrollment_disabled.sql"])],
-  [90, new Set(["0090_contributor_cap_label.sql", "0090_pull_request_detail_sync_head_sha.sql"])],
   [156, new Set(["0156_draft_pr_close_policy.sql", "0156_pull_request_screenshot_table_presence_satisfied.sql"])],
 ]);
 

--- a/test/unit/check-migrations-script.test.ts
+++ b/test/unit/check-migrations-script.test.ts
@@ -37,7 +37,7 @@ describe("check-migrations script", () => {
   it("reports every grandfathered duplicate migration number in the success summary", () => {
     const output = execFileSync(TSX_BIN, ["scripts/check-migrations.ts"], { encoding: "utf8" });
 
-    expect(output).toContain("(5 grandfathered duplicates: 0015, 0017, 0074, 0090, 0156)");
+    expect(output).toContain("(4 grandfathered duplicates: 0015, 0017, 0074, 0156)");
   });
 
   it.each([

--- a/test/unit/migration-collisions.test.ts
+++ b/test/unit/migration-collisions.test.ts
@@ -75,10 +75,16 @@ describe("KNOWN_MIGRATION_DUPLICATES (#2550)", () => {
   it("stays byte-identical to scripts/check-migrations.ts's grandfathered list", () => {
     // A drift here would mean the CI script and the live premerge recheck disagree about what's grandfathered
     // — this pins the exact set so a future addition to one side without the other is caught immediately.
-    expect([...KNOWN_MIGRATION_DUPLICATES.keys()].sort((a, b) => a - b)).toEqual([15, 17, 74, 90, 156]);
-    expect(KNOWN_MIGRATION_DUPLICATES.get(90)).toEqual(new Set(["0090_contributor_cap_label.sql", "0090_pull_request_detail_sync_head_sha.sql"]));
+    expect([...KNOWN_MIGRATION_DUPLICATES.keys()].sort((a, b) => a - b)).toEqual([15, 17, 74, 156]);
+    expect(KNOWN_MIGRATION_DUPLICATES.has(90)).toBe(false);
     expect(KNOWN_MIGRATION_DUPLICATES.get(156)).toEqual(
       new Set(["0156_draft_pr_close_policy.sql", "0156_pull_request_screenshot_table_presence_satisfied.sql"]),
     );
+  });
+
+  it("does not report a collision for the single real migration 90 file (#8897)", () => {
+    expect(
+      detectMigrationCollisions(["0090_contributor_cap_label.sql", "0092_pull_request_detail_sync_head_sha.sql"], KNOWN_MIGRATION_DUPLICATES),
+    ).toEqual([]);
   });
 });

--- a/test/unit/queue-3.test.ts
+++ b/test/unit/queue-3.test.ts
@@ -2197,11 +2197,12 @@ describe("queue processors", () => {
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
       await seedMigrationRecheckRepo(env, 69, { premergeContentRecheck: true });
       const seen = { closed: false, merged: false, labels: [] as string[], comments: [] as string[], treeCalls: 0 };
-      // The real, already-shipped 0090 grandfathered pair (see KNOWN_MIGRATION_DUPLICATES) is present on main —
-      // this must never trigger a hold for an unrelated PR touching a different number.
+      // The real, already-shipped 0156 grandfathered pair (see KNOWN_MIGRATION_DUPLICATES) is present on main —
+      // this must never trigger a hold for an unrelated PR touching a different number. (0090 is no longer
+      // grandfathered after #8897 — only contributor_cap_label remains at that number.)
       stubMigrationRecheckFetch(69, { filename: "migrations/0099_a.sql", status: "added" }, [
-        { type: "blob", path: "migrations/0090_contributor_cap_label.sql" },
-        { type: "blob", path: "migrations/0090_pull_request_detail_sync_head_sha.sql" },
+        { type: "blob", path: "migrations/0156_draft_pr_close_policy.sql" },
+        { type: "blob", path: "migrations/0156_pull_request_screenshot_table_presence_satisfied.sql" },
       ], seen);
 
       await processJob(env, { type: "agent-regate-pr", deliveryId: "migration-grandfathered", repoFullName: "owner/repo", prNumber: 69, installationId: 123 });


### PR DESCRIPTION
## Summary

- Drop the stale `0090` entry from `KNOWN_MIGRATION_DUPLICATES` after the second file was renumbered to `0092`.
- Update check-migrations summary/tests and the live-recheck grandfather fixture to the still-shipped `0156` pair.

Closes #8897

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Full suite not re-run locally (Node 24 vs engines Node 22). Migration grandfather list + unit tests only; CI is source of truth.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — no visible UI changes.

## Notes

- Non-engine aspect (`fix(db)`).