### PR TITLE
fix(review): honor autoCloseExemptLogins in the draft-dodge close guard (#9294)

### DIFF
--- a/src/queue/review-evasion.ts
+++ b/src/queue/review-evasion.ts
@@ -272,6 +272,11 @@ async function closeDraftDodgeAttemptIfBlocked(
   pr: PullRequestRecord,
   settings: RepositorySettings,
 ): Promise<void> {
+  // Honor the operator's auto-close exemptions the same way every sibling guard in this file does (#9294,
+  // same class as #6165): a protected automation author, or one on the autoCloseExemptLogins allowlist, is
+  // never auto-closed by this draft-dodge path either. Checked up front, before any close work, like siblings.
+  if (isProtectedAutomationAuthor(pr.authorLogin, env)) return;
+  if (isAutoCloseExempt(pr.authorLogin, settings.autoCloseExemptLogins)) return;
   const block = await getGateBlockOutcome(
     env,
     repoFullName,

--- a/test/unit/queue-lifecycle-guards.test.ts
+++ b/test/unit/queue-lifecycle-guards.test.ts
@@ -1140,6 +1140,51 @@ describe("converted_to_draft gate-close (draft-dodge prevention)", () => {
     expect(JSON.parse(audit?.metadata_json ?? "{}").explanationPosted).toBe(true);
   });
 
+  it("#9294: does NOT draft-dodge close an autoCloseExemptLogins-listed author, as every sibling guard already honors", async () => {
+    const calls: Array<{ url: string; method: string }> = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      calls.push({ url, method });
+      if (url.includes("/access_tokens")) return Response.json({ token: "t" });
+      return new Response("not found", { status: 404 });
+    });
+
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
+    // Same blocked-PR draft-dodge scenario that closes above, but the author is on the operator's allowlist
+    // (config-as-code via the focus manifest, the same seam every sibling exempt test uses).
+    await setupRepo(env);
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { settings: { reviewCheckMode: "required", autoCloseExemptLogins: ["contributor"] } });
+    await recordGateBlockOutcome(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", blockerCodes: ["missing_linked_issue"] });
+
+    await processJob(env, { type: "github-webhook", deliveryId: "draft-dodge-exempt", eventName: "pull_request", payload: draftPayload("contributor") });
+
+    expect(calls.some((c) => c.method === "PATCH" && c.url.endsWith("/pulls/42"))).toBe(false);
+    const audit = await env.DB.prepare("select outcome from audit_events where event_type = ?").bind("github_app.draft_dodge_closed").first();
+    expect(audit).toBeFalsy();
+  });
+
+  it("#9294: does NOT draft-dodge close a protected automation author (github-actions/dependabot/renovate)", async () => {
+    const calls: Array<{ url: string; method: string }> = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      calls.push({ url, method });
+      if (url.includes("/access_tokens")) return Response.json({ token: "t" });
+      return new Response("not found", { status: 404 });
+    });
+
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "loopover-orb" });
+    await setupRepo(env);
+    await recordGateBlockOutcome(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", blockerCodes: ["missing_linked_issue"] });
+
+    await processJob(env, { type: "github-webhook", deliveryId: "draft-dodge-bot", eventName: "pull_request", payload: draftPayload("dependabot[bot]") });
+
+    expect(calls.some((c) => c.method === "PATCH" && c.url.endsWith("/pulls/42"))).toBe(false);
+    const audit = await env.DB.prepare("select outcome from audit_events where event_type = ?").bind("github_app.draft_dodge_closed").first();
+    expect(audit).toBeFalsy();
+  });
+
   it("#8801: a FAILED close records outcome 'error' with the failure named — never a false 'completed' (the #2260 contract)", async () => {
     const calls: Array<{ url: string; method: string }> = [];
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {


### PR DESCRIPTION
## Problem

Closes #9294.

`closeDraftDodgeAttemptIfBlocked` in `src/queue/review-evasion.ts` auto-closes a PR that converts to draft to dodge a gate block. Its exemption check only considered `authorIsOwner` and `authorIsAdmin`. Every other auto-close guard in the same file additionally honors the operator-configured `autoCloseExemptLogins` allowlist and protected automation authors via `isProtectedAutomationAuthor` + `isAutoCloseExempt` (`maybeCloseReviewEvasionSelfCloseIfReviewed`, `maybeCloseReviewEvasionDraftConversion`, `maybeCloseRepeatedDraftCycling`, `maybeCloseDraftPr`, `maybeCloseSynchronizeAmendment`).

So an author explicitly placed on the operator's `autoCloseExemptLogins` allowlist — or a protected automation bot — was still auto-closed by this one enforcement path. This is the identical bug class already fixed in this file as **#6165** (for `closeRepeatedDraftCyclingIfDetected`); this is the last remaining sibling that lacked it.

## Fix

Add both `isProtectedAutomationAuthor(pr.authorLogin, env)` and `isAutoCloseExempt(pr.authorLogin, settings.autoCloseExemptLogins)` early-return checks at the top of the function, in the same relative position the siblings use. No change to the existing `authorIsOwner`/`authorIsAdmin`/`block.overridden`/`block.headSha` logic; the siblings are untouched.

## Test

`test/unit/queue-lifecycle-guards.test.ts` adds two cases to the draft-dodge describe: an `autoCloseExemptLogins`-listed author and a protected automation author (`dependabot[bot]`) each converting a blocked PR to draft are NOT auto-closed (no close PATCH, no `draft_dodge_closed` audit) — the same scenario that closes for a normal contributor. Both new source branches are covered; reverting the fix makes each assertion fail.