### PR TITLE
fix(rules): extend isCodePath for mts/cts/mjs/cjs/kts/scala/groovy parity

### DIFF
--- a/src/rules/advisory.ts
+++ b/src/rules/advisory.ts
@@ -551,7 +551,7 @@ function effectiveDisplaySeverity(finding: AdvisoryFinding, blockerCodes: Readon
 }
 
 function isCodePath(path: string): boolean {
-  return /\.(ts|tsx|js|jsx|py|go|rs|java|rb|php|cs|cpp|cc|c|h|hpp|swift|kt|m|sql|yaml|yml|json|toml|md|vue|svelte|astro|dart)$/i.test(path);
+  return /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|go|rs|java|rb|php|cs|cpp|cc|c|h|hpp|swift|kt|kts|scala|groovy|m|sql|yaml|yml|json|toml|md|vue|svelte|astro|dart)$/i.test(path);
 }
 
 function collisionClustersForPull(collisions: CollisionReport, pullNumber: number): CollisionCluster[] {

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -1638,6 +1638,35 @@ describe("advisory rules", () => {
     }
   });
 
+  it("flags Missing test evidence for TS/JS module and JVM scripting extensions via isCodePath + isCodeFile parity", () => {
+    const advisory = buildPullRequestAdvisory(repo, {
+      repoFullName: repo.fullName, number: 26, title: "Add module variants without tests", state: "open",
+      authorLogin: "contributor", authorAssociation: "NONE", labels: [], linkedIssues: [],
+    });
+    const sourcePaths = [
+      "src/config.mts",
+      "src/legacy.cts",
+      "scripts/run.mjs",
+      "scripts/legacy.cjs",
+      "build.gradle.kts",
+      "src/main/scala/App.scala",
+      "scripts/deploy.groovy",
+    ];
+    const files: PullRequestFileRecord[] = sourcePaths.map((path) => ({
+      repoFullName: repo.fullName, pullNumber: 26, path, additions: 10, deletions: 0, changes: 10, payload: {},
+    }));
+    const collisions: CollisionReport = {
+      repoFullName: repo.fullName, generatedAt: "2026-06-10T00:00:00.000Z",
+      summary: { clusterCount: 0, highRiskCount: 0, itemsReviewed: 0 }, clusters: [],
+    };
+
+    const { annotations } = buildCheckRunAnnotations(advisory, { files, collisions, pullNumber: 26 }, "standard");
+
+    for (const path of sourcePaths) {
+      expect(annotations.some((entry) => entry.title === "Missing test evidence" && entry.path === path)).toBe(true);
+    }
+  });
+
   it("buildCheckRunAnnotations uses notice level for medium-risk collisions and critical public finding text", () => {
     const advisory = {
       ...buildPullRequestAdvisory(repo, null),


### PR DESCRIPTION
## Summary

- Extend `isCodePath` in `src/rules/advisory.ts` with `.mts`, `.cts`, `.mjs`, `.cjs`, `.kts`, `.scala`, and `.groovy` so it matches `isCodeFile`/`SOURCE_FILE_EXTENSION` parity.
- Add regression test mirroring the existing Vue/Svelte/Astro and Dart parity cases.

Closes #9322

## Scope

- [x] Conventional Commit title, focused rules-only change, `Closes #9322`.

## Validation

- [x] New parity regression test in `test/unit/rules.test.ts`.
- [ ] Full CI (local Node v24; relying on CI).

## Safety

- [x] No secrets or UI changes.

## UI Evidence

N/A — no visible UI changes.