### PR TITLE
docs(readme): reframe intro around two-sided autonomy and the accountability layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,15 @@ _Formerly Gittensory._
   <a href="https://gittensor.io/miners/repository?name=JSONbored/loopover"><img alt="Gittensor impact" src="https://api.gittensor.io/repos/JSONbored%2Floopover/badge.svg" /></a>
 </p>
 
-LoopOver is a deterministic control plane for Gittensor OSS contribution work.
+LoopOver is a two-sided autonomy layer for Gittensor OSS contribution work: an autonomous maintainer review agent on one side, a miner stack (MCP copilot plus an autonomous miner runtime) on the other, and a statistical accountability layer underneath that scores every decision against its real outcome.
 
-It helps contributors plan cleaner work, helps maintainers review with less public noise, and keeps private scoring, wallet, hotkey, and reviewability context out of public GitHub output.
+- **Maintainer side (self-hosted):** works the PR queue end-to-end — AI review grounded in finished CI status, full post-change file content, and codebase RAG — then gates, approves, requests changes, merges, or closes on its own, governed by dry-run / pause / freeze / kill-switch controls.
+- **Miner side:** the [`@loopover/mcp`](https://www.npmjs.com/package/@loopover/mcp) copilot brings predicted gate verdicts, scoreability, duplicate detection, and cross-repo opportunity discovery into the contributor's own AI harness; the autonomous miner runtime (`@loopover/miner`) runs unattended across a fleet of repos, respecting each target repo's `.loopover-miner.yml` goal spec.
+- **Accountability:** merge/close decisions are outcome-confirmed (merged / reopened / reverted), published with coverage and confidence intervals on the live [fairness report](https://loopover.ai/fairness), and backed by a certified close-precision guarantee that self-tightens as data grows. The backtest corpus behind the published numbers is checksummed and [replayable by anyone](https://loopover.ai/docs/verify-this-review).
 
-It is also the single converged home of the native review system; the legacy separate reviewbot repo/runtime is not part of the active architecture described here.
+It keeps private scoring, wallet, hotkey, and reviewability context out of public GitHub output, and it is the single converged home of the native review system; the legacy separate reviewbot repo/runtime is not part of the active architecture described here.
 
-It is not a Gittensor explorer, public leaderboard, reward-farming bot, wallet dashboard, or autonomous PR agent.
+It is not a Gittensor explorer, public leaderboard, reward-farming bot, or wallet dashboard.
 
 ## Privacy Boundary
 

--- a/README.md
+++ b/README.md
@@ -7,16 +7,20 @@ _Formerly Gittensory._
   <a href="https://www.npmjs.com/package/@loopover/mcp"><img alt="MCP package" src="https://img.shields.io/npm/v/@loopover/mcp?label=mcp" /></a>
   <a href="https://github.com/JSONbored/loopover/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/github/license/JSONbored/loopover" /></a>
   <a href="https://loopover.ai/docs"><img alt="Docs" src="https://img.shields.io/badge/docs-loopover.ai-0b6bcb" /></a>
+</p>
+
+<p align="center">
   <a href="https://gittensor.io/miners/repository?name=JSONbored/loopover"><img alt="Gittensor impact" src="https://api.gittensor.io/repos/JSONbored%2Floopover/badge.svg" /></a>
 </p>
 
-LoopOver is a two-sided autonomy layer for Gittensor OSS contribution work: an autonomous maintainer review agent on one side, a miner stack (MCP copilot plus an autonomous miner runtime) on the other, and a statistical accountability layer underneath that scores every decision against its real outcome.
+LoopOver runs the pull-request loop with agents — on any GitHub repo, on both sides.
 
-- **Maintainer side (self-hosted):** works the PR queue end-to-end — AI review grounded in finished CI status, full post-change file content, and codebase RAG — then gates, approves, requests changes, merges, or closes on its own, governed by dry-run / pause / freeze / kill-switch controls.
-- **Miner side:** the [`@loopover/mcp`](https://www.npmjs.com/package/@loopover/mcp) copilot brings predicted gate verdicts, scoreability, duplicate detection, and cross-repo opportunity discovery into the contributor's own AI harness; the autonomous miner runtime (`@loopover/miner`) runs unattended across a fleet of repos, respecting each target repo's `.loopover-miner.yml` goal spec.
-- **Accountability:** merge/close decisions are outcome-confirmed (merged / reopened / reverted), published with coverage and confidence intervals on the live [fairness report](https://loopover.ai/fairness), and backed by a certified close-precision guarantee that self-tightens as data grows. The backtest corpus behind the published numbers is checksummed and [replayable by anyone](https://loopover.ai/docs/verify-this-review).
+- **For maintainers (self-hosted):** an autonomous review agent works the PR queue end-to-end — AI review grounded in finished CI status, full post-change file content, and codebase RAG — then gates, approves, requests changes, merges, or closes on its own, governed by dry-run / pause / freeze / kill-switch controls.
+- **For contributors:** the [`@loopover/mcp`](https://www.npmjs.com/package/@loopover/mcp) copilot brings predicted gate verdicts, branch preflight, duplicate detection, and cross-repo opportunity discovery into your own AI harness; the autonomous miner runtime (`@loopover/miner`) runs unattended across a fleet of repos, respecting each target repo's `.loopover-miner.yml` goal spec.
+- **With proof:** merge/close decisions are outcome-confirmed (merged / reopened / reverted), published with coverage and confidence intervals on the live [fairness report](https://loopover.ai/fairness), and backed by a certified close-precision guarantee that self-tightens as data grows. The backtest corpus behind the published numbers is checksummed and [replayable by anyone](https://loopover.ai/docs/verify-this-review).
+- **Gittensor-native intelligence built in:** for Bittensor SN74 miners the same engine adds scoreability previews, registry economics, and the cross-repo duplicate graph — while keeping wallet, hotkey, and raw trust-score context out of public GitHub output.
 
-It keeps private scoring, wallet, hotkey, and reviewability context out of public GitHub output, and it is the single converged home of the native review system; the legacy separate reviewbot repo/runtime is not part of the active architecture described here.
+It is the single converged home of the native review system; the legacy separate reviewbot repo/runtime is not part of the active architecture described here.
 
 It is not a Gittensor explorer, public leaderboard, reward-farming bot, or wallet dashboard.
 
@@ -73,24 +77,24 @@ See [Tuning your reviews](https://loopover.ai/docs/tuning) for the full flag, se
 
 ## Start Here
 
-| Audience                  | Start                                                                    | Useful next links                                                                                                                                                                                                 |
-| ------------------------- | ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Miners and contributors   | [Quickstart](https://loopover.ai/docs/quickstart)           | [MCP client setup](https://loopover.ai/docs/mcp-clients), [Miner workflow](https://loopover.ai/docs/miner-workflow), [Scoreability](https://loopover.ai/docs/scoreability) |
-| Maintainers               | [GitHub App](https://loopover.ai/docs/github-app)           | [Maintainer workflow](https://loopover.ai/docs/maintainer-workflow), [Self-host reviews](https://loopover.ai/docs/maintainer-self-hosting), [Privacy and security](https://loopover.ai/docs/privacy-security)                         |
-| Repo owners and operators | [Beta onboarding](https://loopover.ai/docs/beta-onboarding) | [Upstream drift](https://loopover.ai/docs/upstream-drift), [Troubleshooting](https://loopover.ai/docs/troubleshooting), [Roadmap](https://loopover.ai/roadmap)             |
-| Agent authors             | [Agents](https://loopover.ai/agents)                        | [API browser](https://loopover.ai/api), [MCP client setup](https://loopover.ai/docs/mcp-clients)                                                                                        |
+| Audience                  | Start                                                       | Useful next links                                                                                                                                                                                             |
+| ------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Miners and contributors   | [Quickstart](https://loopover.ai/docs/quickstart)           | [MCP client setup](https://loopover.ai/docs/mcp-clients), [Miner workflow](https://loopover.ai/docs/miner-workflow), [Scoreability](https://loopover.ai/docs/scoreability)                                    |
+| Maintainers               | [GitHub App](https://loopover.ai/docs/github-app)           | [Maintainer workflow](https://loopover.ai/docs/maintainer-workflow), [Self-host reviews](https://loopover.ai/docs/maintainer-self-hosting), [Privacy and security](https://loopover.ai/docs/privacy-security) |
+| Repo owners and operators | [Beta onboarding](https://loopover.ai/docs/beta-onboarding) | [Upstream drift](https://loopover.ai/docs/upstream-drift), [Troubleshooting](https://loopover.ai/docs/troubleshooting), [Roadmap](https://loopover.ai/roadmap)                                                |
+| Agent authors             | [Agents](https://loopover.ai/agents)                        | [API browser](https://loopover.ai/api), [MCP client setup](https://loopover.ai/docs/mcp-clients)                                                                                                              |
 
 ## Surfaces
 
-| Surface           | Link                                                                                                                               |
-| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| Website           | [loopover.ai](https://loopover.ai/)                                                                      |
-| Docs              | [loopover.ai/docs](https://loopover.ai/docs)                                                             |
-| MCP package       | [@loopover/mcp](https://www.npmjs.com/package/@loopover/mcp)                                               |
-| Engine package    | [`@loopover/engine`](packages/loopover-engine/README.md) — shared deterministic logic for the review stack and miner |
-| Miner package     | [`@loopover/miner`](packages/loopover-miner/README.md) — local foundation CLI for the autonomous miner runtime        |
-| API               | [API browser](https://loopover.ai/api) and [OpenAPI JSON](https://api.loopover.ai/openapi.json)          |
-| GitHub App        | [Setup docs](https://loopover.ai/docs/github-app) — self-hosting is the only currently available path |
+| Surface        | Link                                                                                                                 |
+| -------------- | -------------------------------------------------------------------------------------------------------------------- |
+| Website        | [loopover.ai](https://loopover.ai/)                                                                                  |
+| Docs           | [loopover.ai/docs](https://loopover.ai/docs)                                                                         |
+| MCP package    | [@loopover/mcp](https://www.npmjs.com/package/@loopover/mcp)                                                         |
+| Engine package | [`@loopover/engine`](packages/loopover-engine/README.md) — shared deterministic logic for the review stack and miner |
+| Miner package  | [`@loopover/miner`](packages/loopover-miner/README.md) — local foundation CLI for the autonomous miner runtime       |
+| API            | [API browser](https://loopover.ai/api) and [OpenAPI JSON](https://api.loopover.ai/openapi.json)                      |
+| GitHub App     | [Setup docs](https://loopover.ai/docs/github-app) — self-hosting is the only currently available path                |
 
 ## MCP Install
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ LoopOver runs the pull-request loop with agents — on any GitHub repo, on both 
 - **With proof:** merge/close decisions are outcome-confirmed (merged / reopened / reverted), published with coverage and confidence intervals on the live [fairness report](https://loopover.ai/fairness), and backed by a certified close-precision guarantee that self-tightens as data grows. The backtest corpus behind the published numbers is checksummed and [replayable by anyone](https://loopover.ai/docs/verify-this-review).
 - **Gittensor-native intelligence built in:** for Bittensor SN74 miners the same engine adds scoreability previews, registry economics, and the cross-repo duplicate graph — while keeping wallet, hotkey, and raw trust-score context out of public GitHub output.
 
+Self-hosting the whole stack is the path available today — and it doubles as the trust story: audit the algorithm, run it on your own infra, replay the published numbers yourself. A hosted plane is in open development on the public milestones (ORB Cloud Readiness, Rent-a-Loop): rentable, metered loops you point at a repo — and, further out, at nothing more than an idea.
+
 It is the single converged home of the native review system; the legacy separate reviewbot repo/runtime is not part of the active architecture described here.
 
 It is not a Gittensor explorer, public leaderboard, reward-farming bot, or wallet dashboard.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ _Formerly Gittensory._
   <a href="https://gittensor.io/miners/repository?name=JSONbored/loopover"><img alt="Gittensor impact" src="https://api.gittensor.io/repos/JSONbored%2Floopover/badge.svg" /></a>
 </p>
 
-LoopOver runs the pull-request loop with agents — on any GitHub repo, on both sides.
+Software delivery is a pipeline. LoopOver makes it a loop: agents write, agents review, agents merge — and every outcome trains the next pass. Any GitHub repo, both sides of the lifecycle.
 
 - **For maintainers (self-hosted):** an autonomous review agent works the PR queue end-to-end — AI review grounded in finished CI status, full post-change file content, and codebase RAG — then gates, approves, requests changes, merges, or closes on its own, governed by dry-run / pause / freeze / kill-switch controls.
 - **For contributors:** the [`@loopover/mcp`](https://www.npmjs.com/package/@loopover/mcp) copilot brings predicted gate verdicts, branch preflight, duplicate detection, and cross-repo opportunity discovery into your own AI harness; the autonomous miner runtime (`@loopover/miner`) runs unattended across a fleet of repos, respecting each target repo's `.loopover-miner.yml` goal spec.

--- a/apps/loopover-ui/content/docs/beta-onboarding.mdx
+++ b/apps/loopover-ui/content/docs/beta-onboarding.mdx
@@ -5,11 +5,12 @@ eyebrow: Get started
 ---
 
 <Callout>
-  **Product positioning.** LoopOver is a deterministic base-agent and control-plane layer for the
-  Gittensor ecosystem. It is [jsonbored/loopover](https://github.com/jsonbored/loopover),
-  independent of [entrius/gittensor](https://github.com/entrius/gittensor). Use it to plan work,
-  preflight branches, and keep GitHub review surfaces quiet — not as an official Gittensor frontend,
-  wallet UI, or payout dashboard.
+  **Product positioning.** LoopOver is an agent stack for both sides of the pull request on any
+  GitHub repo, with Gittensor-native intelligence built in. It is
+  [jsonbored/loopover](https://github.com/jsonbored/loopover), independent of
+  [entrius/gittensor](https://github.com/entrius/gittensor). Use it to plan work, preflight
+  branches, and keep GitHub review surfaces quiet — not as an official Gittensor frontend, wallet
+  UI, or payout dashboard.
 </Callout>
 
 ## Miner journey

--- a/apps/loopover-ui/content/docs/upstream-drift.mdx
+++ b/apps/loopover-ui/content/docs/upstream-drift.mdx
@@ -11,9 +11,9 @@ LoopOver stores versioned snapshots of the Gittensor source and ruleset from
 without re-deriving the whole world.
 
 <Callout>
-  **Upstream relationship.** `entrius/gittensor` is the upstream project LoopOver analyzes. LoopOver
-  is [jsonbored/loopover](https://github.com/jsonbored/loopover) — an independent base-agent layer
-  for the Gittensor ecosystem, not affiliated with the official subnet.
+  **Upstream relationship.** `entrius/gittensor` is the upstream project LoopOver's Gittensor-native
+  intelligence analyzes. LoopOver is [jsonbored/loopover](https://github.com/jsonbored/loopover) —
+  an independent project, not affiliated with the official subnet.
 </Callout>
 
 ## Signal fidelity vs readiness

--- a/apps/loopover-ui/src/components/site/site-footer.tsx
+++ b/apps/loopover-ui/src/components/site/site-footer.tsx
@@ -60,8 +60,9 @@ export function SiteFooter() {
             <span aria-hidden>ittensory</span>
           </Link>
           <p className="mt-3 max-w-sm text-token-sm text-muted-foreground">
-            Deterministic base-agent layer for Gittensor OSS contribution mining. Built for the
-            Gittensor ecosystem — not affiliated with the official subnet.
+            Agents for both sides of the pull request — autonomous reviews for maintainers, an MCP
+            copilot and autonomous miner for contributors. Gittensor-native intelligence included;
+            not affiliated with the official subnet.
           </p>
           <div className="mt-5 flex items-center gap-3">
             <a

--- a/apps/loopover-ui/src/components/site/site-footer.tsx
+++ b/apps/loopover-ui/src/components/site/site-footer.tsx
@@ -60,9 +60,9 @@ export function SiteFooter() {
             <span aria-hidden>ittensory</span>
           </Link>
           <p className="mt-3 max-w-sm text-token-sm text-muted-foreground">
-            Agents for both sides of the pull request — autonomous reviews for maintainers, an MCP
-            copilot and autonomous miner for contributors. Gittensor-native intelligence included;
-            not affiliated with the official subnet.
+            Closed loop, open receipts — agents write, review, and merge, and every outcome trains
+            the next pass. Gittensor-native intelligence included; not affiliated with the official
+            subnet.
           </p>
           <div className="mt-5 flex items-center gap-3">
             <a

--- a/apps/loopover-ui/src/routes/__root.tsx
+++ b/apps/loopover-ui/src/routes/__root.tsx
@@ -119,11 +119,11 @@ export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()(
     meta: [
       { charSet: "utf-8" },
       { name: "viewport", content: "width=device-width, initial-scale=1" },
-      { title: "LoopOver — Deterministic base-agent layer for Gittensor OSS mining" },
+      { title: "LoopOver — The pull-request loop, run by agents" },
       {
         name: "description",
         content:
-          "Plan better work, preflight branches, understand score blockers, and keep maintainer review surfaces quiet. Built for the Gittensor ecosystem.",
+          "Agents for both sides of the pull request on any GitHub repo — autonomous reviews with a published error rate, plus an MCP copilot and autonomous miner for contributors.",
       },
       { property: "og:site_name", content: "LoopOver" },
       { property: "og:type", content: "website" },
@@ -154,7 +154,8 @@ export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()(
           "@type": "Organization",
           name: "LoopOver",
           url: "https://loopover.ai",
-          description: "Deterministic base-agent layer for Gittensor OSS contribution mining.",
+          description:
+            "Agents for both sides of the pull request — autonomous reviews with a published error rate, plus an MCP copilot and autonomous miner for contributors.",
         }),
       },
       // Local, cookieless analytics beacon. Do not load the mutable remote

--- a/apps/loopover-ui/src/routes/__root.tsx
+++ b/apps/loopover-ui/src/routes/__root.tsx
@@ -119,11 +119,11 @@ export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()(
     meta: [
       { charSet: "utf-8" },
       { name: "viewport", content: "width=device-width, initial-scale=1" },
-      { title: "LoopOver — The pull-request loop, run by agents" },
+      { title: "LoopOver — Close the loop on software delivery" },
       {
         name: "description",
         content:
-          "Agents for both sides of the pull request on any GitHub repo — autonomous reviews with a published error rate, plus an MCP copilot and autonomous miner for contributors.",
+          "Agents write, review, and merge — and every outcome trains the next pass. Autonomous PR reviews with a certified, published error rate, plus an MCP copilot and autonomous miner for contributors. Any GitHub repo.",
       },
       { property: "og:site_name", content: "LoopOver" },
       { property: "og:type", content: "website" },
@@ -155,7 +155,7 @@ export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()(
           name: "LoopOver",
           url: "https://loopover.ai",
           description:
-            "Agents for both sides of the pull request — autonomous reviews with a published error rate, plus an MCP copilot and autonomous miner for contributors.",
+            "Agents for the whole development loop — autonomous reviews and contributions with a published, certified error rate.",
         }),
       },
       // Local, cookieless analytics beacon. Do not load the mutable remote

--- a/apps/loopover-ui/src/routes/index.tsx
+++ b/apps/loopover-ui/src/routes/index.tsx
@@ -18,17 +18,17 @@ import { MCP_PACKAGE_NAME, getLatestMcpVersion, useMcpPackageMetadata } from "@/
 export const Route = createFileRoute("/")({
   head: () => ({
     meta: [
-      { title: "LoopOver — Plan the work. Skip the noise." },
+      { title: "LoopOver — The pull-request loop, run by agents." },
       {
         name: "description",
         content:
-          "Deterministic base-agent layer for Gittensor OSS contribution mining. Plan better work, preflight branches, and keep maintainer review surfaces quiet.",
+          "Agents for both sides of the pull request on any GitHub repo — autonomous reviews with a published, outcome-scored error rate, plus an MCP copilot and autonomous miner for contributors.",
       },
-      { property: "og:title", content: "LoopOver — Plan the work. Skip the noise." },
+      { property: "og:title", content: "LoopOver — The pull-request loop, run by agents." },
       {
         property: "og:description",
         content:
-          "Deterministic base-agent layer for Gittensor OSS contribution mining — MCP for miners and agents, a quiet GitHub App for maintainers.",
+          "Autonomous reviews for maintainers, an MCP copilot and autonomous miner for contributors — with a published error rate. Works on any GitHub repo.",
       },
       { property: "og:url", content: "/" },
       { property: "og:type", content: "website" },
@@ -67,15 +67,17 @@ function Hero() {
         <div>
           <div className="flex items-center gap-2 text-token-xs text-muted-foreground">
             <span aria-hidden className="size-1 rounded-full bg-coral" />
-            MCP v{latestMcpVersion} · deterministic base agent
+            MCP v{latestMcpVersion} · open source · self-hosted
           </div>
           <h1 className="mt-5 text-token-3xl font-medium leading-token-tight tracking-tight text-foreground">
-            Mine Gittensor like an engineer.
-            <span className="block text-muted-foreground">Not like a bot.</span>
+            The pull-request loop, run by agents.
+            <span className="block text-muted-foreground">With a published error rate.</span>
           </h1>
           <p className="mt-5 max-w-lg text-token-md leading-token-normal text-muted-foreground">
-            LoopOver is the deterministic base-agent layer for Gittensor OSS contribution mining.
-            Plan better work, preflight branches, and keep maintainer review surfaces quiet.
+            LoopOver works both sides of the PR on any GitHub repo: an autonomous review agent that
+            gates, merges, and closes with outcome-scored accuracy, and a contributor stack — MCP
+            copilot plus autonomous miner — that plans and ships real, reviewable work.
+            Gittensor-native mining intelligence built in.
           </p>
           <div className="mt-7 flex flex-wrap items-center gap-2">
             <Link
@@ -645,11 +647,11 @@ function ClosingCta() {
               Ready when you are
             </div>
             <h2 className="mt-2 font-display text-token-xl font-medium tracking-tight">
-              Skip the noise. Plan the work.
+              Close the loop on your next PR.
             </h2>
             <p className="mt-2 text-token-sm text-muted-foreground">
-              Install the MCP, run an analysis, and see the next move with five scoreability
-              scenarios — no PATs, no source upload, no public score numbers.
+              Install the MCP and preflight your next branch, or self-host the review agent on your
+              own repos — no PATs, no source upload, no public score numbers.
             </p>
           </div>
           <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto">

--- a/apps/loopover-ui/src/routes/index.tsx
+++ b/apps/loopover-ui/src/routes/index.tsx
@@ -18,17 +18,17 @@ import { MCP_PACKAGE_NAME, getLatestMcpVersion, useMcpPackageMetadata } from "@/
 export const Route = createFileRoute("/")({
   head: () => ({
     meta: [
-      { title: "LoopOver — The pull-request loop, run by agents." },
+      { title: "LoopOver — Close the loop on software delivery" },
       {
         name: "description",
         content:
-          "Agents for both sides of the pull request on any GitHub repo — autonomous reviews with a published, outcome-scored error rate, plus an MCP copilot and autonomous miner for contributors.",
+          "Agents write, review, and merge — and every outcome trains the next pass. Autonomous PR reviews with a certified, published error rate, plus an MCP copilot and autonomous miner for contributors. Any GitHub repo.",
       },
-      { property: "og:title", content: "LoopOver — The pull-request loop, run by agents." },
+      { property: "og:title", content: "LoopOver — Close the loop on software delivery" },
       {
         property: "og:description",
         content:
-          "Autonomous reviews for maintainers, an MCP copilot and autonomous miner for contributors — with a published error rate. Works on any GitHub repo.",
+          "Closed loop, open receipts: autonomous reviews for maintainers, autonomous contributions for miners, error rate published and replayable.",
       },
       { property: "og:url", content: "/" },
       { property: "og:type", content: "website" },
@@ -70,14 +70,14 @@ function Hero() {
             MCP v{latestMcpVersion} · open source · self-hosted
           </div>
           <h1 className="mt-5 text-token-3xl font-medium leading-token-tight tracking-tight text-foreground">
-            The pull-request loop, run by agents.
-            <span className="block text-muted-foreground">With a published error rate.</span>
+            Software delivery is a pipeline.
+            <span className="block text-muted-foreground">LoopOver makes it a loop.</span>
           </h1>
           <p className="mt-5 max-w-lg text-token-md leading-token-normal text-muted-foreground">
-            LoopOver works both sides of the PR on any GitHub repo: an autonomous review agent that
-            gates, merges, and closes with outcome-scored accuracy, and a contributor stack — MCP
-            copilot plus autonomous miner — that plans and ships real, reviewable work.
-            Gittensor-native mining intelligence built in.
+            Agents write, agents review, agents merge — and every outcome trains the next pass. An
+            autonomous maintainer works your PR queue end-to-end, a contributor stack plans and
+            ships real work, and the loop&apos;s error rate is published, certified, and replayable.
+            Any GitHub repo; Gittensor-native mining intelligence built in.
           </p>
           <div className="mt-7 flex flex-wrap items-center gap-2">
             <Link

--- a/apps/loopover-ui/src/routes/roadmap.tsx
+++ b/apps/loopover-ui/src/routes/roadmap.tsx
@@ -16,7 +16,8 @@ export const Route = createFileRoute("/roadmap")({
       { property: "og:title", content: "LoopOver roadmap" },
       {
         property: "og:description",
-        content: "Upcoming control-plane surfaces for Gittensor OSS contribution mining.",
+        content:
+          "What LoopOver is shipping next across the review agent, contributor stack, and hosted plane.",
       },
       { property: "og:url", content: "/roadmap" },
     ],

--- a/packages/loopover-mcp/README.md
+++ b/packages/loopover-mcp/README.md
@@ -1,6 +1,6 @@
 # @loopover/mcp
 
-Local stdio MCP wrapper for the LoopOver base-agent layer.
+Local stdio MCP wrapper for the LoopOver contributor stack.
 
 It inspects local git metadata and calls the LoopOver API for branch preflight, score blockers, reward/risk reasoning, contributor decision packs, deterministic next-action planning, and public-safe PR packets. It does not upload source contents in v1.
 
@@ -293,12 +293,12 @@ anything leaves your machine. With the flag off — the default — the key is i
 
 Exactly four fields, and there is no fifth:
 
-| Field | Example | What it is |
-|---|---|---|
-| `tool` | `predict_gate` | The MCP tool name. |
-| `caller_type` | `local` | Which surface dispatched it (`local` for this CLI). |
-| `ok` | `true` | Whether the call succeeded. |
-| `duration_ms` | `142` | Coarse wall-clock duration. |
+| Field         | Example        | What it is                                          |
+| ------------- | -------------- | --------------------------------------------------- |
+| `tool`        | `predict_gate` | The MCP tool name.                                  |
+| `caller_type` | `local`        | Which surface dispatched it (`local` for this CLI). |
+| `ok`          | `true`         | Whether the call succeeded.                         |
+| `duration_ms` | `142`          | Coarse wall-clock duration.                         |
 
 **Never recorded:** your tool arguments, source contents, diffs, repository or issue text, file paths, and any
 wallet, hotkey, coldkey, reward, private ranking, or raw trust-score data. Events carry no identity of yours


### PR DESCRIPTION
Replaces the stale "deterministic control plane" opening — that described the original project scope. The intro now leads with what LoopOver actually is today: the autonomous maintainer review agent, the miner stack (MCP copilot + autonomous miner runtime), and the outcome-scored accountability layer (fairness report, certified close-precision guarantee, replayable backtest corpus). Also drops "autonomous PR agent" from the it-is-not list, since the miner runtime is exactly that now.

Paired with (already applied directly): updated GitHub repo description and topics.