### PR TITLE
chore(imports): fix packages/loopover-ui-kit's #9221 extension drift

### DIFF
--- a/packages/loopover-ui-kit/src/components/streaming-text.test.tsx
+++ b/packages/loopover-ui-kit/src/components/streaming-text.test.tsx
@@ -1,7 +1,7 @@
 import { act, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { StreamingText } from "./streaming-text";
-import type { ChunkSource } from "../hooks/use-streaming-text";
+import { StreamingText } from "./streaming-text.js";
+import type { ChunkSource } from "../hooks/use-streaming-text.js";
 
 afterEach(() => vi.unstubAllGlobals());
 

--- a/packages/loopover-ui-kit/src/components/streaming-text.tsx
+++ b/packages/loopover-ui-kit/src/components/streaming-text.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import {
   useStreamingText,
   type ChunkSource,
-} from "../hooks/use-streaming-text";
+} from "../hooks/use-streaming-text.js";
 
 // prefers-reduced-motion detection via window.matchMedia + a `change` listener — the same technique
 // packages/loopover-ui-kit/src/hooks/use-mobile.tsx uses. Kept internal (not exported) so this file only

--- a/packages/loopover-ui-kit/src/components/typing-indicator.test.tsx
+++ b/packages/loopover-ui-kit/src/components/typing-indicator.test.tsx
@@ -1,7 +1,7 @@
 import { render } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import { TypingIndicator } from "./typing-indicator";
+import { TypingIndicator } from "./typing-indicator.js";
 
 // Regression for #8303: the three animate-bounce dots must each pair their animation with
 // motion-reduce:animate-none so a user with the OS "reduce motion" preference set sees a static indicator

--- a/packages/loopover-ui-kit/src/hooks/use-streaming-text.test.ts
+++ b/packages/loopover-ui-kit/src/hooks/use-streaming-text.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { useStreamingText, type ChunkSource } from "./use-streaming-text";
+import { useStreamingText, type ChunkSource } from "./use-streaming-text.js";
 
 afterEach(() => vi.restoreAllMocks());
 


### PR DESCRIPTION
## Summary

#9239 ("relocate streaming-text, use-streaming-text, typing-indicator from loopover-miner-ui") merged 8 minutes after #9221/#9231 landed the `import-specifiers:check` drift guard, introducing 5 relative-import specifiers into `packages/loopover-ui-kit` missing the `.js` extension NodeNext-resolved published packages require. Most likely an ordinary race between two PRs (branch last-CI'd before #9221 merged, nothing required a rebase before merge) — not a gate bypass.

Adds the missing `.js` to each flagged specifier. Mechanical only, no logic change.

Closes #9240

## Validation

- `npm run import-specifiers:check` — clean (was 5 violations, now 0).
- `npm run build --workspace @loopover/ui-kit` — clean.
- `npm run test --workspace @loopover/ui-kit` — **43/43 pass**.

## Safety

- No secrets, wallets, hotkeys, trust scores, or reward values.
- Specifier-only change; no behavior, export-surface, or logic difference.