### PR TITLE
fix(test): repoint the cadence-signal seed helper from review_targets to pull_requests

### DIFF
--- a/test/unit/reputation-wiring.test.ts
+++ b/test/unit/reputation-wiring.test.ts
@@ -278,12 +278,15 @@ describe("shouldSkipAiForReputation (helper)", () => {
   });
 
   describe("submission-cadence signal (#4514)", () => {
-    async function seedReviewTarget(env: Env, args: { number: number; submitter: string; createdAt: string }) {
+    // #9041 repointed getSubmitterCadence from the frozen review_targets table to the live pull_requests
+    // ledger (repo_full_name + author_login, not project + submitter) -- this seed helper follows suit so
+    // these tests exercise the query the code actually runs today, not the dead one it used to.
+    async function seedCadencePullRequest(env: Env, args: { number: number; submitter: string; createdAt: string }) {
       await env.DB.prepare(
-        `INSERT INTO review_targets (id, project, kind, repo, number, submitter, status, decision_json, terminal_at, created_at)
-         VALUES (?, 'acme/widgets', 'pull_request', 'acme/widgets', ?, ?, 'merged', ?, ?, ?)`,
+        `INSERT INTO pull_requests (id, repo_full_name, number, title, state, author_login, created_at)
+         VALUES (?, 'acme/widgets', ?, ?, 'open', ?, ?)`,
       )
-        .bind(`acme/widgets:pull_request:acme/widgets#${args.number}`, args.number, args.submitter, JSON.stringify({ reasonCode: "dual_review_approved" }), args.createdAt, args.createdAt)
+        .bind(`acme/widgets#${args.number}`, args.number, `cadence probe #${args.number}`, args.submitter, args.createdAt)
         .run();
     }
 
@@ -294,7 +297,7 @@ describe("shouldSkipAiForReputation (helper)", () => {
       const t0 = Date.now() - 2 * 60 * 60_000;
       for (let i = 0; i < 5; i++) {
         // All merged/approved -- the QUALITY signal alone stays neutral/trusted; only cadence should trip this.
-        await seedReviewTarget(env, { number: i, submitter: "speedster", createdAt: new Date(t0 + i * 5 * 60_000).toISOString() });
+        await seedCadencePullRequest(env, { number: i, submitter: "speedster", createdAt: new Date(t0 + i * 5 * 60_000).toISOString() });
       }
       expect(await shouldSkipAiForReputation(env, { project: "acme/widgets", submitter: "speedster" })).toBe(true);
     });
@@ -303,7 +306,7 @@ describe("shouldSkipAiForReputation (helper)", () => {
       const env = createTestEnv({ LOOPOVER_REVIEW_REPUTATION: "true" });
       const t0 = Date.now() - 20 * 60 * 60_000;
       for (let i = 0; i < 5; i++) {
-        await seedReviewTarget(env, { number: i + 100, submitter: "steady", createdAt: new Date(t0 + i * 3 * 60 * 60_000).toISOString() });
+        await seedCadencePullRequest(env, { number: i + 100, submitter: "steady", createdAt: new Date(t0 + i * 3 * 60 * 60_000).toISOString() });
       }
       expect(await shouldSkipAiForReputation(env, { project: "acme/widgets", submitter: "steady" })).toBe(false);
     });


### PR DESCRIPTION
## Problem

`main` is currently broken for every subsequent PR: `test/unit/reputation-wiring.test.ts > shouldSkipAiForReputation (helper) > submission-cadence signal (#4514) > FLAG-ON: true for a machine-paced submitter even though every submission itself looks fine (quality-neutral)` fails with `expected false to be true`.

## Root cause

#9041 (merged as `c25fa1ef7`) correctly repointed `getSubmitterCadence`'s query from `review_targets` (frozen since the 2026-06-22 self-host cutover — it stopped receiving writes, so the machine-paced signal was silently inert in production) to the live `pull_requests` ledger.

That PR updated its own new test (`test/unit/submitter-reputation.test.ts`) to assert the query shape, but missed a sibling: `test/unit/reputation-wiring.test.ts`'s local `seedReviewTarget` helper (scoped inside the `"submission-cadence signal (#4514)"` describe block) still inserts rows into `review_targets`. Since the code now reads `pull_requests`, that seed produces zero matching rows regardless of what's inserted — `getSubmitterCadence` always resolves `{count: 0, medianGapMs: null}`, so `isMachinePacedCadence` can never return `true`. The sibling "false for a human pace" test passed vacuously (right answer for the wrong reason); the "true for machine-paced" test asserts `true` and correctly fails.

## Fix

Renamed the local helper to `seedCadencePullRequest` and repointed it at `pull_requests` (`repo_full_name` + `author_login`, matching the real query). The module-level `seedReviewTarget` (line 20, used elsewhere in this same file for the *quality/burst* signal — a separate code path #9041 did not touch) is untouched.

## Validation
- `npx vitest run test/unit/reputation-wiring.test.ts` — 36/36 passed (was 1 failed / 35 passed).
- `tsc --noEmit --incremental false` clean.
- Diff is a single file, test-only.
