### PR TITLE
fix(review): distinguish 'no certifiable threshold' from insufficient labels (#9048)

### DIFF
--- a/src/review/risk-control-wire.ts
+++ b/src/review/risk-control-wire.ts
@@ -134,14 +134,27 @@ async function recalibrateArm(env: Env, arm: "close" | "merge", verdict: "close"
   } else {
     // A stale guarantee is a lie: retract any previously-published λ̂ the moment the data stops supporting it.
     await env.DB.prepare(`DELETE FROM system_flags WHERE key = ?`).bind(riskControlFlagKey(scope)).run();
-    await recordAuditEvent(env, {
-      eventType: "risk_control_insufficient",
-      actor: null,
-      targetKey: `riskcontrol:${scope}`,
-      outcome: "completed",
-      detail: `${scope}: cannot certify α=${alpha} — ${result.have} usable label(s) of ${result.needed} needed`,
-      metadata: { arm, ...result },
-    });
+    if (result.status === "no_certifiable_threshold") {
+      // Distinct event + message so the label burn-down (#8828) never conflates "needs more labels" with
+      // "needs better close precision": this arm HAS the labels, the threshold is the blocker (#9048).
+      await recordAuditEvent(env, {
+        eventType: "risk_control_no_certifiable_threshold",
+        actor: null,
+        targetKey: `riskcontrol:${scope}`,
+        outcome: "completed",
+        detail: `${scope}: ${result.totalPairs} usable label(s) available but no threshold achieves α=${alpha} (best upper bound ${result.bestUpperBound} at λ=${result.bestLambda}, n=${result.bestN}) — the threshold, not the sample, is the blocker`,
+        metadata: { arm, ...result },
+      });
+    } else {
+      await recordAuditEvent(env, {
+        eventType: "risk_control_insufficient",
+        actor: null,
+        targetKey: `riskcontrol:${scope}`,
+        outcome: "completed",
+        detail: `${scope}: cannot certify α=${alpha} — ${result.have} usable label(s) of ${result.needed} needed`,
+        metadata: { arm, ...result },
+      });
+    }
   }
   return result;
 }

--- a/src/review/risk-control.ts
+++ b/src/review/risk-control.ts
@@ -79,7 +79,23 @@ export type CalibrationResult =
       delta: number;
       totalPairs: number;
     }
