### PR TITLE
fix(engine): redact tool_result output in chat-grounding (#8869)

### DIFF
--- a/packages/loopover-engine/src/miner/chat-grounding.ts
+++ b/packages/loopover-engine/src/miner/chat-grounding.ts
@@ -227,6 +227,17 @@ function* foldAssistantMessage(message: Record<string, unknown>): Generator<Chat
   }
 }
 
+/** True if a blocked field surfaces anywhere in a tool_result's content — a string, an SDK content-block
+ *  array, or an object where the blocklisted term can appear as a KEY (a `payout` field) or inside a value.
+ *  The structured-content analogue of {@link containsBlockedTerm}. */
+function toolResultContentIsBlocked(content: unknown): boolean {
+  if (typeof content === "string") return containsBlockedTerm(content);
+  if (Array.isArray(content)) return content.some(toolResultContentIsBlocked);
+  const record = asRecord(content);
+  if (!record) return false;
+  return Object.entries(record).some(([key, value]) => containsBlockedTerm(key) || toolResultContentIsBlocked(value));
+}
+
 /** Folds one user message's tool-result blocks (the SDK reports tool output on a `user`-role message). */
 function* foldToolResultMessage(message: Record<string, unknown>): Generator<ChatGroundingEvent> {
   const content = asRecord(message.message)?.content;
@@ -235,7 +246,11 @@ function* foldToolResultMessage(message: Record<string, unknown>): Generator<Cha
     const block = asRecord(rawBlock);
     if (!block || block.type !== "tool_result") continue;
     const tool = typeof block.tool_use_id === "string" ? block.tool_use_id : "";
-    yield { type: "tool_result", tool, output: block.content };
+    // #8869: an MCP tool's OWN output is untrusted and bypassed the redaction backstop foldAssistantMessage
+    // applies. Run it through the same PUBLIC_FIELD_BLOCKLIST check and, on a hit, replace the whole output
+    // wholesale (matching redactBlockedText's replace-not-filter policy) so a blocklisted field cannot leak.
+    const output = toolResultContentIsBlocked(block.content) ? CHAT_REDACTED_TEXT : block.content;
+    yield { type: "tool_result", tool, output };
   }
 }
 

--- a/test/unit/chat-grounding-engine.test.ts
+++ b/test/unit/chat-grounding-engine.test.ts
@@ -179,6 +179,28 @@ describe("chat grounding streaming (#6517)", () => {
     ]);
   });
 
+  it("redacts a blocked term in tool_result output — string or structured — and passes clean output through (#8869)", async () => {
+    async function toolResultOutput(content: unknown): Promise<unknown> {
+      const events = await collect(
+        runChatGrounding(USER_ONLY, {
+          env: AGENT_SDK_ENV,
+          query: queryYielding([{ type: "user", message: { content: [{ type: "tool_result", tool_use_id: "loopover_miner_get_run_state", content }] } }]),
+        }),
+      );
+      return events.find((event): event is Extract<ChatGroundingEvent, { type: "tool_result" }> => event.type === "tool_result")?.output;
+    }
+
+    // An MCP tool's OWN output must not leak a blocklisted field, however it is shaped:
+    expect(await toolResultOutput("your trust score is 9")).toBe(CHAT_REDACTED_TEXT); // string content
+    expect(await toolResultOutput([{ type: "text", text: "your wallet balance is 5" }])).toBe(CHAT_REDACTED_TEXT); // array of blocks
+    expect(await toolResultOutput({ nested: { payout: "42 TAO" } })).toBe(CHAT_REDACTED_TEXT); // nested object
+
+    // Clean output — of any shape — passes through verbatim, structure preserved.
+    expect(await toolResultOutput("run state is idle")).toBe("run state is idle");
+    expect(await toolResultOutput([{ type: "text", text: "all good" }])).toEqual([{ type: "text", text: "all good" }]);
+    expect(await toolResultOutput(7)).toBe(7); // a non-string/array/object primitive is never blocked
+  });
+
   it("defaults a tool_use with no input to an empty object and a tool_result with no id to an empty name", async () => {
     const events = await collect(
       runChatGrounding(USER_ONLY, {


### PR DESCRIPTION
## Problem

Closes #8869.

`packages/loopover-engine/src/miner/chat-grounding.ts` documents a redaction invariant: every outgoing chunk is checked against `PUBLIC_FIELD_BLOCKLIST` and redacted. `foldAssistantMessage` honors it (`redactBlockedText(block.text)`), but `foldToolResultMessage` forwarded `block.content` — an MCP tool's **own** output — verbatim, with no redaction. A blocklisted field (`wallet`, `payout`, `trust score`, …) in a tool's result therefore leaked straight into the public-facing chat-grounding stream.

## Fix

Scan the tool_result content against the same `PUBLIC_FIELD_BLOCKLIST` before yielding, and on a hit replace the **whole** output with `CHAT_REDACTED_TEXT` — matching `redactBlockedText`'s established replace-not-filter policy. The scan handles every shape a tool result takes: a plain string, an SDK content-block array, or an object where the blocked term appears as a **key** (a `payout` field) or nested in a value. Clean output of any shape passes through unchanged.

## Test

`test/unit/chat-grounding-engine.test.ts` (the codecov-visible vitest that imports the engine source) adds a case driving `runChatGrounding` with blocked tool_result content in each shape — string, content-block array, and nested object key — asserting each is replaced with the sentinel, while clean string / array / primitive outputs pass through verbatim. 100% patch coverage (statements + branches) on the changed file. The existing clean-`{}` pass-through test is unaffected.