### PR TITLE
fix(engine): progressChanged must diff maxIterations and percentComplete too

### DIFF
--- a/packages/loopover-engine/src/loop-progress.ts
+++ b/packages/loopover-engine/src/loop-progress.ts
@@ -85,6 +85,11 @@ export function progressChanged(prev: ProgressSnapshot | null, next: ProgressSna
     prev.phase !== next.phase ||
     prev.status !== next.status ||
     prev.iteration !== next.iteration ||
+    // #9323: maxIterations and percentComplete are displayed axes too -- raising the iteration budget mid-run
+    // changes percentComplete (and maxIterations) while phase/status/iteration/activity stay the same, so
+    // without these the customer-facing progress bar goes stale on a real, displayed change.
+    prev.maxIterations !== next.maxIterations ||
+    prev.percentComplete !== next.percentComplete ||
     activityChanged(prev.recentActivity, next.recentActivity)
   );
 }

--- a/test/unit/loop-progress.test.ts
+++ b/test/unit/loop-progress.test.ts
@@ -113,3 +113,23 @@ describe("progressChanged — push on change, not on a fixed interval (#4800)", 
     });
   });
 });
+
+describe("progressChanged — maxIterations / percentComplete displayed axes (#9323)", () => {
+  it("pushes when maxIterations changes even though iteration/phase/status/activity are identical", () => {
+    // Raising the iteration budget mid-run: iteration stays 2, maxIterations 5 -> 10 (percentComplete 40 -> 20).
+    const prev = buildProgressSnapshot(running({ iteration: 2, maxIterations: 5 }));
+    const next = buildProgressSnapshot(running({ iteration: 2, maxIterations: 10 }));
+    expect(progressChanged(prev, next)).toBe(true);
+  });
+
+  it("pushes when only percentComplete differs, with every other displayed axis identical", () => {
+    // progressChanged compares the displayed field, not a recomputation — a percentComplete-only delta pushes.
+    const base = buildProgressSnapshot(running());
+    expect(progressChanged(base, { ...base, percentComplete: (base.percentComplete ?? 0) + 10 })).toBe(true);
+  });
+
+  it("does not push when maxIterations and percentComplete are both unchanged", () => {
+    const base = buildProgressSnapshot(running());
+    expect(progressChanged(base, { ...base })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

`progressChanged` (`packages/loopover-engine/src/loop-progress.ts`) decides whether a new
`ProgressSnapshot` differs "in a way worth pushing to the customer", but it only compared
`phase`/`status`/`iteration`/`activity`. `ProgressSnapshot` also **displays** `maxIterations` and
`percentComplete`. So when an operator raises the iteration budget mid-run, `percentComplete` (and
`maxIterations`) changes while the other axes stay the same — `progressChanged` returned `false`, and
the customer-facing streaming surface (via `buildProgressSnapshot`'s caller in `routes.ts`) never
pushed the update, leaving the progress bar stale on a real, displayed change.

Adds both fields to the OR-chain. Diffing only — `activityChanged` and the
`percentComplete`/`maxIterations` computation in `buildProgressSnapshot` are unchanged.

## Test plan

- [x] New: a `maxIterations`-only change (iteration/phase/status/activity identical) now pushes
- [x] New: a `percentComplete`-only change (all other displayed axes identical) now pushes
- [x] New: no push when maxIterations/percentComplete are both unchanged
- [x] **100% branch coverage (23/23)** on the function; non-vacuity verified (removing the two comparisons fails both push tests)
- [x] 16/16 loop-progress tests pass; `tsc --noEmit` clean

Closes #9323