### PR TITLE
fix(rate-limit): fail open when the bearer-identity DB lookup errors

### DIFF
--- a/src/auth/rate-limit.ts
+++ b/src/auth/rate-limit.ts
@@ -263,7 +263,17 @@ async function peekWebhookInstallationId(c: Context<{ Bindings: Env }>): Promise
 }
 
 async function validateBearerForRateLimit(c: Context<{ Bindings: Env }>, token: string): Promise<boolean> {
-  return Boolean((await authenticatePrivateToken(c.env, token)) ?? (await authenticateInternalToken(c.env, token)));
+  try {
+    return Boolean((await authenticatePrivateToken(c.env, token)) ?? (await authenticateInternalToken(c.env, token)));
+  } catch (error) {
+    // Fail OPEN (#5000, same reasoning as the DO-fetch catch in checkRateLimitBucket above): this call only
+    // classifies which rate-limit bucket a caller lands in (falling back to IP-keying below), it is never the
+    // actual authorization decision -- a D1 hiccup during the session-token lookup inside
+    // authenticatePrivateToken must not crash the whole request (no app.onError is registered), it should
+    // just be treated the same as an unrecognized token.
+    console.warn(JSON.stringify({ level: "warn", event: "rate_limit_identity_check_failed", message: error instanceof Error ? error.message : String(error) }));
+    return false;
+  }
 }
 
 const LOOPBACK_PEER_IPS = new Set(["127.0.0.1", "::1"]);


### PR DESCRIPTION
## Summary

- `validateBearerForRateLimit` (src/auth/rate-limit.ts) runs on every request ahead of route handlers to decide whether a bearer token should get its own rate-limit bucket or fall back to IP-keying. It calls into `authenticatePrivateToken` → `authenticateSessionToken`, which does a real D1/Drizzle read against `auth_sessions`.
- That read was unguarded. If it throws, the error escapes the `app.use("*", ...)` middleware uncaught (no `app.onError` is registered anywhere in the app), and Hono falls back to a bare, non-JSON `Internal Server Error` for whatever route happened to be hit — indistinguishable from a bug in that route's own handler, even though the request's actual authorization check (later, dedicated middleware) never even ran yet.
- This mirrors an existing fail-open precedent one function up in the same file: the Durable Object rate-limit-bucket call in `checkRateLimitBucket` is explicitly wrapped in try/catch for the same reason (#5000 — no global error handler exists, so a rate-limiting side-channel must never be able to take down an otherwise-healthy request).
- Fix: wrap the DB-touching identity check in try/catch, log, and fail open to "unrecognized token" (IP-keyed identity) on error — this only affects which bucket a request is counted against, never whether it's authorized.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves.

Closes #9223

## Validation

- [x] `npx vitest run test/integration/orb-ingest.test.ts` — 47/47 pass, including the previously-failing `"tolerates a list query that omits results (rows.results ?? [])"` regression test, which reproduces this exact failure mode (a DB stub missing `.bind()` now degrades gracefully instead of throwing an uncaught 500).
- [x] `npm audit --audit-level=moderate` — pre-existing high-severity findings in the `eslint`/`brace-expansion` devDependency chain only; unrelated to this change (no `package.json`/lockfile diff).
- [ ] Full `npm run test:ci` (typecheck, coverage, workers, mcp/miner pack, ui suite, etc.) was not run for this PR.

If any required check was skipped, explain why:

- This is a maintainer PR for a small, self-contained fix (one function, wrapped in a try/catch matching an existing pattern in the same file). The targeted regression test that already exists in the repo (and was failing before this fix) covers the change; the broader `test:ci` suite was skipped to land this fix quickly.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth-adjacent change (rate-limit identity classification) — behavior on error now falls back to the existing "unrecognized token → IP-keyed" path, covered by the existing test suite's happy-path and 401 tests for this middleware; no new negative-path test was added beyond the existing failing-DB-stub test that now passes.
- [x] API/OpenAPI/MCP behavior unaffected (internal middleware only, no route contract change).
- [x] No UI changes.
- [x] No changelog edit.

## Notes

- No UI Evidence section: this is a backend-only middleware fix with no visible surface.