### PR TITLE
fix(engine): chat-grounding tool_result events bypass the privacy redaction backstop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4084,6 +4084,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/@posthog/cli/node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "extraneous": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/@posthog/core": {
       "version": "1.42.1",
       "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.42.1.tgz",

--- a/packages/loopover-engine/src/miner/chat-grounding.ts
+++ b/packages/loopover-engine/src/miner/chat-grounding.ts
@@ -235,7 +235,9 @@ function* foldToolResultMessage(message: Record<string, unknown>): Generator<Cha
     const block = asRecord(rawBlock);
     if (!block || block.type !== "tool_result") continue;
     const tool = typeof block.tool_use_id === "string" ? block.tool_use_id : "";
-    yield { type: "tool_result", tool, output: block.content };
+    const output =
+      typeof block.content === "string" ? redactBlockedText(block.content) : block.content;
+    yield { type: "tool_result", tool, output };
   }
 }
 

--- a/packages/loopover-engine/test/chat-grounding.test.ts
+++ b/packages/loopover-engine/test/chat-grounding.test.ts
@@ -146,6 +146,43 @@ test("a blocked term in a text chunk is redacted, a clean chunk is forwarded ver
   assert.deepEqual(events, [{ type: "text", text: CHAT_REDACTED_TEXT }, { type: "done" }]);
 });
 
+test("a blocked term in a tool_result chunk is redacted, a clean chunk is forwarded verbatim", async () => {
+  const events = await collect(
+    runChatGrounding(USER_ONLY, {
+      env: AGENT_SDK_ENV,
+      query: queryYielding([
+        {
+          type: "user",
+          message: { content: [{ type: "tool_result", tool_use_id: "loopover_miner_status", content: "your wallet balance" }] },
+        },
+      ]),
+    }),
+  );
+  assert.deepEqual(events, [
+    { type: "tool_result", tool: "loopover_miner_status", output: CHAT_REDACTED_TEXT },
+    { type: "done" },
+  ]);
+});
+
+test("non-string tool_result content is forwarded without redaction", async () => {
+  const structured = { status: "idle" };
+  const events = await collect(
+    runChatGrounding(USER_ONLY, {
+      env: AGENT_SDK_ENV,
+      query: queryYielding([
+        {
+          type: "user",
+          message: { content: [{ type: "tool_result", tool_use_id: "loopover_miner_status", content: structured }] },
+        },
+      ]),
+    }),
+  );
+  assert.deepEqual(events, [
+    { type: "tool_result", tool: "loopover_miner_status", output: structured },
+    { type: "done" },
+  ]);
+});
+
 test("a thrown session becomes an error event still followed by done", async () => {
   const events = await collect(
     runChatGrounding(USER_ONLY, {

--- a/test/unit/chat-grounding-engine.test.ts
+++ b/test/unit/chat-grounding-engine.test.ts
@@ -269,6 +269,45 @@ describe("chat grounding privacy backstop (#6517)", () => {
     );
     expect(events).toEqual([{ type: "text", text: "your run state is idle" }, { type: "done" }]);
   });
+
+  it("redacts a tool_result chunk containing a blocked term", async () => {
+    const events = await collect(
+      runChatGrounding(USER_ONLY, {
+        env: AGENT_SDK_ENV,
+        query: queryYielding([
+          {
+            type: "user",
+            message: {
+              content: [{ type: "tool_result", tool_use_id: "loopover_miner_status", content: "your wallet balance" }],
+            },
+          },
+        ]),
+      }),
+    );
+    expect(events).toEqual([
+      { type: "tool_result", tool: "loopover_miner_status", output: CHAT_REDACTED_TEXT },
+      { type: "done" },
+    ]);
+  });
+
+  it("forwards non-string tool_result content without redaction", async () => {
+    const structured = { status: "idle" };
+    const events = await collect(
+      runChatGrounding(USER_ONLY, {
+        env: AGENT_SDK_ENV,
+        query: queryYielding([
+          {
+            type: "user",
+            message: { content: [{ type: "tool_result", tool_use_id: "loopover_miner_status", content: structured }] },
+          },
+        ]),
+      }),
+    );
+    expect(events).toEqual([
+      { type: "tool_result", tool: "loopover_miner_status", output: structured },
+      { type: "done" },
+    ]);
+  });
 });
 
 describe("chat message validation + prompt building (#6517)", () => {


### PR DESCRIPTION
## Summary

`packages/loopover-engine/src/miner/chat-grounding.ts`'s module header states the redaction invariant: every outgoing `text` chunk is checked against `PUBLIC_FIELD_BLOCKLIST` and redacted. `foldAssistantMessage` (line 221) correctly does this, but `foldToolResultMessage` (lines 230-240) forwards `block.content` from an MCP tool's own output verbatim, with zero redaction call. `test/chat-grounding.test.ts:119-134` confirms tool_result content passes through unredacted today.

## Deliverables

- [ ] `foldToolResultMessage` applies the same redaction call `foldAssistantMessage` uses before yielding content
- [ ] A test asserting a tool_result containing a blocklisted term is redacted in the output, matching the existing assistant-message redaction test

All of the above Deliverables are required in the same PR unless the deliverable text itself states otherwise.

## Test plan

`packages/loopover-engine/**` -- 99%+ patch coverage, branch-counted, on the new redaction call site.

Fixes #8869