### PR TITLE
fix(miner): carry assignees through normalizeCandidate in opportunity-ranker

### DIFF
--- a/packages/loopover-miner/lib/opportunity-ranker.ts
+++ b/packages/loopover-miner/lib/opportunity-ranker.ts
@@ -54,6 +54,14 @@ function normalizeCandidate(candidate: Record<string, unknown>) {
         .filter((label) => typeof label === "string" && label.trim())
         .map((label) => label.trim())
     : [];
+  // #9330: RankedCandidateIssue's `RawCandidateIssue &` type promises `assignees`, but this function
+  // dropped it. Mirror `labels`'s array-of-strings validation; no `.trim()` because the producer
+  // (opportunity-fanout.ts assigneeLogins) already emits clean GitHub logins filtered to length > 0.
+  const assignees = Array.isArray(candidate.assignees)
+    ? candidate.assignees.filter(
+        (assignee): assignee is string => typeof assignee === "string" && assignee.length > 0,
+      )
+    : [];
   return {
     owner,
     repo,
@@ -61,6 +69,7 @@ function normalizeCandidate(candidate: Record<string, unknown>) {
     issueNumber,
     title,
     labels,
+    assignees,
     commentsCount: Number.isFinite(candidate.commentsCount) ? (candidate.commentsCount as number) : 0,
     createdAt: typeof candidate.createdAt === "string" ? candidate.createdAt : null,
     updatedAt: typeof candidate.updatedAt === "string" ? candidate.updatedAt : null,

--- a/test/unit/miner-opportunity-ranker.test.ts
+++ b/test/unit/miner-opportunity-ranker.test.ts
@@ -296,3 +296,28 @@ describe("rankCandidateIssues (#2302 follow-up)", () => {
     vi.useRealTimers();
   });
 });
+
+describe("rankCandidateIssues carries assignees through normalizeCandidate (#9330)", () => {
+  it("preserves a populated assignees array in the ranked output", () => {
+    const ranked = rankCandidateIssues(
+      [rawIssue({ assignees: ["octocat", "hubot"] })],
+      { nowMs: NOW },
+    );
+    expect(ranked[0]?.assignees).toEqual(["octocat", "hubot"]);
+  });
+
+  it("normalizes a missing or malformed assignees field to [] without throwing", () => {
+    const ranked = rankCandidateIssues(
+      [
+        rawIssue({ issueNumber: 1, assignees: undefined }),
+        rawIssue({ issueNumber: 2, assignees: "not-an-array" as unknown as string[] }),
+        rawIssue({ issueNumber: 3, assignees: [42, "", "keep"] as unknown as string[] }),
+      ],
+      { nowMs: NOW },
+    );
+    const byNumber = new Map(ranked.map((entry) => [entry.issueNumber, entry.assignees]));
+    expect(byNumber.get(1)).toEqual([]);
+    expect(byNumber.get(2)).toEqual([]);
+    expect(byNumber.get(3)).toEqual(["keep"]);
+  });
+});


### PR DESCRIPTION
## What

`RankedCandidateIssue = RawCandidateIssue & {...score fields}` in
`packages/loopover-miner/lib/opportunity-ranker.ts`, and `RawCandidateIssue` carries
`assignees: string[]` (populated by `normalizeIssue`/`assigneeLogins` in `opportunity-fanout.ts`,
#7040). But `normalizeCandidate` re-copied every other field onto its return object — `owner`,
`repo`, `repoFullName`, `issueNumber`, `title`, `labels`, `commentsCount`, `createdAt`, `updatedAt`,
`htmlUrl`, `aiPolicyAllowed`, `aiPolicySource` — and silently dropped `assignees`. So `discover --json`'s
`result.ranked` (and `options.onResult`'s payload) omitted a field the `RankedCandidateIssue` type
promises. The pre-ranking exclusion filter isn't affected — it runs on raw fan-out candidates — but
consumers of the ranked output lose the field.

## Change

`normalizeCandidate` now copies `assignees`, validated exactly the way the sibling `labels` field is
(array-of-strings, defaulting to `[]` when missing or malformed). No `.trim()` — the producer
(`assigneeLogins`) already emits clean GitHub logins filtered to `length > 0`, so the check mirrors
that (`typeof assignee === "string" && assignee.length > 0`). No other field's normalization,
`RawCandidateIssue`, `RankedCandidateIssue`, or `normalizeIssue` is touched.

## Validation

Two new tests in `test/unit/miner-opportunity-ranker.test.ts`:
- a candidate with a populated `assignees` array survives `rankCandidateIssues` with `assignees`
  present and correct in the ranked output;
- missing (`undefined`), non-array (`"not-an-array"`), and mixed-invalid (`[42, "", "keep"]`)
  `assignees` fields normalize to `[]` / `["keep"]` rather than throwing or propagating invalid values
  — exercising both sides of the `Array.isArray` guard and both operands of the filter predicate.

`npx vitest run test/unit/miner-opportunity-ranker.test.ts` → 22 pass. Every changed line and branch
is covered.

Closes #9330
