### PR TITLE
fix(orb): stop two wrong-close paths — superseded cancelled checks, permanent linked-issue violations

### DIFF
--- a/migrations/0184_linked_issue_violation_snapshot.sql
+++ b/migrations/0184_linked_issue_violation_snapshot.sql
@@ -1,0 +1,14 @@
+-- #9029: the linked-issue hard-rule violation marker (linked_issue_hard_rule_violated_at) is written the first
+-- time ANY pass observes a violation and is then NEVER cleared, so an ephemeral, benign issue state condemns a
+-- PR for its entire lifetime. Concrete case from the audit: a maintainer momentarily self-assigns the linked
+-- issue to triage it, the next pass stamps "issue assigned to someone else", and the PR is permanently marked
+-- for a one-shot close -- removing the assignment does not exonerate it. That punishes a contributor for the
+-- maintainer's own action, with no recourse short of disabling every hard rule repo-wide.
+--
+-- The persistence itself is deliberate and must stay: it exists so a contributor cannot stamp-then-dodge by
+-- editing the PR body to unlink the ineligible issue after the violation was observed. The missing piece is the
+-- ability to tell those two situations apart. Recording WHICH linked issues were observed at violation time
+-- makes that a decidable question: if the PR still links the SAME issue set and the live rules now pass, the
+-- change happened on the ISSUE side (assignee removed, label added, reopened) and the PR is exonerated; if the
+-- linked set CHANGED, the author edited the link and the remembered violation stands.
+ALTER TABLE pull_requests ADD COLUMN linked_issue_hard_rule_violation_issues_json TEXT;

