### PR TITLE
fix(review): widen loop-escalation ALLOWED_DISCORD_HOSTS to match its two siblings

### DIFF
--- a/src/review/loop-escalation-wire.ts
+++ b/src/review/loop-escalation-wire.ts
@@ -28,7 +28,7 @@ import { loadRepoFocusManifest } from "../signals/focus-manifest-loader";
 import { resolveLoopOverSelfRepoFullName } from "../config/loopover-repo-focus-manifest";
 import { errorMessage } from "../utils/json";
 
-const ALLOWED_DISCORD_HOSTS = new Set(["discord.com", "discordapp.com"]);
+const ALLOWED_DISCORD_HOSTS = new Set(["discord.com", "discordapp.com", "canary.discord.com", "ptb.discord.com"]);
 const DEFAULT_COOLDOWN_MINUTES = 60;
 const AUDIT_EVENT_TYPE = "loop_escalation_notification.discord";
 const AUDIT_TARGET_KEY = "fleet:loop-escalation";

--- a/test/unit/loop-escalation-wire.test.ts
+++ b/test/unit/loop-escalation-wire.test.ts
@@ -256,6 +256,34 @@ describe("runLoopEscalationSweep (#6349)", () => {
     expect(result.reason).toBe("invalid_global_webhook");
   });
 
+  it("accepts the canary.discord.com and ptb.discord.com hosts its two siblings already accept (#9288)", async () => {
+    for (const host of ["canary.discord.com", "ptb.discord.com"]) {
+      vi.spyOn(console, "error").mockImplementation(() => undefined);
+      let postedUrl: string | undefined;
+      const result = await runLoopEscalationSweep(createTestEnv({ DISCORD_WEBHOOK_URL: `https://${host}/api/webhooks/123/abc` }), {
+        loadActiveLoops: () => [{ loopId: "broken", tenantId: "acme", runStatus: "abandoned" }],
+        fetchImpl: (async (url) => {
+          postedUrl = String(url);
+          return new Response(null, { status: 204 });
+        }) as typeof fetch,
+        nowMs: () => Date.parse("2026-07-27T12:00:00.000Z"),
+      });
+      expect(result.notified).toBe(true);
+      expect(postedUrl).toBe(`https://${host}/api/webhooks/123/abc`);
+      vi.restoreAllMocks();
+    }
+  });
+
+  it("still rejects a non-Discord host after widening the allowlist (#9288 regression guard)", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const result = await runLoopEscalationSweep(createTestEnv({ DISCORD_WEBHOOK_URL: "https://canary.example.com/api/webhooks/123/abc" }), {
+      loadActiveLoops: () => [{ loopId: "broken", tenantId: "acme", runStatus: "abandoned" }],
+      fetchImpl: (async () => new Response(null, { status: 204 })) as typeof fetch,
+    });
+    expect(result.notified).toBe(false);
+    expect(result.reason).toBe("invalid_global_webhook");
+  });
+
   it("continues when recording the missing-webhook 'denied' audit event itself throws (#9064)", async () => {
     vi.spyOn(console, "error").mockImplementation(() => undefined);
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);


### PR DESCRIPTION
fix(review): widen loop-escalation ALLOWED_DISCORD_HOSTS to match its two siblings

loop-escalation-wire's isValidDiscordWebhook only accepted discord.com and
discordapp.com, silently dropping canary.discord.com / ptb.discord.com webhooks
that alerts.ts and notify-discord.ts already accept. Align the host allowlist to
the same four-host set and cover the two newly-accepted hosts plus a still-rejected
non-Discord host in the unit suite.



Closes #9288


## Validation

Verified locally on this branch before opening:
- [x] `npm run typecheck`
- [x] `npx turbo run build:tsc build:verify`
- [x] `npm run test:coverage` — patch coverage 100.0% of changed lines
