### PR TITLE
chore(imports): fix engine-coverage-script.test.ts's #9221 extension drift

### DIFF
--- a/test/unit/engine-coverage-script.test.ts
+++ b/test/unit/engine-coverage-script.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { normalizeLcovSfPaths } from "../../scripts/engine-coverage.js";
+import { normalizeLcovSfPaths } from "../../scripts/engine-coverage";
 
 describe("engine-coverage script", () => {
   describe("normalizeLcovSfPaths", () => {


### PR DESCRIPTION
## Summary

#9245 merged with a `.js`-suffixed relative specifier in `test/unit/engine-coverage-script.test.ts`, drifting from #9221's Bundler-zone extensionless convention. Same class of gap as #9240/#9241 — a PR merging from a branch state that predates or otherwise missed the drift check.

Drops the `.js` extension. Mechanical only.

Closes #9249

## Validation

- `npm run import-specifiers:check` — clean (was 1 violation, now 0).
- `npx vitest run test/unit/engine-coverage-script.test.ts` — 3/3 pass.
- `npm run typecheck` — clean.

## Safety

- No secrets, wallets, hotkeys, trust scores, or reward values.
- Specifier-only change, no behavior difference.