### PR TITLE
fix(review): widen loop-escalation-wire's Discord host allowlist to match its siblings

### DIFF
--- a/src/review/loop-escalation-wire.ts
+++ b/src/review/loop-escalation-wire.ts
@@ -28,7 +28,7 @@ import { loadRepoFocusManifest } from "../signals/focus-manifest-loader";
 import { resolveLoopOverSelfRepoFullName } from "../config/loopover-repo-focus-manifest";
 import { errorMessage } from "../utils/json";
 
-const ALLOWED_DISCORD_HOSTS = new Set(["discord.com", "discordapp.com"]);
+const ALLOWED_DISCORD_HOSTS = new Set(["discord.com", "discordapp.com", "canary.discord.com", "ptb.discord.com"]);
 const DEFAULT_COOLDOWN_MINUTES = 60;
 const AUDIT_EVENT_TYPE = "loop_escalation_notification.discord";
 const AUDIT_TARGET_KEY = "fleet:loop-escalation";

--- a/test/unit/loop-escalation-wire.test.ts
+++ b/test/unit/loop-escalation-wire.test.ts
@@ -309,6 +309,36 @@ describe("runLoopEscalationSweep (#6349)", () => {
     ).resolves.toMatchObject({ notified: false, reason: "invalid_global_webhook" });
   });
 
+  // #9288: ALLOWED_DISCORD_HOSTS previously only had discord.com/discordapp.com, unlike alerts.ts and
+  // notify-discord.ts's four-host set -- a canary.discord.com or ptb.discord.com webhook was silently
+  // rejected as invalid_global_webhook. Both must now be accepted the same way the other two paths accept
+  // them, and a non-Discord host must still be rejected (the "unknown hosts" regression guard above already
+  // covers that, but this test pins it alongside the newly-accepted hosts for a single clear diff anchor).
+  it("accepts canary.discord.com and ptb.discord.com webhooks, and still rejects a non-Discord host (#9288)", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const load = () => [{ loopId: "broken", tenantId: "acme", runStatus: "abandoned" as const }];
+
+    await expect(
+      runLoopEscalationSweep(createTestEnv({ DISCORD_WEBHOOK_URL: "https://canary.discord.com/api/webhooks/123/abc" }), {
+        loadActiveLoops: load,
+        fetchImpl: (async () => new Response(null, { status: 204 })) as typeof fetch,
+      }),
+    ).resolves.toMatchObject({ notified: true });
+
+    await expect(
+      runLoopEscalationSweep(createTestEnv({ DISCORD_WEBHOOK_URL: "https://ptb.discord.com/api/webhooks/123/abc" }), {
+        loadActiveLoops: load,
+        fetchImpl: (async () => new Response(null, { status: 204 })) as typeof fetch,
+      }),
+    ).resolves.toMatchObject({ notified: true });
+
+    await expect(
+      runLoopEscalationSweep(createTestEnv({ DISCORD_WEBHOOK_URL: "https://fake.discord.com/api/webhooks/123/abc" }), {
+        loadActiveLoops: load,
+      }),
+    ).resolves.toMatchObject({ notified: false, reason: "invalid_global_webhook" });
+  });
+
   it("honors an explicit cooldownMinutes override", async () => {
     vi.spyOn(console, "error").mockImplementation(() => undefined);
     const env = createTestEnv({ DISCORD_WEBHOOK_URL: "https://discord.com/api/webhooks/123/abc" });


### PR DESCRIPTION
## Summary

- `ALLOWED_DISCORD_HOSTS` in `src/review/loop-escalation-wire.ts` only listed `discord.com`/`discordapp.com`, unlike the identical four-host set (`discord.com`, `discordapp.com`, `canary.discord.com`, `ptb.discord.com`) already used by `src/review/alerts.ts` and `src/services/notify-discord.ts`. A valid `canary.discord.com` or `ptb.discord.com` webhook configured for the loop-escalation sweep was silently rejected as `invalid_global_webhook`, with no indication to the operator why.
- Only the host allowlist constant changed — `isValidDiscordWebhook`'s other validation logic (protocol/path checks) is untouched, and neither `alerts.ts` nor `notify-discord.ts` were touched (they were already correct).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (Closes #9288).

## Validation

- [x] `git diff --check`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries
- [x] `npm run actionlint`
- [x] A scoped `tsc --noEmit` (root `tsconfig.json`'s full flag set) against the two changed files — clean
- [x] `npx vitest run test/unit/loop-escalation-wire.test.ts` — 25/25 passing, including new cases asserting `canary.discord.com` and `ptb.discord.com` webhooks are both accepted, and a non-Discord host (`fake.discord.com`) is still rejected
- [x] Scoped coverage on `src/review/loop-escalation-wire.ts` — 100% statements/branches/functions/lines

If any required check was skipped, explain why:

- The whole-repo `npm run typecheck`/`npm run test:coverage` (unsharded) reliably OOM in this sandbox regardless of diff size — a known sandbox resource constraint documented across many prior PRs, not a signal about this change. The scoped typecheck and 100%-branch scoped coverage above stand in for it.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

This is a backend-only fix (`src/review/loop-escalation-wire.ts`, a Discord-webhook host allowlist) with no rendered UI delta — before and after are the same production capture at each required viewport. `apps/loopover-ui` is dark-mode-only, so only the Dark row per viewport applies.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Dark | [![Desktop · Dark before](https://raw.githubusercontent.com/galuis116/gittensory/screenshots/loop-escalation-discord-hosts-9288-desktop-dark.png)](https://raw.githubusercontent.com/galuis116/gittensory/screenshots/loop-escalation-discord-hosts-9288-desktop-dark.png) | [![Desktop · Dark after](https://raw.githubusercontent.com/galuis116/gittensory/screenshots/loop-escalation-discord-hosts-9288-desktop-dark.png)](https://raw.githubusercontent.com/galuis116/gittensory/screenshots/loop-escalation-discord-hosts-9288-desktop-dark.png) |
| Tablet · Dark | [![Tablet · Dark before](https://raw.githubusercontent.com/galuis116/gittensory/screenshots/loop-escalation-discord-hosts-9288-tablet-dark.png)](https://raw.githubusercontent.com/galuis116/gittensory/screenshots/loop-escalation-discord-hosts-9288-tablet-dark.png) | [![Tablet · Dark after](https://raw.githubusercontent.com/galuis116/gittensory/screenshots/loop-escalation-discord-hosts-9288-tablet-dark.png)](https://raw.githubusercontent.com/galuis116/gittensory/screenshots/loop-escalation-discord-hosts-9288-tablet-dark.png) |
| Mobile · Dark | [![Mobile · Dark before](https://raw.githubusercontent.com/galuis116/gittensory/screenshots/loop-escalation-discord-hosts-9288-mobile-dark.png)](https://raw.githubusercontent.com/galuis116/gittensory/screenshots/loop-escalation-discord-hosts-9288-mobile-dark.png) | [![Mobile · Dark after](https://raw.githubusercontent.com/galuis116/gittensory/screenshots/loop-escalation-discord-hosts-9288-mobile-dark.png)](https://raw.githubusercontent.com/galuis116/gittensory/screenshots/loop-escalation-discord-hosts-9288-mobile-dark.png) |

## Notes

- Precedent: `src/review/alerts.ts:101` and `src/services/notify-discord.ts:11` both already carry the correct four-host set.
