### PR TITLE
fix(signals): render discouragedPaths in onboarding-pack preview markdown

### DIFF
--- a/src/signals/onboarding-pack.ts
+++ b/src/signals/onboarding-pack.ts
@@ -410,6 +410,7 @@ function buildPreviewMarkdown(preview: RepoOnboardingPackPreview): string {
     preview.contributionLanes.forEach((lane) => {
       lines.push(`- ${lane.title}: ${lane.summary}`);
       appendNestedList(lines, "Preferred paths", lane.preferredPaths);
+      appendNestedList(lines, "Discouraged paths", lane.discouragedPaths);
       appendNestedList(lines, "Validation", lane.validationExpectations);
       appendNestedList(lines, "Notes", lane.publicNotes);
     });

--- a/test/unit/onboarding-pack.test.ts
+++ b/test/unit/onboarding-pack.test.ts
@@ -96,9 +96,29 @@ describe("buildRepoOnboardingPackPreview", () => {
       "Confirm contribution guidance stays previewable before publication.",
     );
     expect(preview.previewMarkdown).toContain("Direct PR quality lane");
+    expect(preview.previewMarkdown).toContain("Discouraged paths: scripts/release/");
     expect(preview.previewMarkdown).toContain("Label policy");
     expect(preview.previewMarkdown).toContain("Validation expectations");
     expect(preview.previewMarkdown).toContain("Readiness warnings");
+  });
+
+  it("omits the Discouraged paths lane entry when discouragedPaths is empty", () => {
+    const preview = buildRepoOnboardingPackPreview({
+      ...POLICY_COMPILER_FIXTURE,
+      contributionLanes: [
+        {
+          id: "docs-lane",
+          title: "Docs lane",
+          summary: "Documentation-only improvements.",
+          preferredPaths: ["docs/"],
+          discouragedPaths: [],
+          validationExpectations: ["Run npm run test:ci before submission."],
+        },
+      ],
+    });
+
+    expect(preview.previewMarkdown).toContain("Preferred paths: docs/");
+    expect(preview.previewMarkdown).not.toContain("Discouraged paths");
   });
 
   it("keeps private owner context out of public onboarding material", () => {


### PR DESCRIPTION
fix(signals): render discouragedPaths in onboarding-pack preview markdown

buildPreviewMarkdown dropped the sanitized discouragedPaths lane field,
rendering only preferredPaths, validationExpectations, and publicNotes.
Add the missing appendNestedList call so contributors see discouraged
paths that the underlying lane data already carries.



Closes #9286


## Validation

Verified locally on this branch before opening:
- [x] `npm run typecheck`
- [x] `npx turbo run build:tsc build:verify`
- [x] `npm run test:coverage` — patch coverage 100.0% of changed lines