-  | { status: "insufficient_labels"; needed: number; have: number; alpha: number; delta: number };
+  | { status: "insufficient_labels"; needed: number; have: number; alpha: number; delta: number }
+  | {
+      /** Enough labels cleared the sample-size floor, but NO threshold certifies α: the error rate, not the
+       *  label supply, is the blocker (#9048). `totalPairs` is the TRUE usable-label count — never the
+       *  residual size of the final surviving stratum, which the old `insufficient_labels.have` conflated it
+       *  with, telling operators to collect labels that cannot help. */
+      status: "no_certifiable_threshold";
+      totalPairs: number;
+      needed: number;
+      /** n and λ of the sweep step that achieved the tightest bound while still clearing the sample floor. */
+      bestN: number;
+      bestLambda: number;
+      /** The tightest Clopper–Pearson upper bound achieved across the sweep — still above α. */
+      bestUpperBound: number;
+      alpha: number;
+      delta: number;
+    };
 
 /**
  * Fixed-sequence calibration, walked in DESCENDING-coverage order: candidates are the distinct observed
@@ -104,22 +120,27 @@ export function calibrateActThreshold(pairs: CalibrationPair[], alpha: number, d
   let dropped = 0;
   let droppedErrors = 0;
   let index = 0;
-  let lastTestedN = sorted.length;
+  // Every floor-clearing sweep step that failed to certify, so branch B can report the tightest bound achieved
+  // instead of the residual last-stratum size (#9048).
+  const attempts: Array<{ n: number; lambda: number; upperBound: number }> = [];
   for (const lambda of candidates) {
     const n = sorted.length - dropped;
     const errors = totalErrors - droppedErrors;
-    lastTestedN = n;
-    if (n >= needed && clopperPearsonUpperBound(errors, n, delta) <= alpha) {
-      return {
-        status: "calibrated",
-        lambda,
-        coverageAtLambda: n / sorted.length,
-        nAtLambda: n,
-        errorsAtLambda: errors,
-        alpha,
-        delta,
-        totalPairs: sorted.length,
-      };
+    if (n >= needed) {
+      const upperBound = clopperPearsonUpperBound(errors, n, delta);
+      if (upperBound <= alpha) {
+        return {
+          status: "calibrated",
+          lambda,
+          coverageAtLambda: n / sorted.length,
+          nAtLambda: n,
+          errorsAtLambda: errors,
+          alpha,
+          delta,
+          totalPairs: sorted.length,
+        };
+      }
+      attempts.push({ n, lambda, upperBound });
     }
     // Drop this stratum and test the next, more conservative λ.
     while (index < sorted.length && sorted[index]!.confidence <= lambda) {
@@ -128,5 +149,9 @@ export function calibrateActThreshold(pairs: CalibrationPair[], alpha: number, d
       index += 1;
     }
   }
-  return { status: "insufficient_labels", needed, have: lastTestedN, alpha, delta };
+  // The floor was cleared (the first candidate tests the full set, whose n === sorted.length >= needed) so at
+  // least one attempt was recorded, but no λ certified α. Report the TRUE label count and the tightest bound
+  // achieved so the burn-down sees precision — not sample size — as the blocker, never the residual stratum.
+  const best = attempts.reduce((tightest, attempt) => (attempt.upperBound < tightest.upperBound ? attempt : tightest));
+  return { status: "no_certifiable_threshold", totalPairs: sorted.length, needed, bestN: best.n, bestLambda: best.lambda, bestUpperBound: best.upperBound, alpha, delta };
 }

--- a/test/unit/risk-control-wire.test.ts
+++ b/test/unit/risk-control-wire.test.ts
@@ -86,6 +86,26 @@ describe("runRiskControlRecalibration", () => {
     const audit = await env.DB.prepare(`SELECT detail FROM audit_events WHERE event_type = 'risk_control_calibrated'`).first<{ detail: string }>();
     expect(audit!.detail).toContain("P(wrong | acted) ≤ 0.05 guaranteed at 100% coverage");
   });
+
+  it("NO CERTIFIABLE THRESHOLD: ample labels but high error emits a DISTINCT event with the true label count (#9048)", async () => {
+    const env = createTestEnv();
+    await env.DB.prepare(`INSERT INTO system_flags (key, value) VALUES (?, 'stale')`).bind(riskControlFlagKey("close")).run();
+    // 60 close labels clear the 59-label floor (alpha 0.05 under 350 pairs), but ~half are wrong at every
+    // confidence, so no threshold certifies. This is a precision problem, not a supply problem.
+    for (let i = 1; i <= 60; i += 1) await seedLabeledDecision(env, i, "close", i % 2 === 0 ? "correct" : "incorrect", 0.6 + (i % 4) / 100);
+    const summary = await runRiskControlRecalibration(env);
+    expect(summary.close).toBe("no_certifiable_threshold");
+    const flag = await env.DB.prepare(`SELECT value FROM system_flags WHERE key = ?`).bind(riskControlFlagKey("close")).first();
+    expect(flag).toBeFalsy(); // a stale guarantee is still retracted when no threshold certifies
+    const audit = await env.DB
+      .prepare(`SELECT detail FROM audit_events WHERE event_type = 'risk_control_no_certifiable_threshold' AND target_key = 'riskcontrol:close'`)
+      .first<{ detail: string }>();
+    expect(audit!.detail).toContain("60 usable label(s) available but no threshold achieves");
+    expect(audit!.detail).toContain("the threshold, not the sample, is the blocker");
+    // Crucially, the burn-down's supply-shortfall event is NOT emitted for this arm — the two are now distinct.
+    const conflated = await env.DB.prepare(`SELECT detail FROM audit_events WHERE event_type = 'risk_control_insufficient' AND target_key = 'riskcontrol:close'`).first();
+    expect(conflated).toBeFalsy();
+  });
 });
 
 describe("fail-safe arms", () => {

--- a/test/unit/risk-control.test.ts
+++ b/test/unit/risk-control.test.ts
@@ -64,12 +64,41 @@ describe("calibrateActThreshold (fixed-sequence)", () => {
     }
   });
 
-  it("a passing-but-tiny high-confidence clique cannot certify — the prefix itself must clear the floor", () => {
-    // 50 pristine pairs at 0.99, then errors immediately: the 0.99 prefix passes its bound test... but 50
-    // labels cannot certify alpha=0.005, and pretending otherwise is the exact dishonesty this refuses.
+  it("a floor-clearing set that no threshold certifies reports its TRUE label count, not the residual stratum (#9048)", () => {
+    // 50 pristine pairs at 0.99, then 600 errors: 650 labels clear the sample floor (>= 598), so this is NOT
+    // an insufficient-labels case. No λ certifies (the clean 0.99 prefix is under-powered; the full set is 92%
+    // wrong), so it is a "no certifiable threshold" outcome. `totalPairs` must be the true 650 usable labels --
+    // the old `insufficient_labels.have` reported the residual 50 here, the exact conflation #9048 fixes.
     const pairs = [...Array.from({ length: 50 }, () => pair(0.99, true)), ...Array.from({ length: 600 }, () => pair(0.5, false))];
     const result = calibrateActThreshold(pairs, 0.005, 0.05);
-    expect(result).toMatchObject({ status: "insufficient_labels", needed: 598, have: 50 });
+    expect(result).toMatchObject({ status: "no_certifiable_threshold", needed: 598, totalPairs: 650 });
+    // Never a residual: totalPairs is the label supply, distinct from the best surviving stratum's bestN.
+    if (result.status === "no_certifiable_threshold") {
+      expect(result.totalPairs).toBe(650);
+      expect(result.bestUpperBound).toBeGreaterThan(0.005); // still above alpha -- genuinely uncertifiable
+    }
+  });
+
+  it("branch B carries the tightest bound achieved and never mislabels a precision problem as a supply problem (#9048)", () => {
+    const rep = (n: number, confidence: number, wrongBelow: number) =>
+      Array.from({ length: n }, (_, i) => pair(confidence, i >= wrongBelow));
+
+    // A high error rate at every candidate; dropping low-confidence strata TIGHTENS the bound but never to
+    // alpha=0.2. The final 0.9 stratum (n=5) is under the floor and must be excluded from `bestN`.
+    const tightensThenSubFloor = [...rep(14, 0.3, 7), ...rep(14, 0.6, 2), ...rep(5, 0.9, 3)];
+    const a = calibrateActThreshold(tightensThenSubFloor, 0.2, 0.05);
+    expect(a).toMatchObject({ status: "no_certifiable_threshold", totalPairs: 33, needed: 14, bestN: 19, bestLambda: 0.6 });
+
+    // Dropping a CLEAN low-confidence stratum raises the residual error rate, so the tightest bound is the
+    // full set here -- the reduce must keep the earlier, lower bound rather than the looser later one.
+    const loosensAfterDrop = [...rep(14, 0.5, 0), ...rep(14, 0.9, 6)];
+    const b = calibrateActThreshold(loosensAfterDrop, 0.2, 0.05);
+    expect(b).toMatchObject({ status: "no_certifiable_threshold", totalPairs: 28, needed: 14, bestN: 28, bestLambda: 0.5 });
+    if (a.status === "no_certifiable_threshold" && b.status === "no_certifiable_threshold") {
+      // The tightest bound is genuinely the minimum across the sweep, above alpha in both directions of the drop.
+      expect(a.bestUpperBound).toBeGreaterThan(0.2);
+      expect(b.bestUpperBound).toBeGreaterThan(0.2);
+    }
   });
 
   it("is deterministic and input-order independent", () => {


### PR DESCRIPTION
## Problem

Closes #9048.

`calibrateActThreshold` (`src/review/risk-control.ts`) returned `insufficient_labels` from **two branches with two different meanings**:

- **(A)** the pre-loop sample-size guard (`pairs.length < needed`): `have` = total usable pairs. Correct and actionable.
- **(B)** the loop-exhausted exit (enough labels, but no threshold certifies α): `have` = the residual size of the final surviving stratum — an arbitrarily small number that says nothing about label supply.

`recalibrateArm` rendered both through one `risk_control_insufficient` event (`"{have} usable label(s) of {needed} needed"`), so a repo that already has plenty of labels but a too-high error rate was told to go collect more labels — and the more labels it accumulated, the more misleading the count got. The issue's live proof: `close:jsonbored/loopover` reported "**2** usable labels of 59 needed" while actually holding **61**.

## Fix

1. **New result variant** `no_certifiable_threshold` for branch B, carrying the TRUE `totalPairs` plus the tightest bound achieved across the sweep (`bestN`, `bestLambda`, `bestUpperBound`) — never the residual stratum size. Branch A keeps its exact `insufficient_labels` semantics.
2. **Distinct message** in `risk-control-wire.ts`: `"{totalPairs} usable label(s) available but no threshold achieves α=… (best upper bound … at λ=…, n=…) — the threshold, not the sample, is the blocker"`.
3. **Distinct `event_type`** `risk_control_no_certifiable_threshold` so the #8828 label burn-down cannot conflate "needs labels" with "needs better precision". The flag is still retracted in both cases (a stale guarantee is a lie).

## Tests

- `risk-control.test.ts`: a 650-label set that no threshold certifies now reports `totalPairs: 650` (the old code reported the residual `have: 50` — the exact conflation this fixes); plus a branch-B test pinning `bestN`/`bestLambda` and verifying the tightest bound is the genuine minimum across the sweep in both drop directions.
- `risk-control-wire.test.ts`: 60 labels over the floor but ~50% wrong emits `risk_control_no_certifiable_threshold` with the true count, and crucially does **not** emit `risk_control_insufficient` for that arm.

100% patch coverage (statements + branches) on both changed files. The published global guarantee is on the `calibrated` path and is unaffected.