### PR TITLE
fix(review): correct stale 'gittensory' brand reference in a comment

### DIFF
--- a/src/review/predicted-gate-agreement.ts
+++ b/src/review/predicted-gate-agreement.ts
@@ -1,6 +1,6 @@
 // Predicted-vs-live gate agreement (#predicted-live-gate-agreement, maintainer review-stack x AMS integration
 // audit 2026-07-09) -- a SIBLING to computeGateEval/computeGateParity (src/review/parity.ts), answering a
-// DIFFERENT question than either: not "does gittensory match reviewbot" (computeGateParity) and not "does one
+// DIFFERENT question than either: not "does loopover match reviewbot" (computeGateParity) and not "does one
 // system's prediction match the human's realized merge/close" (computeGateEval), but "does the MCP predict_gate
 // tool's pre-submission verdict for a contributor match the REAL gate decision their eventual PR receives."
 //


### PR DESCRIPTION
## Summary

#9173 landed a comment in `src/review/predicted-gate-agreement.ts` referencing the deprecated pre-rename product name ("gittensory") instead of the current one ("loopover"). The `branding-drift:check` gate does not have this in its recorded baseline, so it currently fails on `main` for this file and will fail CI for every PR based on current main until fixed — confirmed via a fresh `origin/main` checkout.

## Test plan

- [x] `npm run branding-drift:check` — now reports ok (39 files match baseline)
- [x] `npx tsc --noEmit -p tsconfig.json --incremental false` (after building `@loopover/engine`) — clean