### PR TITLE
test(review): seed the live pull_requests ledger for the submission-cadence tests

### DIFF
--- a/test/unit/reputation-wiring.test.ts
+++ b/test/unit/reputation-wiring.test.ts
@@ -279,11 +279,20 @@ describe("shouldSkipAiForReputation (helper)", () => {
 
   describe("submission-cadence signal (#4514)", () => {
     async function seedReviewTarget(env: Env, args: { number: number; submitter: string; createdAt: string }) {
+      // Merged/approved review_targets keep the QUALITY signal neutral/trusted, so only cadence can trip these.
       await env.DB.prepare(
         `INSERT INTO review_targets (id, project, kind, repo, number, submitter, status, decision_json, terminal_at, created_at)
          VALUES (?, 'acme/widgets', 'pull_request', 'acme/widgets', ?, ?, 'merged', ?, ?, ?)`,
       )
         .bind(`acme/widgets:pull_request:acme/widgets#${args.number}`, args.number, args.submitter, JSON.stringify({ reasonCode: "dual_review_approved" }), args.createdAt, args.createdAt)
+        .run();
+      // #9041 moved getSubmitterCadence off the cutover-frozen review_targets to the LIVE pull_requests ledger,
+      // so the submission-cadence signal is sourced from here now -- seed it too or the query reads 0 samples.
+      await env.DB.prepare(
+        `INSERT INTO pull_requests (id, repo_full_name, number, title, state, author_login, created_at)
+         VALUES (?, 'acme/widgets', ?, 'PR', 'open', ?, ?)`,
+      )
+        .bind(`acme/widgets#${args.number}`, args.number, args.submitter, args.createdAt)
         .run();
     }
 


### PR DESCRIPTION
## Problem

The `submission-cadence signal (#4514)` tests in `test/unit/reputation-wiring.test.ts` fail on current `main` (the `FLAG-ON: true for a machine-paced submitter` case asserts `true` but gets `false`), which fails `validate-tests` for **every** branch cut from main.

Root cause: **#9041** deliberately moved `getSubmitterCadence` (`src/review/submitter-reputation.ts`) off `review_targets` — which stopped receiving writes at the 2026-06-22 self-host cutover — to read the **live `pull_requests` ledger**:

```sql
SELECT created_at FROM pull_requests WHERE repo_full_name = ? AND LOWER(author_login) = LOWER(?) AND created_at >= datetime('now', '-24 hours') ...
```

But the cadence `describe` block's local `seedReviewTarget` helper still seeds only `review_targets`, so the cadence query reads **zero samples** → `count 0` → `isMachinePacedCadence` returns `false` → the machine-paced assertion fails.

## Fix

Seed `pull_requests` alongside `review_targets` in that helper so the cadence signal has the live data it now reads. The existing merged/approved `review_targets` rows are kept untouched — they are what hold the **quality** signal neutral so only cadence can trip these two tests. Only the assertion's data source is corrected; the assertions themselves are unchanged.

## Verification

`test/unit/reputation-wiring.test.ts`: **36/36 pass** (was 1 failed). The machine-paced test now correctly detects the sub-10-minute median gap, and the human-pace test still reads `false`. Test-only change.