### PR TITLE
fix(queue): correct maybeApplyManifestPolicyGate's "three"->"two" enforceable-findings comments

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -9315,7 +9315,7 @@ export function reviewDurationMsSince(startedAt: string | null, nowMs: number): 
 /**
  * Focus-manifest policy gate (#555, opt-in via `manifestPolicyGateMode`). Reloads the CACHED manifest (the
  * settings resolver discards the raw manifest, but loadRepoFocusManifest is cached so this is cheap),
- * recomputes the guidance over the PR's changed files, and pushes ONLY the three enforceable policy findings
+ * recomputes the guidance over the PR's changed files, and pushes ONLY the two enforceable policy findings
  * onto the advisory so isConfiguredGateBlocker can block under `manifestPolicy: block`. Also runs the E2E
  * test-generation auto-trigger (#4196, part of the #4189 epic) — see the inline comments below for the full
  * rationale of each step. `manifestPolicyGateMode: "off"` (the default) is a no-op, so the advisory/gate
@@ -9338,7 +9338,7 @@ async function maybeApplyManifestPolicyGate(
 ): Promise<void> {
   // Focus-manifest policy (#555, opt-in via manifestPolicyGateMode). Reload the CACHED manifest (the
   // settings resolver discards the raw manifest, but loadRepoFocusManifest is cached so this is cheap),
-  // recompute the guidance over the PR's changed files, and push ONLY the three enforceable policy
+  // recompute the guidance over the PR's changed files, and push ONLY the two enforceable policy
   // findings into the advisory so isConfiguredGateBlocker can block under manifestPolicy: block.
   if (args.settings.manifestPolicyGateMode !== "off") {
     // `gateFiles` is threaded in by the ONLY caller (maybePublishPrPublicSurface) already resolved via


### PR DESCRIPTION
## Summary

`maybeApplyManifestPolicyGate`'s JSDoc and inline comment both said it pushes "three enforceable
policy findings", but its actual `policyCodes` set — and `resolveConfiguredGateMode` in
`src/rules/advisory.ts` — only has **two**. Both comments are updated to "two enforceable policy
findings" so the docs match the code. `policyCodes` and all logic are unchanged.

## Test plan

- [x] Comment-only change — no executable logic modified, so **no test changes are needed** (no behavior changed; no placeholder/stub test added, per the issue's instruction).
- [x] `grep "three enforceable" src/queue/processors.ts` returns **zero** occurrences after the fix.
- [x] `.gittensory.yml.example` / `config/examples/gittensory.full.yml` untouched (already fixed by #5304).

Closes #9295