### PR TITLE
fix(review): correct a stray gittensory reference to loopover in a doc comment

### DIFF
--- a/src/review/predicted-gate-agreement.ts
+++ b/src/review/predicted-gate-agreement.ts
@@ -1,6 +1,6 @@
 // Predicted-vs-live gate agreement (#predicted-live-gate-agreement, maintainer review-stack x AMS integration
 // audit 2026-07-09) -- a SIBLING to computeGateEval/computeGateParity (src/review/parity.ts), answering a
-// DIFFERENT question than either: not "does gittensory match reviewbot" (computeGateParity) and not "does one
+// DIFFERENT question than either: not "does loopover match reviewbot" (computeGateParity) and not "does one
 // system's prediction match the human's realized merge/close" (computeGateEval), but "does the MCP predict_gate
 // tool's pre-submission verdict for a contributor match the REAL gate decision their eventual PR receives."
 //


### PR DESCRIPTION
## Summary

- A leftover pre-rename reference ("gittensory") in a comment in `src/review/predicted-gate-agreement.ts` trips `branding-drift:check` -- confirmed already failing on `main`'s own HEAD (independent of any other in-flight PR).
- One-word doc-comment fix: "does gittensory match reviewbot" -> "does loopover match reviewbot", matching the terminology `computeGateParity`'s own doc comment (`src/review/parity.ts`) already uses for the same comparison ("reviewbot->loopover convergence").

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] No linked issue -- this is a maintainer-authored, pre-existing-CI-breakage fix with no natural existing issue to link (comment-only change, no behavior change, nothing to test beyond the existing drift check itself).

## Validation

- [x] `git diff --check`
- [x] `npm run branding-drift:check` (was failing, now passes: "39 file(s) match the recorded baseline")
- [x] `npx vitest run test/unit/predicted-gate-agreement.test.ts test/unit/check-branding-drift-script.test.ts` (39 tests, all pass)
- [ ] Other `test:ci` steps not run locally -- comment-only change with zero behavior impact, no source logic touched.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] N/A for the rest of the safety checklist -- comment-only change, no UI/API/auth/session surface touched.

## Notes

- This was blocking `validate`/`validate-code` on every open PR (confirmed on `main`'s own latest commit's check-runs), including #9181 -- unrelated to that PR's own diff.