### PR TITLE
fix(db): drop the stale migration-90 grandfather entry (its second file was renumbered to 0092)

### DIFF
--- a/src/db/migration-collisions.ts
+++ b/src/db/migration-collisions.ts
@@ -26,7 +26,8 @@ export const KNOWN_MIGRATION_DUPLICATES: ReadonlyMap<number, ReadonlySet<string>
   [15, new Set(["0015_github_agent_command_feedback.sql", "0015_product_usage_events.sql"])],
   [17, new Set(["0017_agent_recommendation_outcomes.sql", "0017_product_usage_role_retention_rollups.sql"])],
   [74, new Set(["0074_ai_review_cache.sql", "0074_orb_self_enrollment_disabled.sql"])],
-  [90, new Set(["0090_contributor_cap_label.sql", "0090_pull_request_detail_sync_head_sha.sql"])],
+  // #8897: 0090_pull_request_detail_sync_head_sha.sql was later renumbered to migrations/0092_*, so only
+  // 0090_contributor_cap_label.sql exists at 0090 today — a single file, no real collision, so no entry here.
   [156, new Set(["0156_draft_pr_close_policy.sql", "0156_pull_request_screenshot_table_presence_satisfied.sql"])],
 ]);
 

--- a/test/unit/check-migrations-script.test.ts
+++ b/test/unit/check-migrations-script.test.ts
@@ -37,7 +37,7 @@ describe("check-migrations script", () => {
   it("reports every grandfathered duplicate migration number in the success summary", () => {
     const output = execFileSync(TSX_BIN, ["scripts/check-migrations.ts"], { encoding: "utf8" });
 
-    expect(output).toContain("(5 grandfathered duplicates: 0015, 0017, 0074, 0090, 0156)");
+    expect(output).toContain("(4 grandfathered duplicates: 0015, 0017, 0074, 0156)");
   });
 
   it.each([

--- a/test/unit/migration-collisions.test.ts
+++ b/test/unit/migration-collisions.test.ts
@@ -75,10 +75,19 @@ describe("KNOWN_MIGRATION_DUPLICATES (#2550)", () => {
   it("stays byte-identical to scripts/check-migrations.ts's grandfathered list", () => {
     // A drift here would mean the CI script and the live premerge recheck disagree about what's grandfathered
     // — this pins the exact set so a future addition to one side without the other is caught immediately.
-    expect([...KNOWN_MIGRATION_DUPLICATES.keys()].sort((a, b) => a - b)).toEqual([15, 17, 74, 90, 156]);
-    expect(KNOWN_MIGRATION_DUPLICATES.get(90)).toEqual(new Set(["0090_contributor_cap_label.sql", "0090_pull_request_detail_sync_head_sha.sql"]));
+    expect([...KNOWN_MIGRATION_DUPLICATES.keys()].sort((a, b) => a - b)).toEqual([15, 17, 74, 156]);
     expect(KNOWN_MIGRATION_DUPLICATES.get(156)).toEqual(
       new Set(["0156_draft_pr_close_policy.sql", "0156_pull_request_screenshot_table_presence_satisfied.sql"]),
     );
+  });
+
+  it("no longer grandfathers migration 90 — only 0090_contributor_cap_label.sql exists there (#8897)", () => {
+    // 0090_pull_request_detail_sync_head_sha.sql was renumbered to 0092, so 0090 is a single-file number now.
+    expect(KNOWN_MIGRATION_DUPLICATES.has(90)).toBe(false);
+    // detectMigrationCollisions is unaffected: a single real file at 0090 is not a collision, with or without a
+    // grandfather entry (the guard only consults the list when files.length > 1).
+    expect(detectMigrationCollisions(["0090_contributor_cap_label.sql"], KNOWN_MIGRATION_DUPLICATES)).toEqual([]);
+    // And the renumbered file at its new number is likewise a lone, non-colliding entry.
+    expect(detectMigrationCollisions(["0092_pull_request_detail_sync_head_sha.sql"], KNOWN_MIGRATION_DUPLICATES)).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

`KNOWN_MIGRATION_DUPLICATES`'s `[90, {0090_contributor_cap_label.sql, 0090_pull_request_detail_sync_head_sha.sql}]`
entry is stale: `0090_pull_request_detail_sync_head_sha.sql` was later renumbered to `migrations/0092_*`,
so only `0090_contributor_cap_label.sql` exists at 0090 today. `detectMigrationCollisions` only consults
the list when a number has >1 file, so this changes no behavior — but it's factually wrong about what's
grandfathered.

- Removes the `[90, …]` entry (`check-migrations.ts` imports this same constant, so both stay in lockstep).
- Updates the two tests that pin the grandfather set: `migration-collisions.test.ts` (keys `[15,17,74,156]`,
  plus a new assertion that 90 is no longer grandfathered and 0090's single file is not a collision) and
  `check-migrations-script.test.ts` (the success summary now reports `4 grandfathered duplicates: 0015, 0017,
  0074, 0156`).

The four remaining entries (15, 17, 74, 156) all still reference real duplicate files at those numbers.

## Test plan

- [x] `npm run db:migrations:check` → `186 migrations OK — contiguous 0001..0182 (4 grandfathered duplicates: 0015, 0017, 0074, 0156)`
- [x] `npx vitest run test/unit/migration-collisions.test.ts` — 15/15 pass; `tsc --noEmit` clean
- [x] Verified no other test/script references the old count/list (grep repo-wide)

Closes #8897