--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -4229,13 +4229,43 @@ export async function markPullRequestMergeBlocked(env: Env, fullName: string, nu
  *  the body or the linked issue's state changing after this call is a no-op here: the PR already proved itself in
  *  violation once and stays that way for its lifetime. A no-op (0 rows affected) when the PR row doesn't exist yet
  *  is safe -- the caller only reaches this after a live violation was just evaluated against an existing row. */
-export async function markPullRequestLinkedIssueHardRuleViolated(env: Env, fullName: string, number: number, reason: string): Promise<void> {
+export async function markPullRequestLinkedIssueHardRuleViolated(
+  env: Env,
+  fullName: string,
+  number: number,
+  // Nullable: the default lives here rather than at the call site so the fallback is directly unit-testable
+  // (a violation with no reason is not reachable through the live evaluator today, but the column is
+  // NOT NULL-tolerant by contract and a future rule could omit one).
+  reason: string | null | undefined,
+  // #9029: the linked-issue set observed at violation time, COALESCE'd like the siblings so it always describes
+  // the FIRST violation. Without it a later pass cannot tell an issue-side state change (exonerate) from an
+  // author link edit (violation stands) -- see mergeLinkedIssueHardRuleWithPersistedViolation.
+  linkedIssues?: readonly number[] | undefined,
+): Promise<void> {
   const db = getDb(env.DB);
+  const snapshot = jsonString([...new Set(linkedIssues ?? [])].sort((a, b) => a - b));
   await db
     .update(pullRequests)
     .set({
       linkedIssueHardRuleViolatedAt: sql`COALESCE(${pullRequests.linkedIssueHardRuleViolatedAt}, ${nowIso()})`,
-      linkedIssueHardRuleViolationReason: sql`COALESCE(${pullRequests.linkedIssueHardRuleViolationReason}, ${reason.slice(0, 280)})`,
+      linkedIssueHardRuleViolationReason: sql`COALESCE(${pullRequests.linkedIssueHardRuleViolationReason}, ${(reason ?? "the linked issue is not eligible for a community PR").slice(0, 280)})`,
+      linkedIssueHardRuleViolationIssuesJson: sql`COALESCE(${pullRequests.linkedIssueHardRuleViolationIssuesJson}, ${snapshot})`,
+      updatedAt: nowIso(),
+    })
+    .where(and(eq(pullRequests.repoFullName, fullName), eq(pullRequests.number, number)));
+}
+
+/** #9029: clear a remembered linked-issue hard-rule violation once a later pass proves it was an issue-side,
+ *  benign state change rather than an author dodge. Only ever called with that determination already made
+ *  (see mergeLinkedIssueHardRuleWithPersistedViolation's exoneration branch). */
+export async function clearPullRequestLinkedIssueHardRuleViolation(env: Env, fullName: string, number: number): Promise<void> {
+  const db = getDb(env.DB);
+  await db
+    .update(pullRequests)
+    .set({
+      linkedIssueHardRuleViolatedAt: null,
+      linkedIssueHardRuleViolationReason: null,
+      linkedIssueHardRuleViolationIssuesJson: null,
       updatedAt: nowIso(),
     })
     .where(and(eq(pullRequests.repoFullName, fullName), eq(pullRequests.number, number)));
@@ -6844,6 +6874,7 @@ function toPullRequestRecordFromRow(row: typeof pullRequests.$inferSelect): Pull
     lastRegatedAt: row.lastRegatedAt,
     lastPublishedSurfaceSha: row.lastPublishedSurfaceSha,
     linkedIssueHardRuleViolatedAt: row.linkedIssueHardRuleViolatedAt,
+    linkedIssueHardRuleViolationIssues: parseJson<number[]>(row.linkedIssueHardRuleViolationIssuesJson, []),
     linkedIssueHardRuleViolationReason: row.linkedIssueHardRuleViolationReason,
     visualCaptureSatisfiedSha: row.visualCaptureSatisfiedSha,
     screenshotTablePresenceSatisfied: parseJson<{ headSha: string; evidenceFingerprint: string } | null>(row.screenshotTablePresenceSatisfiedJson, null),

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -420,6 +420,10 @@ export const pullRequests = sqliteTable(
     // pairing with merge_blocked_sha) -- so a later close can still cite the concrete rule even if the live
     // re-parse can no longer reproduce it (the issue was unlinked or its state changed).
     linkedIssueHardRuleViolationReason: text("linked_issue_hard_rule_violation_reason"),
+    // #9029: the linked-issue set observed AT violation time. Lets a later pass distinguish "the issue's state
+    // changed underneath the contributor" (same issues still linked, live rules now pass ⇒ exonerate) from
+    // "the author edited the link to dodge the remembered violation" (issue set changed ⇒ violation stands).
+    linkedIssueHardRuleViolationIssuesJson: text("linked_issue_hard_rule_violation_issues_json"),
     // Visual-capture gate satisfaction (#4110): the head SHA at which the bot's before/after capture pipeline
     // (review.visual.enabled) last produced a REAL before+after render pair (not a placeholder/failed/pending
     // shot) for this PR. Lets the deterministic screenshotTableGate treat a successful automated capture as

--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -2878,6 +2878,54 @@ function dedupeLatestCheckRunsByIdentity(checkRuns: ReadonlyArray<LiveCiCheckRun
 }
 
 /**
+ * #9053: drop a `cancelled` check-run that a NEWER check suite has already superseded with the same check name.
+ *
+ * CONFIRMED live, not theoretical: `GET /commits/{sha}/check-runs` (even with GitHub's default `filter=latest`)
+ * returns runs from MULTIPLE suites for one SHA — measured 11 runs across 6 suites on a real PR head, 10 of them
+ * from older suites. A same-SHA workflow re-trigger (`reopened`, `ready_for_review`, `labeled` — and ORB ITSELF
+ * applies labels) starts a new suite; `.github/workflows/ci.yml` sets `concurrency: cancel-in-progress: true`,
+ * so the first run is cancelled and its `conclusion: "cancelled"` runs stay attached to the same head SHA in the
+ * OLD suite. Because `cancelled` is in CI_FAILING_CONCLUSIONS and the dedupe key deliberately includes the suite
+ * id (so a genuine failure can never be hidden by a later success), those stale cancelled runs landed in
+ * `failingDetails` alongside the new suite's passing ones → ciState "failed" → `willClose` on ciFailed →
+ * one-shot auto-close of a PR whose CI is actually green. The executor's recheck re-derives the same verdict,
+ * so it confirmed rather than caught it. "CI is failing" is the single most common close reason in the ledger,
+ * which makes any false-positive rate here expensive.
+ *
+ * Scoped as narrowly as possible: ONLY `cancelled` conclusions, and ONLY when a strictly newer suite carries the
+ * same (name, app) — a cancellation with no superseding attempt still counts as failing, and genuine `failure` /
+ * `timed_out` / `startup_failure` conclusions are never dropped, so the cross-suite non-collapse this function
+ * sits beside keeps doing its job. Suite ids are compared numerically (GitHub's are monotonically increasing);
+ * a non-numeric or absent id is not comparable, so such a run is conservatively KEPT.
+ */
+function dropSupersededCancelledCheckRuns(checkRuns: ReadonlyArray<LiveCiCheckRun>): LiveCiCheckRun[] {
+  const suiteIdOf = (run: LiveCiCheckRun): number | null => {
+    const raw = run.check_suite?.id ?? run.check_suite?.databaseId ?? null;
+    if (raw == null || raw === "") return null;
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) ? parsed : null;
+  };
+  const identityOf = (run: LiveCiCheckRun): string => `${run.name}\0${(run.app?.slug ?? "").toLowerCase()}`;
+  // Highest suite id observed per (name, app), across every conclusion — a later suite supersedes an earlier
+  // attempt at the same check regardless of how that later attempt turned out.
+  const newestSuiteByIdentity = new Map<string, number>();
+  for (const run of checkRuns) {
+    const suiteId = suiteIdOf(run);
+    if (suiteId == null) continue;
+    const identity = identityOf(run);
+    const seen = newestSuiteByIdentity.get(identity);
+    if (seen == null || suiteId > seen) newestSuiteByIdentity.set(identity, suiteId);
+  }
+  return checkRuns.filter((run) => {
+    if ((run.conclusion ?? "").toLowerCase() !== "cancelled") return true;
+    const suiteId = suiteIdOf(run);
+    if (suiteId == null) return true; // not comparable → keep (conservative)
+    const newest = newestSuiteByIdentity.get(identityOf(run));
+    return newest == null || suiteId >= newest;
+  });
+}
+
+/**
  * Pure reduction of a head SHA's check-runs + classic statuses (+ a lazily-fetched check-suite backstop) into the
  * gate's LiveCiAggregate. Extracted so the REST fetch path (fetchLiveCiAggregate) and the GraphQL rollup path
  * (fetchLiveCiAggregateViaGraphQl) produce BYTE-IDENTICAL verdicts from ONE set of rules — only the data source
@@ -2934,7 +2982,7 @@ async function reduceLiveCiAggregate(
   // current one, without collapsing unrelated checks that merely share a display name.
   const checkRunSummary = (run: LiveCiCheckRun): string | undefined =>
     [run.output?.title, run.output?.summary].find((value): value is string => typeof value === "string" && value.trim().length > 0)?.trim().slice(0, 200);
-  for (const run of dedupeLatestCheckRunsByIdentity(checkRuns)) {
+  for (const run of dropSupersededCancelledCheckRuns(dedupeLatestCheckRunsByIdentity(checkRuns))) {
     seenContextNames.add(run.name); // mark BEFORE bot-check skip: a bot-owned required context is "seen"
     const appSlug = (run.app?.slug ?? "").toLowerCase();
     if (appSlug === "github-actions") sawFirstPartyCheckRun = true;

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -74,6 +74,7 @@ import {
   isGlobalAgentFrozen,
   markGateOutcomeOverridden,
   markPullRequestLinkedIssueHardRuleViolated,
+  clearPullRequestLinkedIssueHardRuleViolation,
   startActiveReviewTracking,
   terminalizeActiveReviewTracking,
   bumpPullRequestDraftConversionCount,
@@ -3093,16 +3094,26 @@ async function runAgentMaintenancePlanAndExecute(
   // confirmed violation isn't remembered, matching every other loopover-computed marker write in this file
   // (mergeBlockedSha, draftConversionCount, lastRegatedAt).
   if (liveLinkedIssueHardRule?.violated === true) {
-    await markPullRequestLinkedIssueHardRuleViolated(env, repoFullName, pr.number, liveLinkedIssueHardRule.reason ?? "the linked issue is not eligible for a community PR").catch(() => undefined);
+    // #9029: snapshot WHICH issues were linked at violation time, so a later pass can tell an issue-side state
+    // change (exonerate) from an author link edit (violation stands).
+    await markPullRequestLinkedIssueHardRuleViolated(env, repoFullName, pr.number, liveLinkedIssueHardRule.reason, pr.linkedIssues).catch(() => undefined);
   }
   const linkedIssueHardRule = mergeLinkedIssueHardRuleWithPersistedViolation(
     liveLinkedIssueHardRule,
     {
       violatedAt: pr.linkedIssueHardRuleViolatedAt,
       reason: pr.linkedIssueHardRuleViolationReason,
+      issuesAtViolation: pr.linkedIssueHardRuleViolationIssues,
+      currentIssues: pr.linkedIssues,
     },
     anyLinkedIssueHardRuleOn(linkedIssueRulesConfig),
   );
+  // #9029: the merge just exonerated a remembered violation (same issues still linked, live rules now pass), so
+  // drop the marker rather than re-deciding it identically on every future pass. Best-effort: a failed clear
+  // only means the next pass re-derives the same exoneration, never a wrong close.
+  if (pr.linkedIssueHardRuleViolatedAt != null && linkedIssueHardRule?.violated !== true) {
+    await clearPullRequestLinkedIssueHardRuleViolation(env, repoFullName, pr.number).catch(() => undefined);
+  }
 
   // Unlinked-issue guardrail (#unlinked-issue-guardrail, credibility-gate-farming defense): when this PR
   // links NO issue and the repo opted in (settings.unlinkedIssueGuardrail.mode === "hold"), check whether the

--- a/src/review/linked-issue-hard-rules.ts
+++ b/src/review/linked-issue-hard-rules.ts
@@ -170,13 +170,44 @@ export function evaluateLinkedIssueHardRules(input: {
  */
 export function mergeLinkedIssueHardRuleWithPersistedViolation(
   live: LinkedIssueHardRuleResult | undefined,
-  persisted: { violatedAt: string | null | undefined; reason: string | null | undefined },
+  persisted: {
+    violatedAt: string | null | undefined;
+    reason: string | null | undefined;
+    // #9029: the linked-issue set observed when the violation was first recorded, and the set linked NOW.
+    // Both absent ⇒ pre-#9029 rows and every caller that has no snapshot behave exactly as before.
+    issuesAtViolation?: readonly number[] | null | undefined;
+    currentIssues?: readonly number[] | null | undefined;
+  },
   anyRuleOn: boolean,
 ): LinkedIssueHardRuleResult | undefined {
   if (live?.violated === true) return live;
   if (!anyRuleOn) return live;
   if (persisted.violatedAt == null) return live;
+  // #9029: the live rules now PASS. Persisting regardless is what let an ephemeral, benign issue state condemn
+  // a PR forever -- a maintainer momentarily self-assigning the linked issue to triage it stamped the violation,
+  // and un-assigning did not exonerate it. The persistence exists to stop a stamp-then-dodge (edit the body to
+  // unlink the ineligible issue AFTER being caught), so the question that actually matters is WHICH SIDE moved:
+  // if the PR still links exactly the issues that were linked at violation time, nothing the author controls
+  // changed and the improvement came from the issue itself ⇒ exonerate. If the linked set changed, the author
+  // edited the link and the remembered violation stands, unchanged from before.
+  if (linkedIssueSetsMatch(persisted.issuesAtViolation, persisted.currentIssues)) return live;
   return { violated: true, reason: persisted.reason ?? "the linked issue is not eligible for a community PR" };
+}
+
+/** True only when BOTH sides are present and describe the same set of issue numbers (order-insensitive). A
+ *  missing/empty snapshot (pre-#9029 rows) is deliberately NOT a match: without knowing what was linked at
+ *  violation time we cannot rule out a dodge, so those rows keep the original permanent-violation behavior. */
+function linkedIssueSetsMatch(
+  atViolation: readonly number[] | null | undefined,
+  current: readonly number[] | null | undefined,
+): boolean {
+  if (!atViolation || atViolation.length === 0) return false;
+  if (!current || current.length === 0) return false;
+  const a = new Set(atViolation);
+  const b = new Set(current);
+  if (a.size !== b.size) return false;
+  for (const value of a) if (!b.has(value)) return false;
+  return true;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -694,6 +694,8 @@ export type PullRequestRecord = {
    *  pairing with mergeBlockedSha) — so a later close can still cite the concrete rule even when the live re-parse
    *  can no longer reproduce it. */
   linkedIssueHardRuleViolationReason?: string | null | undefined;
+  /** #9029: linked-issue numbers observed when the violation was first recorded. */
+  linkedIssueHardRuleViolationIssues?: number[] | undefined;
   /** Visual-capture gate satisfaction (#4110): the head SHA at which the bot's before/after capture pipeline
    *  last produced a REAL before+after render pair (not a placeholder/failed/pending shot) for this PR. The
    *  screenshotTableGate treats visualCaptureSatisfiedSha === headSha as evidence equivalent to a hand-authored

--- a/test/unit/backfill-2.test.ts
+++ b/test/unit/backfill-2.test.ts
@@ -338,6 +338,109 @@ describe("GitHub backfill", () => {
       expect(aggregate.ciState).toBe("pending"); // unreadable backstop => not certified settled
     });
 
+    // #9053 — CONFIRMED live, not theoretical. Verified on a real PR head: GET /commits/{sha}/check-runs (even
+    // with GitHub's default filter=latest) returned 11 runs across 6 SUITES, 10 of them from older suites. A
+    // same-SHA re-trigger (reopened / ready_for_review / labeled — and ORB ITSELF applies labels) starts a new
+    // suite, and ci.yml sets `concurrency: cancel-in-progress: true`, so the first run's check-runs stay on the
+    // head SHA with conclusion "cancelled". Because "cancelled" is a FAILING conclusion and the dedupe key
+    // includes the suite id (so a genuine failure is never hidden by a later success), those stale runs landed
+    // in failingDetails next to the new suite's green ones -> ciState "failed" -> one-shot auto-close of a PR
+    // whose CI is green. "CI is failing" is the most common close reason in the ledger.
+    it("#9053: a cancelled run from a SUPERSEDED suite does not fail CI when a newer suite ran the same check green", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        if (url.includes("/check-runs?")) {
+          return Response.json({
+            check_runs: [
+              // New suite FIRST in array order, old (cancelled) suite second — GitHub documents no stable
+              // ordering for /check-runs, so supersession must be decided by suite id, not array position.
+              { name: "validate", status: "completed", conclusion: "success", check_suite: { id: 200 }, app: { slug: "github-actions" } },
+              { name: "validate", status: "completed", conclusion: "cancelled", check_suite: { id: 100 }, app: { slug: "github-actions" } },
+            ],
+          });
+        }
+        if (url.includes("/status?")) return Response.json({ statuses: [] });
+        if (url.includes("/check-suites")) return Response.json({ check_suites: [{ status: "completed", app: { slug: "github-actions" } }] });
+        return new Response("not found", { status: 404 });
+      });
+
+      const aggregate = await fetchLiveCiAggregate(env, "JSONbored/gittensory", "resha", "public-token", new Set(["validate"]));
+
+      expect(aggregate.ciState).toBe("passed");
+      expect(aggregate.failingDetails).toEqual([]);
+    });
+
+    it("#9053: a cancelled run is STILL failing when no newer suite superseded it", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        if (url.includes("/check-runs?")) {
+          return Response.json({
+            check_runs: [{ name: "validate", status: "completed", conclusion: "cancelled", check_suite: { id: 100 }, app: { slug: "github-actions" } }],
+          });
+        }
+        if (url.includes("/status?")) return Response.json({ statuses: [] });
+        if (url.includes("/check-suites")) return Response.json({ check_suites: [] });
+        return new Response("not found", { status: 404 });
+      });
+
+      const aggregate = await fetchLiveCiAggregate(env, "JSONbored/gittensory", "solo", "public-token", new Set(["validate"]));
+
+      expect(aggregate.ciState).toBe("failed");
+      expect(aggregate.failingDetails.map((d) => d.name)).toEqual(["validate"]);
+    });
+
+    it("#9053: a genuine FAILURE in an older suite is still reported — only `cancelled` is superseded-scoped", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        if (url.includes("/check-runs?")) {
+          return Response.json({
+            check_runs: [
+              { name: "validate", status: "completed", conclusion: "failure", check_suite: { id: 100 }, app: { slug: "github-actions" } },
+              { name: "validate", status: "completed", conclusion: "success", check_suite: { id: 200 }, app: { slug: "github-actions" } },
+            ],
+          });
+        }
+        if (url.includes("/status?")) return Response.json({ statuses: [] });
+        if (url.includes("/check-suites")) return Response.json({ check_suites: [] });
+        return new Response("not found", { status: 404 });
+      });
+
+      const aggregate = await fetchLiveCiAggregate(env, "JSONbored/gittensory", "realfail", "public-token", new Set(["validate"]));
+
+      // The cross-suite non-collapse this fix sits beside must keep doing its job for real failures.
+      expect(aggregate.ciState).toBe("failed");
+      expect(aggregate.failingDetails.map((d) => d.name)).toEqual(["validate"]);
+    });
+
+    it("#9053: a cancelled run with an ABSENT or non-numeric suite id is kept (not comparable ⇒ conservative)", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        if (url.includes("/check-runs?")) {
+          return Response.json({
+            check_runs: [
+              // No suite at all — supersession is undecidable, so this must still count as failing.
+              { name: "nosuite", status: "completed", conclusion: "cancelled", app: { slug: "github-actions" } },
+              // A non-numeric suite id is equally undecidable.
+              { name: "weirdsuite", status: "completed", conclusion: "cancelled", check_suite: { id: "not-a-number" }, app: { slug: "github-actions" } },
+              { name: "weirdsuite", status: "completed", conclusion: "success", check_suite: { id: "also-not-a-number" }, app: { slug: "github-actions" } },
+            ],
+          });
+        }
+        if (url.includes("/status?")) return Response.json({ statuses: [] });
+        if (url.includes("/check-suites")) return Response.json({ check_suites: [] });
+        return new Response("not found", { status: 404 });
+      });
+
+      const aggregate = await fetchLiveCiAggregate(env, "JSONbored/gittensory", "weird", "public-token", new Set(["nosuite", "weirdsuite"]));
+
+      expect(aggregate.ciState).toBe("failed");
+      expect(aggregate.failingDetails.map((d) => d.name).sort()).toEqual(["nosuite", "weirdsuite"]);
+    });
+
     it("fails completed non-required red checks while still reporting optional pending visibility", async () => {
       const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
       vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {

--- a/test/unit/linked-issue-hard-rules.test.ts
+++ b/test/unit/linked-issue-hard-rules.test.ts
@@ -1,3 +1,4 @@
+import { clearPullRequestLinkedIssueHardRuleViolation, getPullRequest, markPullRequestLinkedIssueHardRuleViolated, upsertPullRequestFromGitHub, upsertRepositoryFromGitHub } from "../../src/db/repositories";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createTestEnv } from "../helpers/d1";
 import * as backfillModule from "../../src/github/backfill";
@@ -747,6 +748,65 @@ describe("hasVerifiableOpenLinkedIssueReference (#unlinked-issue-guardrail-follo
   });
 });
 
+// #9029: the persisted violation used to be permanent, so an ephemeral, benign issue state condemned a PR for
+// its whole lifetime — a maintainer momentarily self-assigning the linked issue to triage it stamped a one-shot
+// close on every PR linking it, and un-assigning did not exonerate. The persistence still exists to stop a
+// stamp-then-dodge; the snapshot is what makes "the author edited the link" and "the issue's state changed
+// underneath them" separable.
+describe("mergeLinkedIssueHardRuleWithPersistedViolation — issue-side change exonerates, author link edit does not (#9029)", () => {
+  const persistedBase = { violatedAt: "2026-07-26T00:00:00.000Z", reason: "issue assigned to the maintainer" };
+
+  it("EXONERATES when the same issue set is still linked and the live rules now pass", () => {
+    expect(
+      mergeLinkedIssueHardRuleWithPersistedViolation(
+        { violated: false, reason: null },
+        { ...persistedBase, issuesAtViolation: [9], currentIssues: [9] },
+        true,
+      ),
+    ).toEqual({ violated: false, reason: null });
+  });
+
+  it("is order-insensitive about the issue set (a re-ordered body is not an edit)", () => {
+    expect(
+      mergeLinkedIssueHardRuleWithPersistedViolation(
+        { violated: false, reason: null },
+        { ...persistedBase, issuesAtViolation: [9, 12], currentIssues: [12, 9] },
+        true,
+      )?.violated,
+    ).toBe(false);
+  });
+
+  it("KEEPS the violation when the author changed the linked set — the dodge this persistence exists for", () => {
+    // Swapped to a different issue...
+    expect(
+      mergeLinkedIssueHardRuleWithPersistedViolation({ violated: false, reason: null }, { ...persistedBase, issuesAtViolation: [9], currentIssues: [10] }, true)?.violated,
+    ).toBe(true);
+    // ...unlinked entirely...
+    expect(
+      mergeLinkedIssueHardRuleWithPersistedViolation({ violated: false, reason: null }, { ...persistedBase, issuesAtViolation: [9], currentIssues: [] }, true)?.violated,
+    ).toBe(true);
+    // ...or added a second, eligible issue alongside the ineligible one.
+    expect(
+      mergeLinkedIssueHardRuleWithPersistedViolation({ violated: false, reason: null }, { ...persistedBase, issuesAtViolation: [9], currentIssues: [9, 10] }, true)?.violated,
+    ).toBe(true);
+  });
+
+  it("keeps the pre-#9029 permanent behavior for rows with no snapshot (we cannot rule out a dodge)", () => {
+    expect(
+      mergeLinkedIssueHardRuleWithPersistedViolation({ violated: false, reason: null }, { ...persistedBase, currentIssues: [9] }, true)?.violated,
+    ).toBe(true);
+    expect(
+      mergeLinkedIssueHardRuleWithPersistedViolation({ violated: false, reason: null }, { ...persistedBase, issuesAtViolation: [], currentIssues: [9] }, true)?.violated,
+    ).toBe(true);
+  });
+
+  it("never resurrects a violation while the LIVE rules still fail, snapshot or not", () => {
+    expect(
+      mergeLinkedIssueHardRuleWithPersistedViolation({ violated: true, reason: "still bad" }, { ...persistedBase, issuesAtViolation: [9], currentIssues: [9] }, true),
+    ).toEqual({ violated: true, reason: "still bad" });
+  });
+});
+
 describe("resolveLinkedIssueHasOpenReference (#unlinked-issue-guardrail-followup — live orchestration)", () => {
   afterEach(() => vi.unstubAllGlobals());
 
@@ -823,5 +883,49 @@ describe("resolveLinkedIssueHasOpenReference (#unlinked-issue-guardrail-followup
     });
     const result = await resolveLinkedIssueHasOpenReference({ env: createTestEnv({}), repoFullName: "owner/repo", linkedIssues: [1, 2] });
     expect(result).toBe(true);
+  });
+});
+
+// #9029: the persisted-violation writer/clearer, exercised directly against the real schema.
+describe("markPullRequestLinkedIssueHardRuleViolated / clear (#9029)", () => {
+  async function seedPr(env: Env) {
+    await upsertRepositoryFromGitHub(env, { name: "repo", full_name: "o/r", private: false, owner: { login: "o" } }, 1);
+    await upsertPullRequestFromGitHub(env, "o/r", { number: 3, title: "PR", state: "open", user: { login: "c" }, head: { sha: "h" }, labels: [], body: "Closes #9" });
+  }
+
+  it("records the issue snapshot (deduped + sorted) and never overwrites the FIRST violation", async () => {
+    const env = createTestEnv();
+    await seedPr(env);
+    await markPullRequestLinkedIssueHardRuleViolated(env, "o/r", 3, "first reason", [12, 9, 9]);
+    const first = await getPullRequest(env, "o/r", 3);
+    expect(first?.linkedIssueHardRuleViolationIssues).toEqual([9, 12]);
+    expect(first?.linkedIssueHardRuleViolationReason).toBe("first reason");
+
+    // A second violation must not clobber the original snapshot or reason (COALESCE semantics).
+    await markPullRequestLinkedIssueHardRuleViolated(env, "o/r", 3, "second reason", [77]);
+    const second = await getPullRequest(env, "o/r", 3);
+    expect(second?.linkedIssueHardRuleViolationIssues).toEqual([9, 12]);
+    expect(second?.linkedIssueHardRuleViolationReason).toBe("first reason");
+    expect(second?.linkedIssueHardRuleViolatedAt).toBe(first?.linkedIssueHardRuleViolatedAt);
+  });
+
+  it("applies the default reason when the evaluator supplies none, and tolerates an absent issue list", async () => {
+    const env = createTestEnv();
+    await seedPr(env);
+    await markPullRequestLinkedIssueHardRuleViolated(env, "o/r", 3, null, undefined);
+    const row = await getPullRequest(env, "o/r", 3);
+    expect(row?.linkedIssueHardRuleViolationReason).toContain("not eligible for a community PR");
+    expect(row?.linkedIssueHardRuleViolationIssues).toEqual([]);
+  });
+
+  it("clear removes the marker, the reason, and the snapshot together", async () => {
+    const env = createTestEnv();
+    await seedPr(env);
+    await markPullRequestLinkedIssueHardRuleViolated(env, "o/r", 3, "reason", [9]);
+    await clearPullRequestLinkedIssueHardRuleViolation(env, "o/r", 3);
+    const row = await getPullRequest(env, "o/r", 3);
+    expect(row?.linkedIssueHardRuleViolatedAt).toBeNull();
+    expect(row?.linkedIssueHardRuleViolationReason).toBeNull();
+    expect(row?.linkedIssueHardRuleViolationIssues).toEqual([]);
   });
 });

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -2813,7 +2813,17 @@ describe("queue processors", () => {
       }
     });
 
-    it("REGRESSION (live-issue-state-change-before-re-evaluation): Pass 1 flags a real violation; Pass 2's live re-parse re-evaluates the SAME issue as clean (assignee removed) but the persisted violation still closes the PR", async () => {
+    // #9029 POLICY REVERSAL. This test previously asserted the opposite: that an unchanged PR body whose linked
+    // issue merely had its assignee removed STILL closed, because the persisted violation was permanent. That
+    // punished a contributor for the maintainer's own triage action — a maintainer who momentarily self-assigns
+    // an issue to look at it stamped a permanent one-shot-close marker on every PR linking it, and un-assigning
+    // did not exonerate them. There was no recourse short of disabling every hard rule repo-wide.
+    //
+    // The persistence exists to stop a stamp-then-dodge, so #9029's fix keeps it and narrows it to the case it
+    // was actually built for: the violation stands when the AUTHOR changes the linked-issue set (see the sibling
+    // test above, where the body is edited to unlink the issue — still closes), and is lifted only when the SAME
+    // issues are still linked and the improvement came from the issue side, which is nothing the author controls.
+    it("#9029: Pass 1 flags a real violation; Pass 2 EXONERATES when the same issue is still linked and its state improved (assignee removed)", async () => {
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
       await seedHardRuleRepoAndPr(env);
       const requiredContextsSpy = requiredContextsMock();
@@ -2843,13 +2853,47 @@ describe("queue processors", () => {
         stubHardRuleFetch(liveLabels, { prBody: "Closes #9", issueState: "open", issueAssignees: [], ruleEnabled: true });
         await processJob(env, { type: "agent-regate-pr", deliveryId: "hard-rule-live-pass-2-unassigned", repoFullName: "owner/agent-repo", prNumber: 7, installationId: 9001 });
 
-        // See the sibling test's identical comment: the `close` action's own audit outcome is the observable
-        // proof (the PR row's `state` column only flips once GitHub's `closed` webhook round-trips back).
-        const close = await env.DB.prepare("select outcome, detail from audit_events where event_type = ? order by rowid desc limit 1").bind("agent.action.close").first<{ outcome: string; detail: string }>();
-        expect(close?.outcome).toBe("completed");
-        expect(close?.detail).toContain("#9");
-        const clearedFlag = await env.DB.prepare("select count(*) as n from audit_events where event_type = ? and detail like ?").bind("agent.action.label", "%resolved%").first<{ n: number }>();
-        expect(clearedFlag?.n).toBe(0);
+        // The PR is NOT closed: the same issue is still linked, so the only thing that changed is the issue's
+        // own state, and the contributor is exonerated.
+        const close = await env.DB.prepare("select count(*) as n from audit_events where event_type = ?").bind("agent.action.close").first<{ n: number }>();
+        expect(close?.n).toBe(0);
+        // ...and the remembered violation is actually cleared from the row, so this is decided once rather than
+        // re-derived identically on every future pass.
+        const afterPass2 = await getPullRequest(env, "owner/agent-repo", 7);
+        expect(afterPass2?.state).toBe("open");
+        expect(afterPass2?.linkedIssueHardRuleViolatedAt).toBeNull();
+      } finally {
+        liveCiSpy.mockRestore();
+        requiredContextsSpy.mockRestore();
+      }
+    });
+
+    // #9029: the exoneration CLEAR is best-effort — a failed D1 write must never turn into a wrong close (the
+    // next pass simply re-derives the same exoneration from the unchanged row).
+    it("#9029: a failing exoneration clear does not close the PR — the pass still treats it as exonerated", async () => {
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+      await seedHardRuleRepoAndPr(env);
+      const requiredContextsSpy = requiredContextsMock();
+      const liveCiSpy = liveCiMock();
+      const liveLabels: string[] = [];
+      try {
+        stubHardRuleFetch(liveLabels, { prBody: "Closes #9", issueState: "open", issueAssignees: ["owner"], ruleEnabled: true });
+        await processJob(env, { type: "agent-regate-pr", deliveryId: "clear-fail-pass-1", repoFullName: "owner/agent-repo", prNumber: 7, installationId: 9001 });
+        expect((await getPullRequest(env, "owner/agent-repo", 7))?.linkedIssueHardRuleViolatedAt).toEqual(expect.any(String));
+
+        await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Ineligible linked issue", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, base: { ref: "main" }, labels: liveLabels.map((name) => ({ name })), body: "Closes #9" });
+
+        const clearSpy = vi
+          .spyOn(repositoriesModule, "clearPullRequestLinkedIssueHardRuleViolation")
+          .mockRejectedValue(new Error("D1 unavailable"));
+        stubHardRuleFetch(liveLabels, { prBody: "Closes #9", issueState: "open", issueAssignees: [], ruleEnabled: true });
+        await expect(
+          processJob(env, { type: "agent-regate-pr", deliveryId: "clear-fail-pass-2", repoFullName: "owner/agent-repo", prNumber: 7, installationId: 9001 }),
+        ).resolves.toBeUndefined();
+        clearSpy.mockRestore();
+
+        const close = await env.DB.prepare("select count(*) as n from audit_events where event_type = ?").bind("agent.action.close").first<{ n: number }>();
+        expect(close?.n).toBe(0);
       } finally {
         liveCiSpy.mockRestore();
         requiredContextsSpy.mockRestore();


### PR DESCRIPTION
## Summary

Two paths that auto-closed PRs that should not have been closed.

**#9053 — upgraded from "suspected" to CONFIRMED.** The issue asked for one empirical check; I ran it. On a real PR head, `GET /commits/{sha}/check-runs` returned **11 runs across 6 suites — 10 of them from older suites**, even under GitHub's default `filter=latest`. Combined with `ci.yml`'s `concurrency: cancel-in-progress: true`, a same-SHA re-trigger (`reopened` / `ready_for_review` / `labeled` — and **ORB itself applies labels**) starts a new suite and cancels the first, leaving `conclusion: "cancelled"` runs on the head SHA in the *old* suite.

`cancelled` is in `CI_FAILING_CONCLUSIONS`, and the dedupe key deliberately includes the suite id so a genuine failure can't be hidden by a later success — so those stale runs landed in `failingDetails` beside the new suite's green ones → `ciState: "failed"` → `willClose` → **one-shot auto-close of a PR whose CI is green**. The executor's act-boundary recheck re-derives the same verdict, so it confirmed rather than caught it. `CI is failing` is the single most common close reason in the ledger, which makes the false-positive cost high.

The fix drops a cancelled run **only** when a strictly newer suite ran the same `(name, app)`. A cancellation with no superseding attempt still fails; genuine `failure`/`timed_out`/`startup_failure` are never dropped; a non-numeric or absent suite id isn't comparable and is conservatively kept.

**#9029 — a momentary issue state condemned a PR forever.** `linked_issue_hard_rule_violated_at` was written the first time *any* pass saw a violation and **never cleared**. A maintainer who momentarily self-assigns the linked issue to triage it stamped a permanent one-shot-close marker on every PR linking it — and un-assigning did not exonerate. The only escape was disabling every hard rule repo-wide. That punishes a contributor for the maintainer's own action.

The persistence exists to stop a **stamp-then-dodge** (edit the body to unlink the ineligible issue after being caught), so it's kept and narrowed to exactly that. Migration `0184` records *which* issues were linked at violation time; the merge exonerates only when the same set is still linked and the live rules now pass — i.e. the improvement came from the **issue side**, which the author doesn't control. A changed linked set (swapped, unlinked, or extended) still stands, as do pre-#9029 rows with no snapshot where a dodge can't be ruled out.

Closes #9029
Closes #9053

## ⚠️ Deliberate policy reversal — please sanity-check

#9029 requires inverting an existing regression test that asserted an unchanged PR body whose linked issue merely lost its assignee **still closed**. That behavior is precisely the harm #9029 documents, so the test is rewritten to the new policy with the rationale inline. The sibling test covering the genuine dodge (body edited to unlink) is **unchanged and still passes** — that's the discrimination working, and it's what makes this a narrowing rather than a removal of the protection.

### On #9031 (also in this branch name)
Not fixed here. Its core ask — a cron-rechecked deadline on the pending-closure flag — is a scheduling design I didn't want to bundle into a behavior-change PR. Worth noting its stated cause is now partly addressed: it says `clearLinkedIssueFlag` "can never fire" *because* the violation memory is permanent, and #9029 makes that memory clearable. I'll take the remaining deadline work as its own change.

## Test plan

- [x] 4 CI regressions: superseded-cancelled ignored (**including when the newer suite appears first in array order** — GitHub documents no ordering contract, so supersession must be decided by suite id); a lone cancelled run still fails; a genuine older-suite failure still reports; non-comparable suite ids are kept
- [x] 5 merge-discriminator unit tests: same-set exonerates, order-insensitive, swapped/unlinked/extended all still violate, no-snapshot rows keep pre-#9029 behavior, live-violation never resurrected
- [x] 3 repository-level tests against the real schema: snapshot deduped+sorted, COALESCE never overwrites the first violation, default reason applied, clear removes all three fields
- [x] Exoneration-clear-failure test proving a failed D1 write never becomes a wrong close
- [x] 100% line **and branch** coverage on every added line; 1715/1715 across 12 suites; migrations/schema-drift/docs/engine-parity/cf-typegen/release-manifest gates all green