### PR TITLE
fix(engine): redact blocklisted terms in chat-grounding tool_result content

### DIFF
--- a/packages/loopover-engine/src/miner/chat-grounding.ts
+++ b/packages/loopover-engine/src/miner/chat-grounding.ts
@@ -227,7 +227,12 @@ function* foldAssistantMessage(message: Record<string, unknown>): Generator<Chat
   }
 }
 
-/** Folds one user message's tool-result blocks (the SDK reports tool output on a `user`-role message). */
+/**
+ * Folds one user message's tool-result blocks (the SDK reports tool output on a `user`-role message). String tool
+ * output is a public-facing leak vector the same way an assistant `text` chunk is — an MCP tool's own output could
+ * echo a blocklisted field — so it passes through the same PUBLIC_FIELD_BLOCKLIST backstop `foldAssistantMessage`
+ * applies. Non-string content (structured blocks) is forwarded unchanged.
+ */
 function* foldToolResultMessage(message: Record<string, unknown>): Generator<ChatGroundingEvent> {
   const content = asRecord(message.message)?.content;
   if (!Array.isArray(content)) return;
@@ -235,7 +240,8 @@ function* foldToolResultMessage(message: Record<string, unknown>): Generator<Cha
     const block = asRecord(rawBlock);
     if (!block || block.type !== "tool_result") continue;
     const tool = typeof block.tool_use_id === "string" ? block.tool_use_id : "";
-    yield { type: "tool_result", tool, output: block.content };
+    const output = typeof block.content === "string" ? redactBlockedText(block.content) : block.content;
+    yield { type: "tool_result", tool, output };
   }
 }
 

--- a/packages/loopover-engine/test/chat-grounding.test.ts
+++ b/packages/loopover-engine/test/chat-grounding.test.ts
@@ -146,6 +146,43 @@ test("a blocked term in a text chunk is redacted, a clean chunk is forwarded ver
   assert.deepEqual(events, [{ type: "text", text: CHAT_REDACTED_TEXT }, { type: "done" }]);
 });
 
+test("a blocked term in string tool_result content is redacted, non-string content passes through", async () => {
+  const redacted = await collect(
+    runChatGrounding(USER_ONLY, {
+      env: AGENT_SDK_ENV,
+      query: queryYielding([
+        {
+          type: "user",
+          message: {
+            content: [{ type: "tool_result", tool_use_id: "loopover_miner_status", content: "your trust score is 9" }],
+          },
+        },
+      ]),
+    }),
+  );
+  assert.deepEqual(redacted, [
+    { type: "tool_result", tool: "loopover_miner_status", output: CHAT_REDACTED_TEXT },
+    { type: "done" },
+  ]);
+
+  const structured = [{ type: "text", text: "run state is idle" }];
+  const passthrough = await collect(
+    runChatGrounding(USER_ONLY, {
+      env: AGENT_SDK_ENV,
+      query: queryYielding([
+        {
+          type: "user",
+          message: { content: [{ type: "tool_result", tool_use_id: "loopover_miner_status", content: structured }] },
+        },
+      ]),
+    }),
+  );
+  assert.deepEqual(passthrough, [
+    { type: "tool_result", tool: "loopover_miner_status", output: structured },
+    { type: "done" },
+  ]);
+});
+
 test("a thrown session becomes an error event still followed by done", async () => {
   const events = await collect(
     runChatGrounding(USER_ONLY, {

--- a/test/unit/chat-grounding-engine.test.ts
+++ b/test/unit/chat-grounding-engine.test.ts
@@ -269,6 +269,45 @@ describe("chat grounding privacy backstop (#6517)", () => {
     );
     expect(events).toEqual([{ type: "text", text: "your run state is idle" }, { type: "done" }]);
   });
+
+  it("redacts a blocklisted term in string tool_result content", async () => {
+    const events = await collect(
+      runChatGrounding(USER_ONLY, {
+        env: AGENT_SDK_ENV,
+        query: queryYielding([
+          {
+            type: "user",
+            message: {
+              content: [{ type: "tool_result", tool_use_id: "loopover_miner_status", content: "your trust score is 9" }],
+            },
+          },
+        ]),
+      }),
+    );
+    expect(events).toEqual([
+      { type: "tool_result", tool: "loopover_miner_status", output: CHAT_REDACTED_TEXT },
+      { type: "done" },
+    ]);
+  });
+
+  it("forwards non-string tool_result content unchanged", async () => {
+    const structured = [{ type: "text", text: "run state is idle" }];
+    const events = await collect(
+      runChatGrounding(USER_ONLY, {
+        env: AGENT_SDK_ENV,
+        query: queryYielding([
+          {
+            type: "user",
+            message: { content: [{ type: "tool_result", tool_use_id: "loopover_miner_status", content: structured }] },
+          },
+        ]),
+      }),
+    );
+    expect(events).toEqual([
+      { type: "tool_result", tool: "loopover_miner_status", output: structured },
+      { type: "done" },
+    ]);
+  });
 });
 
 describe("chat message validation + prompt building (#6517)", () => {


### PR DESCRIPTION
fix(engine): redact blocklisted terms in chat-grounding tool_result content

foldToolResultMessage forwarded an MCP tool's own output verbatim, so a
tool that echoed a blocklisted field could leak it into the public-facing
chat-grounding stream — bypassing the PUBLIC_FIELD_BLOCKLIST backstop that
foldAssistantMessage already applies to text chunks. Run string tool_result
content through the same redactBlockedText call before yielding; non-string
structured content still passes through unchanged.

Closes #8869



## Validation

Verified locally on this branch before opening:
- [x] `npm run typecheck`
- [x] `npx turbo run build:tsc build:verify`
- [x] `npm run test:coverage` — patch coverage 100.0% of changed lines
