### PR TITLE
chore(deps): require dashboard approval before renovate opens PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,7 @@
   ],
   "assignees": ["JSONbored"],
   "branchPrefix": "renovate/",
+  "dependencyDashboardApproval": true,
   "dependencyDashboardTitle": "Dependency Dashboard",
   "enabledManagers": ["npm", "github-actions"],
   "minimumReleaseAge": "3 days",
@@ -22,7 +23,6 @@
       "semanticCommitScope": "deps"
     },
     {
-      "dependencyDashboardApproval": true,
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["major"],
       "semanticCommitScope": "deps"


### PR DESCRIPTION
## Summary
- Renovate was auto-opening PRs for every minor/patch and grouped dependency/GitHub Actions update.
- Set top-level `dependencyDashboardApproval: true` in `renovate.json` so all update types are listed on the Dependency Dashboard issue and require an explicit checkbox before a branch/PR is opened, instead of gating only major updates.
- Removed the now-redundant per-rule `dependencyDashboardApproval: true` on the major-update package rule.

## Validation
- Verified `renovate.json` still validates against its schema (structure unchanged aside from the moved/added key).