### PR TITLE
fix(db): drop stale migration-90 grandfather entry after its second file was renumbered to 0092

### DIFF
--- a/scripts/check-migrations.ts
+++ b/scripts/check-migrations.ts
@@ -23,12 +23,9 @@
 //   • 0074 — both 0074_ai_review_cache (#1462) and 0074_orb_self_enrollment_disabled (#1465, a bare ADD COLUMN)
 //     merged + deployed before the collision surfaced; the column already exists in prod, so a rename would
 //     re-run the ALTER and fail. Grandfathered for the same reason as 0015/0017.
-//   • 0090 — both 0090_contributor_cap_label (#2479) and 0090_pull_request_detail_sync_head_sha (#2527)
-//     merged with bare ADD COLUMN statements. Preserve both filenames so already-applied databases never
-//     replay either ALTER under a new migration name.
 //   • 0156 — both 0156_draft_pr_close_policy and 0156_pull_request_screenshot_table_presence_satisfied
 //     merged independently from the same base and were both applied to production before the collision
-//     surfaced; bare ADD COLUMN statements, same grandfather reasoning as 0074/0090.
+//     surfaced; bare ADD COLUMN statements, same grandfather reasoning as 0074.
 import { readdirSync, readFileSync } from "node:fs";
 import { detectMigrationCollisions, extractMigrationNumber, KNOWN_MIGRATION_DUPLICATES, MIGRATION_FILENAME_PATTERN } from "../src/db/migration-collisions.js";
 import { detectColumnCollisions } from "../src/db/migration-column-extraction.js";

--- a/src/db/migration-collisions.ts
+++ b/src/db/migration-collisions.ts
@@ -26,7 +26,6 @@ export const KNOWN_MIGRATION_DUPLICATES: ReadonlyMap<number, ReadonlySet<string>
   [15, new Set(["0015_github_agent_command_feedback.sql", "0015_product_usage_events.sql"])],
   [17, new Set(["0017_agent_recommendation_outcomes.sql", "0017_product_usage_role_retention_rollups.sql"])],
   [74, new Set(["0074_ai_review_cache.sql", "0074_orb_self_enrollment_disabled.sql"])],
-  [90, new Set(["0090_contributor_cap_label.sql", "0090_pull_request_detail_sync_head_sha.sql"])],
   [156, new Set(["0156_draft_pr_close_policy.sql", "0156_pull_request_screenshot_table_presence_satisfied.sql"])],
 ]);
 

--- a/test/unit/check-migrations-script.test.ts
+++ b/test/unit/check-migrations-script.test.ts
@@ -37,7 +37,7 @@ describe("check-migrations script", () => {
   it("reports every grandfathered duplicate migration number in the success summary", () => {
     const output = execFileSync(TSX_BIN, ["scripts/check-migrations.ts"], { encoding: "utf8" });
 
-    expect(output).toContain("(5 grandfathered duplicates: 0015, 0017, 0074, 0090, 0156)");
+    expect(output).toContain("(4 grandfathered duplicates: 0015, 0017, 0074, 0156)");
   });
 
   it.each([

--- a/test/unit/migration-collisions.test.ts
+++ b/test/unit/migration-collisions.test.ts
@@ -69,14 +69,20 @@ describe("detectMigrationCollisions (#2550)", () => {
   it("defaults knownDuplicates to an empty map when omitted", () => {
     expect(detectMigrationCollisions(["0090_a.sql", "0090_b.sql"])).toHaveLength(1);
   });
+
+  it("reports no collision for migration 90 now that only its single real file remains (#8897)", () => {
+    // 0090_pull_request_detail_sync_head_sha was renumbered to 0092, so 0090 has a single real file today and
+    // is no longer in KNOWN_MIGRATION_DUPLICATES — a single file at a number never collides regardless.
+    expect(detectMigrationCollisions(["0090_contributor_cap_label.sql"], KNOWN_MIGRATION_DUPLICATES)).toEqual([]);
+  });
 });
 
 describe("KNOWN_MIGRATION_DUPLICATES (#2550)", () => {
   it("stays byte-identical to scripts/check-migrations.ts's grandfathered list", () => {
     // A drift here would mean the CI script and the live premerge recheck disagree about what's grandfathered
     // — this pins the exact set so a future addition to one side without the other is caught immediately.
-    expect([...KNOWN_MIGRATION_DUPLICATES.keys()].sort((a, b) => a - b)).toEqual([15, 17, 74, 90, 156]);
-    expect(KNOWN_MIGRATION_DUPLICATES.get(90)).toEqual(new Set(["0090_contributor_cap_label.sql", "0090_pull_request_detail_sync_head_sha.sql"]));
+    expect([...KNOWN_MIGRATION_DUPLICATES.keys()].sort((a, b) => a - b)).toEqual([15, 17, 74, 156]);
+    expect(KNOWN_MIGRATION_DUPLICATES.get(90)).toBeUndefined();
     expect(KNOWN_MIGRATION_DUPLICATES.get(156)).toEqual(
       new Set(["0156_draft_pr_close_policy.sql", "0156_pull_request_screenshot_table_presence_satisfied.sql"]),
     );

--- a/test/unit/queue-3.test.ts
+++ b/test/unit/queue-3.test.ts
@@ -2294,11 +2294,11 @@ describe("queue processors", () => {
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
       await seedMigrationRecheckRepo(env, 69, { premergeContentRecheck: true });
       const seen = { closed: false, merged: false, labels: [] as string[], comments: [] as string[], treeCalls: 0 };
-      // The real, already-shipped 0090 grandfathered pair (see KNOWN_MIGRATION_DUPLICATES) is present on main —
+      // The real, already-shipped 0156 grandfathered pair (see KNOWN_MIGRATION_DUPLICATES) is present on main —
       // this must never trigger a hold for an unrelated PR touching a different number.
       stubMigrationRecheckFetch(69, { filename: "migrations/0099_a.sql", status: "added" }, [
-        { type: "blob", path: "migrations/0090_contributor_cap_label.sql" },
-        { type: "blob", path: "migrations/0090_pull_request_detail_sync_head_sha.sql" },
+        { type: "blob", path: "migrations/0156_draft_pr_close_policy.sql" },
+        { type: "blob", path: "migrations/0156_pull_request_screenshot_table_presence_satisfied.sql" },
       ], seen);
 
       await processJob(env, { type: "agent-regate-pr", deliveryId: "migration-grandfathered", repoFullName: "owner/repo", prNumber: 69, installationId: 123 });


### PR DESCRIPTION
fix(db): drop stale migration-90 grandfather entry after its second file was renumbered to 0092

0090_pull_request_detail_sync_head_sha.sql was renumbered to
migrations/0092_pull_request_detail_sync_head_sha.sql, leaving only
0090_contributor_cap_label.sql at number 90. The [90, ...] entry in
KNOWN_MIGRATION_DUPLICATES therefore documented a grandfathered pair that no
longer exists on disk. Remove it so the list reflects the real set of
grandfathered collisions, and retarget the fixtures and header comment that
referenced the 0090 pair to the still-shipped 0156 pair.

Closes #8897



## Validation

Verified locally on this branch before opening:
- [x] `npm run typecheck`
- [x] `npx turbo run build:tsc build:verify`
- [x] `npm run test:coverage` — patch coverage 100.0% of changed lines
