### PR TITLE
fix(engine): warn and fall back for out-of-range similarityThreshold (#8862)

### DIFF
--- a/packages/loopover-engine/src/miner-goal-spec.ts
+++ b/packages/loopover-engine/src/miner-goal-spec.ts
@@ -259,10 +259,16 @@ function normalizeSelfPlagiarismPolicy(
   const record = value as Record<string, unknown>;
   if (
     record.similarityThreshold !== undefined &&
-    typeof record.similarityThreshold !== "number"
+    (typeof record.similarityThreshold !== "number" ||
+      !Number.isFinite(record.similarityThreshold) ||
+      record.similarityThreshold < 0 ||
+      record.similarityThreshold > 1)
   ) {
+    // An out-of-range or non-finite value previously fell through to self-plagiarism.ts's Math.min(1, Math.max(0, ...))
+    // and was silently clamped with no warning, marked "present" -- unlike every sibling numeric normalizer here.
+    // Warn and fall back to the default instead (#8862).
     warnings.push(
-      `MinerGoalSpec field "${field}.similarityThreshold" must be a number; falling back to ${fallback.similarityThreshold}.`,
+      `MinerGoalSpec field "${field}.similarityThreshold" must be a number in [0, 1]; falling back to ${fallback.similarityThreshold}.`,
     );
     return fallback;
   }

--- a/test/unit/miner-goal-spec-parser.test.ts
+++ b/test/unit/miner-goal-spec-parser.test.ts
@@ -224,6 +224,25 @@ describe("MinerGoalSpec parser (#2301)", () => {
     expect(arrayValue.warnings.join(" ")).toMatch(/selfPlagiarism.*must be a mapping/i);
   });
 
+  it("warns and falls back for an out-of-range or non-finite similarityThreshold instead of silently clamping (#8862)", () => {
+    // A numeric value outside [0, 1] used to fall through to self-plagiarism.ts's Math.min(1, Math.max(0, value)),
+    // silently clamping (e.g. 5 -> 1) with zero warnings and the field marked "present" -- unlike every sibling
+    // numeric normalizer. Each of these must now warn AND fall back to the documented default of 0.85.
+    for (const badThreshold of [5, -1, Number.POSITIVE_INFINITY, Number.NaN]) {
+      const parsed = parseMinerGoalSpec({
+        wantedPaths: ["src/**"],
+        selfPlagiarism: { similarityThreshold: badThreshold },
+      });
+      expect(parsed.spec.selfPlagiarism).toEqual({ similarityThreshold: 0.85 });
+      expect(parsed.warnings.join(" ")).toMatch(/selfPlagiarism\.similarityThreshold.*must be a number in \[0, 1\]/i);
+    }
+
+    // An in-range value is still accepted verbatim with no warning.
+    const valid = parseMinerGoalSpec({ selfPlagiarism: { similarityThreshold: 0.42 } });
+    expect(valid.spec.selfPlagiarism).toEqual({ similarityThreshold: 0.42 });
+    expect(valid.warnings.join(" ")).not.toMatch(/similarityThreshold/i);
+  });
+
   it("a killSwitch policy alone (all other fields default) marks the spec present", () => {
     const parsed = parseMinerGoalSpec({ killSwitch: { paused: true } });
     expect(parsed.present).toBe(true);


### PR DESCRIPTION
## Problem

Closes #8862.

`normalizeSelfPlagiarismPolicy` in `packages/loopover-engine/src/miner-goal-spec.ts` only warned when `similarityThreshold` was **not a number**. A finite numeric value outside `[0, 1]` (e.g. `5` or `-1`) passed the type check, fell through to `resolveSelfPlagiarismConfig`, and was then silently clamped by `self-plagiarism.ts`'s `Math.min(1, Math.max(0, value))` -- collapsing to a bound with **no warning**, and the field reported as present/configured.

Every sibling numeric normalizer here behaves differently: `normalizePositiveInteger` warns and falls back to the documented default when a value is non-finite or out of range. This normalizer was the odd one out, so a fat-fingered threshold silently changed miner behavior.

## Fix

Extend the guard so a `similarityThreshold` that is non-finite or outside `[0, 1]` also warns and falls back to the default, matching the warn-and-fall-back convention of the sibling normalizers.

## Test

`test/unit/miner-goal-spec-parser.test.ts` asserts that `5`, `-1`, `Infinity`, and `NaN` each produce a `similarityThreshold ... must be a number in [0, 1]` warning and fall back to the default `0.85`, while an in-range value (`0.42`) is still accepted verbatim with no warning. The test targets the observable warning + fallback, so it fails if the guard is reverted.