### PR TITLE
fix(rules): align isCodePath with isCodeFile for mts/cts/mjs/cjs/kts/scala/groovy

### DIFF
--- a/src/rules/advisory.ts
+++ b/src/rules/advisory.ts
@@ -551,7 +551,9 @@ function effectiveDisplaySeverity(finding: AdvisoryFinding, blockerCodes: Readon
 }
 
 function isCodePath(path: string): boolean {
-  return /\.(ts|tsx|js|jsx|py|go|rs|java|rb|php|cs|cpp|cc|c|h|hpp|swift|kt|m|sql|yaml|yml|json|toml|md|vue|svelte|astro|dart)$/i.test(path);
+  // Keep in sync with isCodeFile/isSourcePath — advisory.ts can't import the engine predicate here (#2722),
+  // so mirror every extension isSourcePath recognizes (.mts/.cts/.mjs/.cjs/.kts/.scala/.groovy; #9322).
+  return /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|go|rs|java|rb|php|cs|cpp|cc|c|h|hpp|swift|kt|kts|scala|groovy|m|sql|yaml|yml|json|toml|md|vue|svelte|astro|dart)$/i.test(path);
 }
 
 function collisionClustersForPull(collisions: CollisionReport, pullNumber: number): CollisionCluster[] {

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -1638,6 +1638,35 @@ describe("advisory rules", () => {
     }
   });
 
+  it("flags Missing test evidence for .mts/.cts/.mjs/.cjs/.kts/.scala/.groovy via isCodePath + isCodeFile parity (#9322)", () => {
+    const advisory = buildPullRequestAdvisory(repo, {
+      repoFullName: repo.fullName, number: 26, title: "Add JVM/JS module sources without tests", state: "open",
+      authorLogin: "contributor", authorAssociation: "NONE", labels: [], linkedIssues: [],
+    });
+    const sourcePaths = [
+      "src/index.mts",
+      "src/util.cts",
+      "lib/entry.mjs",
+      "lib/legacy.cjs",
+      "src/App.kts",
+      "src/Main.scala",
+      "src/Build.groovy",
+    ];
+    const files: PullRequestFileRecord[] = sourcePaths.map((path) => ({
+      repoFullName: repo.fullName, pullNumber: 26, path, additions: 10, deletions: 0, changes: 10, payload: {},
+    }));
+    const collisions: CollisionReport = {
+      repoFullName: repo.fullName, generatedAt: "2026-06-10T00:00:00.000Z",
+      summary: { clusterCount: 0, highRiskCount: 0, itemsReviewed: 0 }, clusters: [],
+    };
+
+    const { annotations } = buildCheckRunAnnotations(advisory, { files, collisions, pullNumber: 26 }, "standard");
+
+    for (const path of sourcePaths) {
+      expect(annotations.some((entry) => entry.title === "Missing test evidence" && entry.path === path)).toBe(true);
+    }
+  });
+
   it("buildCheckRunAnnotations uses notice level for medium-risk collisions and critical public finding text", () => {
     const advisory = {
       ...buildPullRequestAdvisory(repo, null),


### PR DESCRIPTION
﻿## Problem

Closes #9322.

`isCodePath` in `src/rules/advisory.ts` is meant to mirror `isCodeFile` for check-run annotation gating, but its extension regex still excluded `.mts`, `.cts`, `.mjs`, `.cjs`, `.kts`, `.scala`, and `.groovy` that `isSourcePath` already recognizes — so missing-test annotations were silently skipped for those source files.

## Fix

Extend `isCodePath`'s extension list to include the same JVM/JS module extensions `isSourcePath` uses.

## Tests

- New parity regression test (mirroring the existing Vue/C++/Dart cases) asserting missing-test annotations fire for `.mts/.cts/.mjs/.cjs/.kts/.scala/.groovy` paths.

Reverting the regex extension fails the test. `git diff --check` clean.

## Validation

- [x] `vitest run test/unit/rules.test.ts -t 9322`
- Rules/advisory-only; unrelated UI/MCP checks not exercised.

## Safety

- [x] No secrets exposed; no UI changes (N/A evidence)
