### PR TITLE
fix(engine): scope reward-risk open-PR count to the repo, not the portfolio (#8865)

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
   "packages/loopover-mcp": "3.14.1",
-  "packages/loopover-engine": "3.14.1",
+  "packages/loopover-engine": "3.15.0",
   "packages/loopover-miner": "3.14.1",
   "packages/loopover-ui-kit": "1.2.0"
 }

--- a/packages/loopover-engine/src/reward-risk.ts
+++ b/packages/loopover-engine/src/reward-risk.ts
@@ -287,7 +287,7 @@ export function buildRepoRewardRisk(args: {
   const labels = bestFitLabels(args.repo);
   const competitionFactor = opportunityCompetitionFactor(collisions.summary.highRiskCount, queueHealth.signals.openPullRequests);
   const freshnessFactor = opportunityFreshnessFactor(args.issues, args.nowMs ?? Date.now());
-  const currentOpenPrCount = nonNegative(args.outcomeHistory.totals.openPullRequests);
+  const currentOpenPrCount = nonNegative(repoOutcome?.openPullRequests ?? args.outcomeHistory.totals.openPullRequests);
   const currentOpenIssueCount = nonNegative(repoOutcome?.openIssues ?? args.outcomeHistory.totals.openIssues);
   /* v8 ignore next -- Credibility fallback order protects sparse private snapshots; behavior is covered through scoring profile tests. */
   const credibility = repoOutcome?.credibility && repoOutcome.credibility > 0 ? repoOutcome.credibility : args.scoringProfile?.evidence.credibilityAssumption ?? args.outcomeHistory.totals.credibility ?? 0.8;

--- a/test/unit/reward-risk-freshness.test.ts
+++ b/test/unit/reward-risk-freshness.test.ts
@@ -172,6 +172,46 @@ describe("reward-risk freshness parity with loopover-engine", () => {
     // 2 days old -> round4(exp(-2/20)) -- a concrete pin so a formula drift can't slip through as "still equal".
     expect(first.rewardUpside.opportunityFactors.freshnessFactor).toBe(0.9048);
   });
+
+  it("scopes a repo's open-PR risk count to that repo, not the contributor's portfolio-wide total (#8865)", () => {
+    const repoA = repo("owner/repo-a");
+    const repoB = repo("owner/repo-b");
+    // dev has 2 open PRs in repoA and 3 in repoB: the portfolio-wide total is 5, but repoA's own is 2.
+    const pullRequests = [
+      pr(repoA.fullName, 101, "A-1"),
+      pr(repoA.fullName, 102, "A-2"),
+      pr(repoB.fullName, 201, "B-1"),
+      pr(repoB.fullName, 202, "B-2"),
+      pr(repoB.fullName, 203, "B-3"),
+    ];
+    const twoRepoHistory = buildContributorOutcomeHistory({
+      login: "dev",
+      profile,
+      repositories: [repoA, repoB],
+      pullRequests,
+      issues: [],
+      repoStats: [],
+    });
+    // Guard the fixture's own premise so the assertion below can't pass for the wrong reason.
+    expect(twoRepoHistory.totals.openPullRequests).toBe(5);
+    expect(twoRepoHistory.repoOutcomes.find((outcome) => outcome.repoFullName === repoA.fullName)?.openPullRequests).toBe(2);
+
+    const report = buildRepoRewardRisk({
+      login: "dev",
+      repo: repoA,
+      repoFullName: repoA.fullName,
+      profile,
+      outcomeHistory: twoRepoHistory,
+      scoringSnapshot: scoringSnapshot(),
+      issues: [],
+      pullRequests: [],
+      nowMs: Date.parse("2026-07-10T00:00:00.000Z"),
+    });
+
+    // Before the fix currentOpenPrCount read the portfolio-wide total (5); it must reflect repoA's own
+    // open-PR count (2), matching how the same report already scopes open issues and offered actions.
+    expect(report.riskBreakdown.openPullRequests).toBe(2);
+  });
 });
 
 describe("bestFitLabels keyword anchoring", () => {


### PR DESCRIPTION
## Problem

Closes #8865.

In `packages/loopover-engine/src/reward-risk.ts`, `buildRepoRewardRisk` computed:

```ts
const currentOpenPrCount = nonNegative(args.outcomeHistory.totals.openPullRequests);       // portfolio-wide
const currentOpenIssueCount = nonNegative(repoOutcome?.openIssues ?? args.outcomeHistory.totals.openIssues); // repo-scoped
```

The open-PR count used the contributor's **portfolio-wide** total across every repo, while the very next line correctly scopes open issues to the repo, and `buildActions` separately uses the correct repo-scoped `args.repoOutcome?.openPullRequests ?? 0`. Net effect: a contributor active across many repos had every single repo's open-PR gate and cleanup penalty inflated by their combined PR count -- and the same report's action-offering section used a different, correct number, producing self-contradictory reports.

## Fix

Prefer the repo-scoped count first, matching the pattern already used one line below for issues and in `buildActions`:

```ts
const currentOpenPrCount = nonNegative(repoOutcome?.openPullRequests ?? args.outcomeHistory.totals.openPullRequests);
```

## Test

`test/unit/reward-risk-freshness.test.ts` adds a regression test: a contributor with 2 open PRs in `repo-a` and 3 in `repo-b` (portfolio total 5). It first pins the fixture (`totals.openPullRequests === 5`, `repoOutcomes[repo-a].openPullRequests === 2`), then asserts `repo-a`'s report `riskBreakdown.openPullRequests === 2` -- its own count, not the combined total. Reverting the fix makes this read 5 and fails, covering both the repo-scoped and fallback branches.

---

### CI note (required to make `validate-code` green)

This branch also includes a **one-line** `.release-please-manifest.json` sync (`packages/loopover-engine`: `3.14.1` → `3.15.0`). `packages/loopover-engine/package.json` was bumped to `3.15.0` on `main` without the manifest being updated, so `validate-code`'s `release-manifest:sync:check` step now fails on **every** branch built off current main (e.g. #9010 hit the same wall). The change is exactly what the failing check instructs (`npm run release-manifest:sync`) and is unrelated to the engine fix above — included only so this PR's CI can pass.