### PR TITLE
fix(content-lane): harden duplicates block-scalar header detection

### DIFF
--- a/src/review/content-lane/duplicates.ts
+++ b/src/review/content-lane/duplicates.ts
@@ -40,12 +40,25 @@ export type ContentDuplicateReview = {
   relatedCandidates: ContentDuplicateMatch[];
 };
 
+function stripYamlComment(value: string): string {
+  return value.replace(/\s+#.*$/, "").trim();
+}
+
 function unquoteYamlScalar(value: string): string {
   const trimmed = value.trim();
   if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
     return trimmed.slice(1, -1).trim();
   }
   return trimmed.replace(/\s+#.*$/, "").trim();
+}
+
+// A YAML block-scalar header indicator: `|` or `>` with an optional chomping (`+`/`-`) and/or a single indentation
+// digit, in EITHER order — `|`, `>`, `|-`, `>+`, `|2`, `|2-`, `|-2`, `>2+`. Kept in one place so parseSimpleFrontmatter
+// and findDuplicateFrontmatterKeys agree on what is a block-scalar header (mirrors source-evidence.ts).
+const BLOCK_SCALAR_INDICATOR = /^[|>](?:[+-]?\d?|\d[+-]?)$/;
+
+function isBlockScalarHeader(raw: string): boolean {
+  return BLOCK_SCALAR_INDICATOR.test(stripYamlComment(raw));
 }
 
 /**
@@ -74,7 +87,7 @@ export function parseSimpleFrontmatter(source: string): Record<string, string> {
     /* v8 ignore next -- noUncheckedIndexedAccess fallback: capture group 2 (.*) always participates when head matches, so head[2] is never undefined */
     const inline = (head[2] ?? "").trim();
     i += 1;
-    if (/^[|>][+-]?\d*$/.test(inline)) {
+    if (isBlockScalarHeader(inline)) {
       // Block literal (`|`) / folded (`>`) scalar: gather the indented block that follows.
       const block: string[] = [];
       /* v8 ignore next -- noUncheckedIndexedAccess fallback: i < lines.length guards the index; split() elements are always strings */
@@ -129,7 +142,7 @@ export function findDuplicateFrontmatterKeys(source: string): string[] {
     /* v8 ignore next -- noUncheckedIndexedAccess fallback: capture group 2 (.*) always participates when head matches, so head[2] is never undefined */
     const inline = (head[2] ?? "").trim();
     i += 1;
-    if (/^[|>][+-]?\d*$/.test(inline)) {
+    if (isBlockScalarHeader(inline)) {
       /* v8 ignore next -- noUncheckedIndexedAccess fallback: i < lines.length guards the index; split() elements are always strings */
       while (i < lines.length && ((lines[i] ?? "").trim() === "" || /^\s/.test(lines[i] ?? ""))) i += 1;
     } else if (inline === "") {

--- a/test/unit/content-lane-duplicates.test.ts
+++ b/test/unit/content-lane-duplicates.test.ts
@@ -58,6 +58,22 @@ describe("parseSimpleFrontmatter", () => {
     expect(f.title).toBe("Real");
     expect(Object.keys(f)).toEqual(["title"]);
   });
+
+  it("recognizes block-scalar headers with chomping/indent in either order and trailing comments (#9290)", () => {
+    const indicators = ["|", ">", "|-", ">-", "|+", ">+", "|2", ">2", "|-2", "|2-", ">2+", ">2-"];
+    for (const indicator of indicators) {
+      const src = ["---", `description: ${indicator}`, "  line one", "  line two", "title: Real", "---", "", "body"].join("\n");
+      const f = parseSimpleFrontmatter(src);
+      expect(f.description).toBe("line one\nline two");
+      expect(f.title).toBe("Real");
+    }
+    for (const indicator of ["|-", ">", "|2-"]) {
+      const src = ["---", `description: ${indicator} # sources below`, "  only line", "title: Real", "---", "", "body"].join("\n");
+      const f = parseSimpleFrontmatter(src);
+      expect(f.description).toBe("only line");
+      expect(f.title).toBe("Real");
+    }
+  });
 });
 
 describe("findDuplicateFrontmatterKeys", () => {
@@ -282,6 +298,36 @@ describe("findDuplicateFrontmatterKeys — block-scalar + sequence skipping", ()
     const src = ["---", "", "# comment line", "title: A", "slug: a", "---", "", "body"].join("\n");
     // The blank + comment lines fail the key regex → the `if (!head) continue` branch runs; no dupes.
     expect(findDuplicateFrontmatterKeys(src)).toEqual([]);
+  });
+
+  it("skips block-scalar headers with chomping/indent in either order and trailing comments (#9290)", () => {
+    const indicators = ["|", ">", "|-", ">-", "|+", ">+", "|2", ">2", "|-2", "|2-", ">2+", ">2-"];
+    for (const indicator of indicators) {
+      const src = [
+        "---",
+        `description: ${indicator}`,
+        "  title: not-a-real-key",
+        "title: Real",
+        "title: DupReal",
+        "---",
+        "",
+        "body",
+      ].join("\n");
+      expect(findDuplicateFrontmatterKeys(src)).toEqual(["title"]);
+    }
+    for (const indicator of ["|-", ">", "|2-"]) {
+      const src = [
+        "---",
+        `description: ${indicator} # sources below`,
+        "  title: not-a-real-key",
+        "title: Real",
+        "title: DupReal",
+        "---",
+        "",
+        "body",
+      ].join("\n");
+      expect(findDuplicateFrontmatterKeys(src)).toEqual(["title"]);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- Harden block-scalar header detection in `src/review/content-lane/duplicates.ts` to match the grammar already used in `source-evidence.ts` (`stripYamlComment`, `BLOCK_SCALAR_INDICATOR`, `isBlockScalarHeader`).
- Replace the old `/^[|>][+-]?\d*$/` checks in `parseSimpleFrontmatter` and `findDuplicateFrontmatterKeys` so chomping/indent permutations (`|2-`, `>2+`, etc.) and trailing inline comments (`| # note`) are recognized.
- Add regression tests mirroring `content-lane-source-evidence.test.ts`.

Closes #9290

## Scope

- [x] True leaf path: only `duplicates.ts` + `content-lane-duplicates.test.ts` (scoped CI should stay ~1 test file, same shape as merged #9336 / #9338).
- [x] Duplicate gate: no other open PR for #9290; issue still open.
- [x] Avoids hub files (`processors.ts`, `advisory.ts`) that fan out to thousands of tests and hit maintainer #9285 flake.

## Validation

- [x] Block-scalar header permutations + comment-tolerant cases covered in unit tests.
- [ ] Full CI — expecting narrow `--changed` selection (not the #9285 `selfhost-pg-retention` / `salvageability` slice).