### PR TITLE
fix(orb): degrade rate-limit installation-identity resolution on a DB error instead of escaping uncaught

### DIFF
--- a/src/auth/rate-limit.ts
+++ b/src/auth/rate-limit.ts
@@ -237,7 +237,15 @@ async function installationRateLimitIdentity(c: Context<{ Bindings: Env }>): Pro
   if (INSTALLATION_KEYED_ORB_BEARER_PATHS.has(path)) {
     const token = extractBearerToken(c.req.header("authorization"));
     if (!token) return null;
-    const enrollment = await validateOrbRelayEnrollment(c.env, token);
+    // #9225: this middleware runs BEFORE the route handler, which has its own well-tested error response for
+    // an unresolvable enrollment (a clean `503 broker_error` for the relay/token routes' own later call to
+    // this same function). A DB error here must never escape uncaught -- it would surface as a bare framework
+    // 500 upstream of that handler, exactly the class of gap #4995 already fixed for the handler's OWN call.
+    // Degrading to null (→ IP-keyed fallback below) matches peekWebhookInstallationId's sibling pattern and
+    // this function's own doc comment: a DB error is just another "not resolvable" case, alongside a
+    // malformed payload or an unenrolled secret.
+    const enrollment = await validateOrbRelayEnrollment(c.env, token).catch(() => null);
+    if (enrollment === null) return null;
     return "error" in enrollment ? null : `installation:${enrollment.installationId}`;
   }
   return null;

--- a/test/unit/auth.test.ts
+++ b/test/unit/auth.test.ts
@@ -515,6 +515,42 @@ describe("private-beta auth and rate limiting", () => {
     expect(observedKeys[0]).toMatch(/^strict:\/v1\/orb\/token:ip:/);
   });
 
+  it("REGRESSION (#9225): a DB error resolving installation identity falls back to IP-keying instead of escaping uncaught, for all three bearer-keyed paths", async () => {
+    // The bug: installationRateLimitIdentity's ORB_BEARER_PATHS branch called validateOrbRelayEnrollment
+    // unguarded. This middleware runs BEFORE the route handler, so an uncaught rejection here previously
+    // surfaced as a bare framework 500 -- upstream of, and bypassing, the route's own #4995 fix (its `.catch`
+    // around its OWN later call to the same function). Forcing the underlying orb_enrollments lookup to
+    // reject exercises exactly that earlier call site.
+    const observedKeys: string[] = [];
+    const env = rateLimitTestEnv({}, observedKeys);
+    const db = env.DB as unknown as TestD1Database;
+    await db.prepare("INSERT INTO orb_github_installations (installation_id, registered) VALUES (?, 1)").bind(603).run();
+    const { secret } = (await issueOrbEnrollment(env, 603)) as { secret: string };
+
+    const realPrepare = db.prepare.bind(db);
+    db.prepare = ((sql: string) => {
+      const statement = realPrepare(sql);
+      if (!/select .* from ["`]?orb_enrollments["`]?/i.test(sql)) return statement;
+      return {
+        ...statement,
+        bind(...values: unknown[]) {
+          const bound = statement.bind(...(values as never[]));
+          return { ...bound, first: () => Promise.reject(new Error("db unavailable")) };
+        },
+      };
+    }) as typeof realPrepare;
+
+    for (const path of ["/v1/orb/token", "/v1/orb/relay/register", "/v1/orb/relay/pull"] as const) {
+      observedKeys.length = 0;
+      // Falls back to IP-keying (never rejects, never throws) -- the middleware itself must resolve cleanly
+      // regardless of what the route handler downstream will separately decide to respond with.
+      await expect(
+        enforceRateLimit(fakeContext(env, path, { authorization: `Bearer ${secret}`, "cf-connecting-ip": "203.0.113.27" }), "strict"),
+      ).resolves.toBeNull();
+      expect(observedKeys[0]).toMatch(new RegExp(`^strict:${path.replace(/\//g, "\\/")}:ip:`));
+    }
+  });
+
   it("ignores proxy fallback headers when cf-connecting-ip is absent", async () => {
     const observedKeys: string[] = [];
     const env = rateLimitTestEnv({}, observedKeys);


### PR DESCRIPTION
## Summary

The global rate-limit middleware (`app.use("*", ...)` → `enforceRateLimit` → `rateLimitIdentity` → `installationRateLimitIdentity`) runs **before every route handler**, including `/v1/orb/token`, `/v1/orb/relay/register`, and `/v1/orb/relay/pull`. For those three paths it called `validateOrbRelayEnrollment(c.env, token)` **unguarded**.

If the DB throws inside that function (a real, if rare, failure mode), the rejection propagated uncaught through the middleware — which has no try/catch around `await enforceRateLimit(...)` — producing a bare framework `500` **upstream of the route handler**. This silently defeated the route-level `#4995` fix, whose `.catch(dbBrokerError)` only guards the handler's own, LATER call to the same function.

Verified live by instrumenting the existing `#4995` regression tests in `test/integration/orb-relay.test.ts` — both currently pass on `main`, but only because their assertions never inspected the actual failure mode. The real response was a bare 500 with the throw originating in `installationRateLimitIdentity`, not in the route handler:

```
Error: db unavailable
    at Object.first (test/integration/orb-relay.test.ts:150:58)
    at validateOrbRelayEnrollment (src/orb/relay.ts:224:6)
    at installationRateLimitIdentity (src/auth/rate-limit.ts:240:24)
...
DEBUG STATUS 500 BODY Internal Server Error
```

**Fix:** `.catch(() => null)` around the call, degrading to IP-keyed rate limiting for that one request — exactly the fallback this function's own doc comment already promises ("falling back to IP-keying ... when [identity is] not resolvable -- a malformed payload, an unenrolled secret"), matching the sibling `peekWebhookInstallationId` branch's existing best-effort pattern. A DB error is just another "not resolvable" case.

Closes #9225

## Validation

- New regression test in `test/unit/auth.test.ts` (co-located with the existing #4891/installation-keying suite): forces the `orb_enrollments` lookup to reject, asserts all three affected paths resolve to IP-keying rather than rejecting.
- `npx vitest run test/unit/auth.test.ts test/integration/orb-relay.test.ts` — **133/133 pass**, including both of `orb-relay.test.ts`'s own pre-existing `#4995` regression tests, which now exercise the code path their names actually describe.
- `npm run typecheck` — clean.

## Safety

- No secrets, wallets, hotkeys, trust scores, or reward values.
- No change to any non-error resolution path — a valid/invalid/absent token still resolves identity exactly as before.
- No change to `peekWebhookInstallationId` or the `/v1/orb/relay` single-tenant branch (out of scope, unaffected).