### PR TITLE
fix(engine): pin web-tree-sitter back to ^0.20.8, unblocking the engine build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20789,12 +20789,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/web-tree-sitter": {
-      "version": "0.26.11",
-      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.26.11.tgz",
-      "integrity": "sha512-Q5Dm3YTIXSXuH6FxX6RuzX2Qwpc4DPGiYMU87Wg5Z8OIStiQFiUex4zMDc0vBTw78EphaYJacncJghCHzbZptg==",
-      "license": "MIT"
-    },
     "node_modules/web-worker": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
@@ -22005,7 +21999,7 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.218",
         "tree-sitter-wasms": "^0.1.13",
-        "web-tree-sitter": "^0.26.11",
+        "web-tree-sitter": "^0.20.8",
         "yaml": "^2.9.0"
       },
       "devDependencies": {
@@ -22031,6 +22025,12 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "packages/loopover-engine/node_modules/web-tree-sitter": {
+      "version": "0.20.8",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.20.8.tgz",
+      "integrity": "sha512-weOVgZ3aAARgdnb220GqYuh7+rZU0Ka9k9yfKtGAzEYMa6GgiCzW9JjQRJyCJakvibQW+dfjJdihjInKuuCAUQ==",
       "license": "MIT"
     },
     "packages/loopover-mcp": {

--- a/packages/loopover-engine/package.json
+++ b/packages/loopover-engine/package.json
@@ -82,7 +82,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.218",
     "tree-sitter-wasms": "^0.1.13",
-    "web-tree-sitter": "^0.26.11",
+    "web-tree-sitter": "^0.20.8",
     "yaml": "^2.9.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

The npm dependency bump in #9232 jumped `web-tree-sitter` from `^0.20.8` to `^0.26.11` — a breaking major-version range change. `Parser.init()` and the `SyntaxNode` export moved in the new major version, breaking `packages/loopover-engine/src/miner/repo-map.ts`'s `tsc` build. This has been failing the engine build (and any CI job that builds it) for every PR based on `main` since that merge — confirmed reproducing on a fresh `origin/main` checkout.

This PR pins `web-tree-sitter` back to `^0.20.8` (the previously-working range) rather than migrating `repo-map.ts` to the new major-version API, to unblock CI immediately. A proper migration to 0.26.x (updating `repo-map.ts` for the new `Parser.init()`/`SyntaxNode` shape) can follow as a separate, deliberate PR.

## Test plan

- [x] `npm run build --workspace @loopover/engine` — clean (was failing before this pin)
- [x] `npx tsc --noEmit -p tsconfig.json --incremental false` — clean across the whole repo