### PR TITLE
fix(engine): remove the dead AMS_POLICY_SPEC_FILENAMES discovery constant

### DIFF
--- a/packages/loopover-engine/src/ams-policy-spec.ts
+++ b/packages/loopover-engine/src/ams-policy-spec.ts
@@ -407,6 +407,3 @@ export function parseAmsPolicySpecContent(content: string | null | undefined): P
   }
   return parseAmsPolicySpec(parsed);
 }
-
-/** The documented `.loopover-ams` file-discovery order (first match wins), mirroring `MINER_GOAL_SPEC_FILENAMES`. */
-export const AMS_POLICY_SPEC_FILENAMES = [".loopover-ams.yml", ".github/loopover-ams.yml", ".loopover-ams.json", ".github/loopover-ams.json"] as const;

--- a/packages/loopover-engine/src/index.ts
+++ b/packages/loopover-engine/src/index.ts
@@ -559,7 +559,6 @@ export {
   DEFAULT_AMS_POLICY_SPEC,
   parseAmsPolicySpec,
   parseAmsPolicySpecContent,
-  AMS_POLICY_SPEC_FILENAMES,
   AMS_NETWORK_ALLOWLIST_ECOSYSTEMS,
   type AmsCapLimits,
   type AmsNetworkAllowlist,

--- a/packages/loopover-engine/test/ams-policy-spec-parser.test.ts
+++ b/packages/loopover-engine/test/ams-policy-spec-parser.test.ts
@@ -1,7 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
-  AMS_POLICY_SPEC_FILENAMES,
   DEFAULT_AMS_POLICY_SPEC,
   parseAmsPolicySpec,
   parseAmsPolicySpecContent,
@@ -10,12 +9,6 @@ import {
 test("barrel: the public entrypoint re-exports the AmsPolicySpec parser API", () => {
   assert.equal(typeof parseAmsPolicySpec, "function");
   assert.equal(typeof parseAmsPolicySpecContent, "function");
-  assert.deepEqual(AMS_POLICY_SPEC_FILENAMES, [
-    ".loopover-ams.yml",
-    ".github/loopover-ams.yml",
-    ".loopover-ams.json",
-    ".github/loopover-ams.json",
-  ]);
 });
 
 test("parseAmsPolicySpec: missing raw input returns an absent safe-default spec with no warnings", () => {

--- a/test/unit/ams-policy-spec-parser.test.ts
+++ b/test/unit/ams-policy-spec-parser.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import {
-  AMS_POLICY_SPEC_FILENAMES,
   DEFAULT_AMS_POLICY_SPEC,
   parseAmsPolicySpec,
   parseAmsPolicySpecContent,
@@ -10,12 +9,6 @@ describe("AmsPolicySpec parser (#5132)", () => {
   it("re-exports the parser API from the engine barrel", () => {
     expect(typeof parseAmsPolicySpec).toBe("function");
     expect(typeof parseAmsPolicySpecContent).toBe("function");
-    expect(AMS_POLICY_SPEC_FILENAMES).toEqual([
-      ".loopover-ams.yml",
-      ".github/loopover-ams.yml",
-      ".loopover-ams.json",
-      ".github/loopover-ams.json",
-    ]);
   });
 
   it("treats missing raw input as an absent safe-default spec", () => {


### PR DESCRIPTION
## What & why

Closes #8863.

`packages/loopover-engine/src/ams-policy-spec.ts` exported `AMS_POLICY_SPEC_FILENAMES`, claiming a
documented 4-path first-match-wins discovery order "mirroring `MINER_GOAL_SPEC_FILENAMES`". But the
real consumer, `packages/loopover-miner/lib/ams-policy.ts`, resolves AMS policy from a **single**
operator-config-dir filename (`.loopover-ams.yml`), never imports the constant, and has no fallback
chain — so an operator using `.github/` or `.json` variants silently got defaults. The constant was
dead and its comment misdescribed real behavior.

## Choice (issue option a)

AMS policy is **deliberately operator-local**, not repo-discovered (the resolver reads only the
operator config dir), so I removed the misleading constant rather than wiring a repo-discovery chain
the resolver is not meant to have.

## Change

- Delete `AMS_POLICY_SPEC_FILENAMES` and its doc comment from `ams-policy-spec.ts`.
- Drop the barrel re-export from `packages/loopover-engine/src/index.ts`.
- Remove the two barrel tests' assertions of the literal array.

## Confirmation

Grep-verified the constant had **no other references** anywhere in the tree (only its declaration,
the barrel export, and the two removed test assertions). `ams-policy.ts` is unchanged. The engine
typecheck and both barrel test suites pass with the constant removed.
