### PR TITLE
fix(engine): align computeMinerGoalLaneFit's no-preference score with computeLaneFit

### DIFF
--- a/packages/loopover-engine/src/miner-goal-lane-fit.ts
+++ b/packages/loopover-engine/src/miner-goal-lane-fit.ts
@@ -21,6 +21,10 @@ function normalizeLabels(labels: readonly string[]): string[] {
 /**
  * Compute a [0, 1] lane-fit score from issue labels and a parsed {@link MinerGoalSpec}. Path-based fit is
  * intentionally omitted — discovery metadata has labels only; path gating belongs in the analyze phase.
+ *
+ * The no-preference neutral score matches {@link computeLaneFit}'s rule 2 (`0.5`, unopinionated) rather
+ * than `1`: an unconfigured `preferredLabels` means the operator has no opinion, not that every issue is
+ * a perfect fit (#8870).
  */
 export function computeMinerGoalLaneFit(
   issue: { labels: readonly string[] },
@@ -36,7 +40,7 @@ export function computeMinerGoalLaneFit(
 
   let score: number;
   if (preferred.length === 0) {
-    score = 1;
+    score = 0.5;
   } else {
     const preferredMatch = preferred.some((want) => issueLabels.includes(want));
     if (preferredMatch) {

--- a/packages/loopover-engine/test/miner-goal-lane-fit.test.ts
+++ b/packages/loopover-engine/test/miner-goal-lane-fit.test.ts
@@ -9,8 +9,8 @@ test("isMinerRepoTargetable respects minerEnabled opt-out", () => {
   assert.equal(isMinerRepoTargetable({ ...DEFAULT_MINER_GOAL_SPEC, minerEnabled: false }), false);
 });
 
-test("computeMinerGoalLaneFit returns 1 when no preferred labels are configured", () => {
-  assert.equal(computeMinerGoalLaneFit({ labels: ["docs"] }, DEFAULT_MINER_GOAL_SPEC), 1);
+test("computeMinerGoalLaneFit returns the neutral 0.5 when no preferred labels are configured", () => {
+  assert.equal(computeMinerGoalLaneFit({ labels: ["docs"] }, DEFAULT_MINER_GOAL_SPEC), 0.5);
 });
 
 test("computeMinerGoalLaneFit matches preferred labels case-insensitively", () => {
@@ -39,7 +39,7 @@ test("computeMinerGoalLaneFit applies issueDiscoveryPolicy modifiers", () => {
 test("computeMinerGoalLaneFit returns 0 when a blocked label matches case-insensitively", () => {
   const spec = { ...DEFAULT_MINER_GOAL_SPEC, blockedLabels: ["wontfix"] };
   assert.equal(computeMinerGoalLaneFit({ labels: ["WontFix"] }, spec), 0);
-  assert.equal(computeMinerGoalLaneFit({ labels: ["bug"] }, spec), 1);
+  assert.equal(computeMinerGoalLaneFit({ labels: ["bug"] }, spec), 0.5);
 });
 
 test("computeMinerGoalLaneFit ignores malformed label entries safely", () => {

--- a/test/unit/metadata-min-score.test.ts
+++ b/test/unit/metadata-min-score.test.ts
@@ -23,9 +23,9 @@ describe("rankMetadataOpportunitiesAtOrAboveScore", () => {
   ];
 
   it("keeps only metadata candidates at or above the score threshold in rank order", () => {
-    const filtered = rankMetadataOpportunitiesAtOrAboveScore(candidates, { nowMs: NOW }, 0.1);
+    const filtered = rankMetadataOpportunitiesAtOrAboveScore(candidates, { nowMs: NOW }, 0.05);
     expect(filtered.map((entry) => entry.issueNumber)).toEqual([3, 2]);
-    expect(filtered.every((entry) => entry.rankScore >= 0.1)).toBe(true);
+    expect(filtered.every((entry) => entry.rankScore >= 0.05)).toBe(true);
   });
 
   it("returns every targetable candidate when the threshold is zero", () => {
@@ -72,7 +72,7 @@ describe("rankMetadataOpportunitiesAtOrAboveScore", () => {
     const barrel = await import("../../packages/loopover-engine/src/index");
     expect(typeof barrel.rankMetadataOpportunitiesAtOrAboveScore).toBe("function");
     expect(
-      barrel.rankMetadataOpportunitiesAtOrAboveScore(candidates, { nowMs: NOW }, 0.1).map(
+      barrel.rankMetadataOpportunitiesAtOrAboveScore(candidates, { nowMs: NOW }, 0.05).map(
         (entry: { issueNumber: number }) => entry.issueNumber,
       ),
     ).toEqual([3, 2]);

--- a/test/unit/metadata-top-min-score.test.ts
+++ b/test/unit/metadata-top-min-score.test.ts
@@ -24,14 +24,14 @@ describe("pickTopMetadataOpportunitiesAtOrAboveScore", () => {
   ];
 
   it("returns the top survivors after applying the score threshold", () => {
-    const topTwo = pickTopMetadataOpportunitiesAtOrAboveScore(candidates, { nowMs: NOW }, 0.1, 2);
+    const topTwo = pickTopMetadataOpportunitiesAtOrAboveScore(candidates, { nowMs: NOW }, 0.05, 2);
     expect(topTwo.map((entry) => entry.issueNumber)).toEqual([3, 2]);
-    expect(topTwo.every((entry) => entry.rankScore >= 0.1)).toBe(true);
+    expect(topTwo.every((entry) => entry.rankScore >= 0.05)).toBe(true);
   });
 
   it("returns every qualifying candidate when the limit exceeds the filtered list", () => {
     expect(
-      pickTopMetadataOpportunitiesAtOrAboveScore(candidates, { nowMs: NOW }, 0.1, 10).map(
+      pickTopMetadataOpportunitiesAtOrAboveScore(candidates, { nowMs: NOW }, 0.05, 10).map(
         (entry) => entry.issueNumber,
       ),
     ).toEqual([3, 2, 4]);

--- a/test/unit/miner-goal-lane-fit.test.ts
+++ b/test/unit/miner-goal-lane-fit.test.ts
@@ -89,7 +89,7 @@ describe("computeMinerGoalLaneFit", () => {
     expect(computeMinerGoalLaneFit({ labels: ["feature"] }, spec)).toBe(0.25);
   });
 
-  it("scores normally when no blocked labels are configured", () => {
-    expect(computeMinerGoalLaneFit({ labels: ["docs"] }, DEFAULT_MINER_GOAL_SPEC)).toBe(1);
+  it("returns the neutral 0.5 when no preferred labels are configured", () => {
+    expect(computeMinerGoalLaneFit({ labels: ["docs"] }, DEFAULT_MINER_GOAL_SPEC)).toBe(0.5);
   });
 });


### PR DESCRIPTION
Closes #8870

computeMinerGoalLaneFit and computeLaneFit disagreed on what "no preference configured" should score: computeLaneFit's rule 2 returns the neutral 0.5 when neither wantedPaths nor preferredLabels is set, but computeMinerGoalLaneFit's label-only equivalent returned 1 for an unconfigured preferredLabels — a silent 2x divergence that skewed issue-ranking for autonomous targeting toward repos with no configured label preference at all.

Aligned computeMinerGoalLaneFit's no-preference branch to return 0.5 and added a doc comment cross-referencing computeLaneFit's rule so the two scorers stay in sync going forward. Updated the direct unit-test assertions in both `packages/loopover-engine/test/miner-goal-lane-fit.test.ts` and `test/unit/miner-goal-lane-fit.test.ts` to expect 0.5.

This neutral-score change flows into `buildMetadataRankInput`'s composite rankScore, so two existing threshold-based tests (`test/unit/metadata-min-score.test.ts`, `test/unit/metadata-top-min-score.test.ts`) that relied on unconfigured-label candidates scoring a full 1 needed their fixed thresholds recalibrated from 0.1 to 0.05 — the filtered/ordered issue-number expectations are unchanged, only the threshold value that was tuned against the old (incorrect) neutral score.

No UI files touched — this is a pure `src/`/`test/` scoring-logic change with no visible output, so no screenshot evidence applies.

## Validation
- `npx turbo run build --filter=@loopover/engine && npx turbo run build --filter=@loopover/mcp && npx turbo run build:tsc build:verify --filter=@loopover/miner` — green
- `npx vitest run --changed=upstream/main --passWithNoTests` — 110 files / 1754 tests passed
- `npm test` — 1177 files / 22009 tests passed (one pre-existing, unrelated environmental failure in check-ui-kit-package.test.ts, resolved by running `npm run build --workspace @loopover/ui-kit` first)

## Residuals
None — the issue's full scope (align the value, update tests, keep coverage on the changed branch) is covered in this PR.