### PR TITLE
fix(miner): log discovery-index query failures before failing open

### DIFF
--- a/packages/loopover-miner/lib/discovery-index-client.ts
+++ b/packages/loopover-miner/lib/discovery-index-client.ts
@@ -107,7 +107,10 @@ export async function queryDiscoveryIndex(
     if (!response.ok) return EMPTY_QUERY_RESPONSE;
     const payload = await response.json().catch(() => null);
     return normalizeDiscoveryIndexResponse(payload).response;
-  } catch {
+  } catch (error) {
+    // #9329: log before failing open, matching submitSoftClaim's best-effort-network convention; the
+    // EMPTY_QUERY_RESPONSE return type has no slot to surface the error, so a debug line is the only visibility.
+    getLogger().debug("discovery_plane_query_failed", { error: describeCliError(error) });
     return EMPTY_QUERY_RESPONSE;
   }
 }

--- a/test/unit/miner-discovery-index-client.test.ts
+++ b/test/unit/miner-discovery-index-client.test.ts
@@ -111,6 +111,20 @@ describe("queryDiscoveryIndex (#7168)", () => {
     );
     expect(threw.candidates).toEqual([]);
   });
+
+  it("logs discovery_plane_query_failed before failing open when the fetch throws (#9329)", async () => {
+    const response = await queryDiscoveryIndex(
+      { repos: ["a/b"] },
+      {
+        env: ENABLED_ENV,
+        fetchImpl: async () => {
+          throw new Error("network exploded");
+        },
+      },
+    );
+    expect(response.candidates).toEqual([]);
+    expect(logSpy.debug).toHaveBeenCalledWith("discovery_plane_query_failed", { error: "network exploded" });
+  });
 });
 
 describe("submitSoftClaim (#7168)", () => {


### PR DESCRIPTION
## What

`queryDiscoveryIndex` in `packages/loopover-miner/lib/discovery-index-client.ts` had a bare
`} catch { return EMPTY_QUERY_RESPONSE; }` — any fetch/network/parse failure was silently dropped
with zero logging, even at `--verbose`.

Its sibling `submitSoftClaim` in the same file — the equivalent best-effort fire-and-forget network
call — already logs the failure before returning its fail-open result:

```ts
} catch (error) {
  getLogger().debug("discovery_plane_soft_claim_failed", { error: describeCliError(error) });
  return { sent: false };
}
```

## Change

Give `queryDiscoveryIndex`'s catch the same treatment: bind the error (`catch (error)`) and
`getLogger().debug("discovery_plane_query_failed", { error: describeCliError(error) })` before
returning. The fail-open behavior and the `EMPTY_QUERY_RESPONSE` return type are unchanged — this only
adds visibility. `submitSoftClaim` is untouched (it is the precedent). The event name mirrors its
`discovery_plane_soft_claim_failed` convention.

## Validation

- New test in `test/unit/miner-discovery-index-client.test.ts`: when the injected `fetchImpl` throws,
  `queryDiscoveryIndex` still returns empty (`candidates: []`) **and** `logSpy.debug` is called with
  `"discovery_plane_query_failed"` and `{ error: "network exploded" }` (`describeCliError` returns the
  Error's `message`).
- `npx vitest run test/unit/miner-discovery-index-client.test.ts` → 25 pass. The added lines are
  unconditional (no new branch) and are executed by the throw-path test.

Closes #9329
