### PR TITLE
fix(engine): key denyResult decision off eventType, not stage

### DIFF
--- a/packages/loopover-engine/src/governor/chokepoint.ts
+++ b/packages/loopover-engine/src/governor/chokepoint.ts
@@ -130,7 +130,7 @@ function denyResult(input: {
       eventType: input.eventType,
       repoFullName: input.repoFullName,
       actionClass: input.actionClass,
-      decision: input.stage === "kill_switch" ? "paused" : input.eventType === "throttled" ? "throttle" : "deny",
+      decision: input.eventType === "kill_switch" ? "paused" : input.eventType === "throttled" ? "throttle" : "deny",
       reason: input.reason,
       payload: { stage: input.stage, ...input.extraPayload },
     },

--- a/packages/loopover-engine/test/chokepoint.test.ts
+++ b/packages/loopover-engine/test/chokepoint.test.ts
@@ -94,6 +94,7 @@ test("budget cap: the termination ceiling denies with a kill_switch eventType (h
   );
   assert.equal(decision.stage, "budget_cap");
   assert.equal(decision.ledgerEvent.eventType, "kill_switch");
+  assert.equal(decision.ledgerEvent.decision, "paused", "a kill_switch eventType must record decision=paused regardless of which stage triggered it");
 });
 
 test("non-convergence: a stuck item denies before reputation/self-plagiarism run", () => {


### PR DESCRIPTION
## Summary
Fixes the governor ledger misclassifying the budget-cap termination ceiling as `deny` instead of `paused`.

`denyResult` in `packages/loopover-engine/src/governor/chokepoint.ts` computed the ledger's `decision` field by checking `stage === "kill_switch"`. But the budget-cap termination ceiling reaches `denyResult` with `stage: "budget_cap"` and `eventType: "kill_switch"` (see `budget-cap.ts:87-92` — the termination dimension is deliberately the most severe verdict, `kill_switch`). Because the stage label isn't literally `"kill_switch"`, that path recorded `decision: "deny"` even though the same `eventType` is mapped to `"paused"` on the top-level kill-switch path. The ternary now checks `eventType` instead of `stage`, so any chokepoint stage whose event type is `kill_switch` consistently records `decision: "paused"`.

## Scope
- `packages/loopover-engine/src/governor/chokepoint.ts` — the ternary fix
- `packages/loopover-engine/test/chokepoint.test.ts` — regression assertion on the existing termination-ceiling test

## Validation
- `npx turbo run build --filter=@loopover/engine && npx turbo run build --filter=@loopover/mcp && npx turbo run build:tsc build:verify --filter=@loopover/miner` — green
- `npx vitest run --changed=upstream/main --passWithNoTests` — 109 files / 1745 tests, all passed
- `npm test` — 21981/22002 tests passed (21 skipped); the package's own `chokepoint.test.ts` suite (27 tests) passes including the new assertion

## Notes
This is a two-line, engine-only logic fix — no UI/frontend files were touched, so no screenshot evidence applies.

Closes #8864