### PR TITLE
fix(engine): declare web-tree-sitter/tree-sitter-wasms as root devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,10 +54,12 @@
         "playwright": "^1.61.1",
         "pngjs": "^7.0.0",
         "semver": "^7.8.5",
+        "tree-sitter-wasms": "^0.1.13",
         "tsx": "^4.23.1",
         "turbo": "^2.10.6",
         "typescript": "^5.9.3",
         "vitest": "^4.1.10",
+        "web-tree-sitter": "^0.20.8",
         "wrangler": "^4.114.0"
       },
       "engines": {
@@ -20789,6 +20791,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/web-tree-sitter": {
+      "version": "0.20.8",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.20.8.tgz",
+      "integrity": "sha512-weOVgZ3aAARgdnb220GqYuh7+rZU0Ka9k9yfKtGAzEYMa6GgiCzW9JjQRJyCJakvibQW+dfjJdihjInKuuCAUQ==",
+      "license": "MIT"
+    },
     "node_modules/web-worker": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
@@ -22025,12 +22033,6 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
-      "license": "MIT"
-    },
-    "packages/loopover-engine/node_modules/web-tree-sitter": {
-      "version": "0.20.8",
-      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.20.8.tgz",
-      "integrity": "sha512-weOVgZ3aAARgdnb220GqYuh7+rZU0Ka9k9yfKtGAzEYMa6GgiCzW9JjQRJyCJakvibQW+dfjJdihjInKuuCAUQ==",
       "license": "MIT"
     },
     "packages/loopover-mcp": {

--- a/package.json
+++ b/package.json
@@ -157,10 +157,12 @@
     "playwright": "^1.61.1",
     "pngjs": "^7.0.0",
     "semver": "^7.8.5",
+    "tree-sitter-wasms": "^0.1.13",
     "tsx": "^4.23.1",
     "turbo": "^2.10.6",
     "typescript": "^5.9.3",
     "vitest": "^4.1.10",
+    "web-tree-sitter": "^0.20.8",
     "wrangler": "^4.114.0"
   },
   "engines": {


### PR DESCRIPTION
## Summary

Follow-up to #9234. Pinning \`web-tree-sitter\` back to \`^0.20.8\` fixed the engine's own \`tsc\` build, but changed npm's hoisting decision: both \`web-tree-sitter\` and \`tree-sitter-wasms\` ended up nested under \`packages/loopover-engine/node_modules/\` only, breaking \`test/unit/repo-map.test.ts\` (a pre-existing root-level test that imports both directly) — \`Cannot find package 'web-tree-sitter'\`. This was failing \`validate-tests\` on every open PR based on current \`main\`.

Declares both as explicit root \`devDependencies\` (matching the engine's pinned version), so they resolve from root-level tests regardless of hoisting.

## Test plan

- [x] \`npx vitest run test/unit/repo-map.test.ts\` — 35/35 passing (was failing with "Cannot find package 'web-tree-sitter'" before this fix)
- [x] \`npx tsc --noEmit -p tsconfig.json --incremental false\` — clean