### PR TITLE
fix(rules): extend isCodePath for mts/cts/mjs/cjs/kts/scala/groovy parity

### DIFF
--- a/src/rules/advisory.ts
+++ b/src/rules/advisory.ts
@@ -551,7 +551,7 @@ function effectiveDisplaySeverity(finding: AdvisoryFinding, blockerCodes: Readon
 }
 
 function isCodePath(path: string): boolean {
-  return /\.(ts|tsx|js|jsx|py|go|rs|java|rb|php|cs|cpp|cc|c|h|hpp|swift|kt|m|sql|yaml|yml|json|toml|md|vue|svelte|astro|dart)$/i.test(path);
+  return /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|go|rs|java|rb|php|cs|cpp|cc|c|h|hpp|swift|kt|kts|scala|groovy|m|sql|yaml|yml|json|toml|md|vue|svelte|astro|dart)$/i.test(path);
 }
 
 function collisionClustersForPull(collisions: CollisionReport, pullNumber: number): CollisionCluster[] {

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -1638,6 +1638,35 @@ describe("advisory rules", () => {
     }
   });
 
+  it("flags Missing test evidence for TS/JS module and JVM scripting extensions via isCodePath + isCodeFile parity", () => {
+    const advisory = buildPullRequestAdvisory(repo, {
+      repoFullName: repo.fullName, number: 26, title: "Add module variants without tests", state: "open",
+      authorLogin: "contributor", authorAssociation: "NONE", labels: [], linkedIssues: [],
+    });
+    const sourcePaths = [
+      "src/config.mts",
+      "src/legacy.cts",
+      "scripts/run.mjs",
+      "scripts/legacy.cjs",
+      "build.gradle.kts",
+      "src/main/scala/App.scala",
+      "scripts/deploy.groovy",
+    ];
+    const files: PullRequestFileRecord[] = sourcePaths.map((path) => ({
+      repoFullName: repo.fullName, pullNumber: 26, path, additions: 10, deletions: 0, changes: 10, payload: {},
+    }));
+    const collisions: CollisionReport = {
+      repoFullName: repo.fullName, generatedAt: "2026-06-10T00:00:00.000Z",
+      summary: { clusterCount: 0, highRiskCount: 0, itemsReviewed: 0 }, clusters: [],
+    };
+
+    const { annotations } = buildCheckRunAnnotations(advisory, { files, collisions, pullNumber: 26 }, "standard");
+
+    for (const path of sourcePaths) {
+      expect(annotations.some((entry) => entry.title === "Missing test evidence" && entry.path === path)).toBe(true);
+    }
+  });
+
   it("buildCheckRunAnnotations uses notice level for medium-risk collisions and critical public finding text", () => {
     const advisory = {
       ...buildPullRequestAdvisory(repo, null),


### PR DESCRIPTION
## Summary

- Extend `isCodePath` in `src/rules/advisory.ts` with `.mts`, `.cts`, `.mjs`, `.cjs`, `.kts`, `.scala`, and `.groovy` so it matches `isCodeFile`/`SOURCE_FILE_EXTENSION` parity.
- Add regression test mirroring the existing Vue/Svelte/Astro and Dart parity cases in `test/unit/rules.test.ts`.

Closes #9322

## Scope

- [x] Focused rules-only change (2 files), `Closes #9322`.
- [x] Duplicate gate: no other open PR for #9322; issue still open on `main`.

## Validation

- [x] Targeted regression test for all seven extensions.
- [ ] Full CI — scoped `--changed` selection should stay narrow (same shape as merged #9336: `src/signals` + 2 files, green CI).

## Safety

- [x] No secrets or UI changes.

## UI Evidence

N/A.

## Notes

- Avoids `src/queue/processors.ts` hub path so scoped CI does not fan out to the full suite / pre-existing `selfhost-pg-retention` flake (see open maintainer #9285).