### PR TITLE
test(scoring): cover activeModelWarnings both-saturation-and-density branch

### DIFF
--- a/test/unit/scoring.test.ts
+++ b/test/unit/scoring.test.ts
@@ -352,6 +352,26 @@ NOVELTY_BONUS_SCALAR = 3
     expect(refreshed.warnings.join(" ")).toMatch(/recognized active-model indicator/i);
   });
 
+  it("warns when fetched constants include both saturation and density indicators", async () => {
+    const env = createTestEnv();
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("constants.py")) {
+        return new Response(
+          VALID_CONSTANTS_PY + "SRC_TOK_SATURATION_SCALE = 58.0\nMIN_TOKEN_SCORE_FOR_BASE_SCORE = 5\nMAX_CODE_DENSITY_MULTIPLIER = 1.15\n",
+        );
+      }
+      if (url.includes("programming_languages.json")) return Response.json({});
+      return new Response("not found", { status: 404 });
+    });
+
+    const refreshed = await refreshScoringModelSnapshot(env);
+
+    expect(refreshed.warnings).toContain(
+      "Scoring constants include both exponential saturation and density-era indicators; using exponential saturation as the active model.",
+    );
+  });
+
   it("flags upstream scoring constants loopover does not model (staleness visibility)", () => {
     // SRC_TOK_SATURATION_SCALE and the TIME_DECAY_* constants are now modeled (#703); a hypothetical new
     // upstream dimension is NOT — so only that surfaces as unmodeled drift.


### PR DESCRIPTION
Closes #9321

## Summary
The `activeModelWarnings` function in `src/scoring/model.ts` has three branches, but only the "neither saturation nor density constants present" branch was exercised end-to-end through `refreshScoringModelSnapshot`. This adds the missing test for the "both present" branch, mirroring the existing sibling test pattern.

No production code changes — this is a pure test-coverage gap fix, as called out in the issue.

## Scope
- [x] Backend/test only
- [x] `test/unit/scoring.test.ts`

## Validation
- [x] `npx turbo run build --filter=@loopover/engine` — green
- [x] `npx turbo run build --filter=@loopover/mcp` — green
- [x] `npx turbo run build:tsc build:verify --filter=@loopover/miner` — green
- [x] `npx vitest run --changed=upstream/main --passWithNoTests` — 90/90 passed
- [x] `npm test` (full unsharded suite) — 1220/1226 test files passed; the 6 failing tests (`check-ui-kit-package.test.ts`, `salvageability.test.ts`, `selfhost-metrics.test.ts`, `selfhost-pg-retention.test.ts` ×2, `worker-entry-boundary.test.ts`) are pre-existing and unrelated — verified by re-running those same files with this diff stashed out, reproducing identical failures on the unmodified tree.

## Safety
- [x] No secrets, wallets, hotkeys, trust scores, or reward values touched
- [x] No auth/CORS surface touched (test-only change)

## UI Evidence
Not applicable — this change only adds a unit test in `test/unit/scoring.test.ts`; no UI, route, or component files were touched.

## Notes
New test stubs a `constants.py` response containing `SRC_TOK_SATURATION_SCALE`, `MIN_TOKEN_SCORE_FOR_BASE_SCORE`, and `MAX_CODE_DENSITY_MULTIPLIER` together, calls `refreshScoringModelSnapshot`, and asserts the exact warning text: "Scoring constants include both exponential saturation and density-era indicators; using exponential saturation as the active model."