### PR TITLE
fix(mcp): mirror loopover_clear_selftune_override in the CLI stdio package

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.ts
+++ b/packages/loopover-mcp/bin/loopover-mcp.ts
@@ -1070,6 +1070,14 @@ const selftuneOverrideAuditShape = {
   limit: z.number().int().positive().optional(),
 };
 
+// #9300: write-side sibling of selftuneOverrideAuditShape — mirrors src/mcp/server.ts's
+// clearSelftuneOverrideShape (`confirm` must be the literal true; omitted/false is schema-rejected).
+const clearSelftuneOverrideShape = {
+  owner: z.string().min(1),
+  repo: z.string().min(1),
+  confirm: z.literal(true),
+};
+
 // #7764: mirrors the remote loopover_plan_repo_issues tool's input (src/mcp/server.ts's planRepoIssuesShape),
 // minus the create-only `milestone` which this proxy (and the `maintain plan-issues` CLI) does not expose --
 // forwarded to POST /v1/repos/:owner/:repo/issue-plan-drafts/generate. `goal` is the required maintainer
@@ -1582,6 +1590,12 @@ const STDIO_TOOL_DESCRIPTORS = [
     category: "maintainer",
     description:
       "Return the self-tune override audit trail for a repo — why the self-tune loop promoted, shadowed, or cleared a live gate override, newest first. Optionally capped by limit. Maintainer-authenticated; read-only measurement.",
+  },
+  {
+    name: "loopover_clear_selftune_override",
+    category: "maintainer",
+    description:
+      "Clear a repo's LIVE self-tune gate override (the operator's \"reset to config base\" control), mirroring DELETE /v1/repos/:owner/:repo/selftune/overrides. Requires confirm:true; the automatic self-tune promote path is untouched. Maintainer access required.",
   },
   {
     name: "loopover_get_automation_state",
@@ -3189,6 +3203,20 @@ registerStdioTool(
     const query = limit ? `?limit=${encodeURIComponent(limit)}` : "";
     const payload = await apiGet(`${toolRepoBase(owner, repo)}/selftune/overrides/audit${query}`);
     return toolResult(`Self-tune override audit for ${owner}/${repo}.`, payload);
+  },
+);
+
+// #9300: write-side sibling of loopover_get_selftune_override_audit — DELETE {repoBase}/selftune/overrides
+// with confirm:true (schema-enforced; never silently defaulted). Same apiDelete helper the unwatch action uses.
+registerStdioTool(
+  "loopover_clear_selftune_override",
+  {
+    description: stdioToolDescription("loopover_clear_selftune_override"),
+    inputSchema: clearSelftuneOverrideShape,
+  },
+  async ({ owner, repo, confirm }: any) => {
+    const payload = await apiDelete(`${toolRepoBase(owner, repo)}/selftune/overrides`, { confirm });
+    return toolResult(`Cleared the live self-tune gate override for ${owner}/${repo}.`, payload);
   },
 );
 

--- a/test/unit/mcp-cli-clear-selftune-override.test.ts
+++ b/test/unit/mcp-cli-clear-selftune-override.test.ts
@@ -1,0 +1,121 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { closeFixtureServer, startFixtureServer } from "./support/mcp-cli-harness";
+
+// #9300: in-process coverage for loopover_clear_selftune_override in packages/loopover-mcp/bin/loopover-mcp.ts.
+// Same entrypoint-guard pattern as mcp-cli-selftune-audit — import the committed .ts so v8/Codecov
+// attributes the new registerStdioTool + apiDelete lines.
+const MODULES = ["../../packages/loopover-mcp/bin/loopover-mcp.ts"] as const;
+
+type BinModule = {
+  server: { connect: (transport: unknown) => Promise<void> };
+};
+
+let tempDir = "";
+const capturedDeletes: Array<{ url: string; method: string; body: { confirm?: boolean } }> = [];
+const loaded = new Map<string, BinModule>();
+
+beforeAll(async () => {
+  tempDir = mkdtempSync(join(tmpdir(), "loopover-clear-selftune-"));
+  const apiUrl = await startFixtureServer({
+    onClearSelftuneOverride: (body) => {
+      capturedDeletes.push({
+        url: "/v1/repos/owner/repo/selftune/overrides",
+        method: "DELETE",
+        body,
+      });
+    },
+  });
+  process.env.LOOPOVER_API_URL = apiUrl;
+  process.env.LOOPOVER_API_TOKEN = "in-process-token";
+  process.env.LOOPOVER_API_TIMEOUT_MS = "2000";
+  process.env.LOOPOVER_CONFIG_DIR = tempDir;
+  process.env.LOOPOVER_SKIP_NPM_VERSION_CHECK = "1";
+  for (const specifier of MODULES) {
+    loaded.set(specifier, (await import(specifier)) as unknown as BinModule);
+  }
+}, 120_000);
+
+afterAll(async () => {
+  await closeFixtureServer();
+  if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+  delete process.env.LOOPOVER_API_URL;
+  delete process.env.LOOPOVER_API_TOKEN;
+  delete process.env.LOOPOVER_CONFIG_DIR;
+  delete process.env.LOOPOVER_SKIP_NPM_VERSION_CHECK;
+});
+
+describe("bin loopover_clear_selftune_override stdio tool (in-process, #9300)", () => {
+  it.each(MODULES)("registers and proxies DELETE .../selftune/overrides with confirm:true — %s", async (specifier) => {
+    capturedDeletes.length = 0;
+    const mod = loaded.get(specifier)!;
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await mod.server.connect(serverTransport);
+    const client = new Client({ name: "clear-selftune-test", version: "0.1.0" }, { capabilities: {} });
+    await client.connect(clientTransport);
+    try {
+      const { tools } = await client.listTools();
+      const tool = tools.find((entry) => entry.name === "loopover_clear_selftune_override");
+      expect(tool).toBeDefined();
+      expect(tool?.description).toMatch(/clear.*self-tune.*override/i);
+
+      const result = await client.callTool({
+        name: "loopover_clear_selftune_override",
+        arguments: { owner: "owner", repo: "repo", confirm: true },
+      });
+      expect(result.isError).toBeFalsy();
+      expect(capturedDeletes).toEqual([
+        {
+          url: "/v1/repos/owner/repo/selftune/overrides",
+          method: "DELETE",
+          body: { confirm: true },
+        },
+      ]);
+      expect(JSON.stringify(result)).toMatch(/Cleared the live self-tune gate override for owner\/repo/);
+      expect(JSON.stringify(result)).toContain('"cleared":true');
+    } finally {
+      await client.close().catch(() => undefined);
+    }
+  });
+
+  it.each(MODULES)("rejects missing or false confirm without calling DELETE — %s", async (specifier) => {
+    capturedDeletes.length = 0;
+    const mod = loaded.get(specifier)!;
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await mod.server.connect(serverTransport);
+    const client = new Client({ name: "clear-selftune-reject-test", version: "0.1.0" }, { capabilities: {} });
+    await client.connect(clientTransport);
+    try {
+      const missing = await client
+        .callTool({
+          name: "loopover_clear_selftune_override",
+          arguments: { owner: "owner", repo: "repo" },
+        })
+        .then(
+          (r) => ({ isError: Boolean(r.isError), text: JSON.stringify(r) }),
+          (e: unknown) => ({ isError: true, text: String(e) }),
+        );
+      expect(missing.isError).toBe(true);
+
+      const falsy = await client
+        .callTool({
+          name: "loopover_clear_selftune_override",
+          arguments: { owner: "owner", repo: "repo", confirm: false },
+        })
+        .then(
+          (r) => ({ isError: Boolean(r.isError), text: JSON.stringify(r) }),
+          (e: unknown) => ({ isError: true, text: String(e) }),
+        );
+      expect(falsy.isError).toBe(true);
+
+      // Schema rejection must never reach the REST route.
+      expect(capturedDeletes).toEqual([]);
+    } finally {
+      await client.close().catch(() => undefined);
+    }
+  });
+});

--- a/test/unit/mcp-tool-rename-aliases.test.ts
+++ b/test/unit/mcp-tool-rename-aliases.test.ts
@@ -43,6 +43,7 @@
 // (#7755 registered the loopover_generate_contributor_issue_drafts stdio tool, taking the count from 98 to 99.)
 // (#7753 registered the loopover_propose_action stdio tool, taking the count from 99 to 100.)
 // (#7798 registered the loopover_get_selftune_override_audit remote+stdio tool, taking the count from 100 to 101.)
+// (#9300 registered the loopover_clear_selftune_override CLI mirror, taking the count from 101 to 102.)
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { mkdtempSync, rmSync } from "node:fs";
@@ -89,14 +90,14 @@ describe("MCP legacy alias retirement (#4777) — discovery invariants", () => {
   });
   afterEach(disconnect);
 
-  it("lists exactly 101 loopover_ tools and zero gittensory_-prefixed aliases", async () => {
+  it("lists exactly 102 loopover_ tools and zero gittensory_-prefixed aliases", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name);
     const primary = names.filter((n) => n.startsWith("loopover_"));
     const legacy = names.filter((n) => n.startsWith("gittensory_"));
-    expect(primary.length).toBe(101);
+    expect(primary.length).toBe(102);
     expect(legacy.length).toBe(0);
-    expect(names.length).toBe(101);
+    expect(names.length).toBe(102);
   });
 
   it("no loopover_ tool's description carries a stale deprecation notice", async () => {
@@ -108,14 +109,14 @@ describe("MCP legacy alias retirement (#4777) — discovery invariants", () => {
     }
   });
 
-  it("`loopover-mcp tools --json` reports the same 101-tool count the live server registers", async () => {
+  it("`loopover-mcp tools --json` reports the same 102-tool count the live server registers", async () => {
     const { tools } = await client.listTools();
     const payload = JSON.parse(run(["tools", "--json"])) as {
       count: number;
       tools: Array<{ name: string }>;
     };
     expect(payload.count).toBe(tools.length);
-    expect(payload.count).toBe(101);
+    expect(payload.count).toBe(102);
     expect([...payload.tools.map((t) => t.name)].sort()).toEqual(
       [...tools.map((t) => t.name)].sort(),
     );

--- a/test/unit/support/mcp-cli-harness.ts
+++ b/test/unit/support/mcp-cli-harness.ts
@@ -189,6 +189,8 @@ export async function startFixtureServer(
     onPlanIssuesRequest?: (body: { goal?: string; dryRun?: boolean; create?: boolean; limit?: number }) => void;
     onWatchRequest?: (req: { method: string; body: { repoFullName?: string; labels?: string[] } }) => void;
     onApiRequest?: (request: IncomingMessage) => void;
+    /** #9300: captures DELETE /v1/repos/:owner/:repo/selftune/overrides body ({ confirm }). */
+    onClearSelftuneOverride?: (body: { confirm?: boolean }) => void;
     validateConfigWarnings?: string[];
     openPrMonitor?: Record<string, unknown>;
     prOutcomes?: Record<string, unknown>;
@@ -746,6 +748,13 @@ export async function startFixtureServer(
     // #7798: audit-less variant — a payload without rows, for the CLI's defensive audit fallback.
     if (request.url?.startsWith("/v1/repos/owner/bare/selftune/overrides/audit") && request.method === "GET") {
       response.end(JSON.stringify({ repoFullName: "owner/bare" }));
+      return;
+    }
+    // #9300: clear live self-tune override (write-side sibling of the audit GET above).
+    if (request.url?.startsWith("/v1/repos/owner/repo/selftune/overrides") && !request.url.includes("/audit") && request.method === "DELETE") {
+      const body = (await readJsonRequest(request)) as { confirm?: boolean };
+      options.onClearSelftuneOverride?.(body);
+      response.end(JSON.stringify({ repoFullName: "owner/repo", cleared: true }));
       return;
     }
     if (request.url?.startsWith("/v1/repos/owner/repo/outcome-calibration") && request.method === "GET") {


### PR DESCRIPTION
## Summary

- Closes #9300
- Adds `loopover_clear_selftune_override` to the `packages/loopover-mcp` tool catalog (`maintainer`) and a `registerStdioTool` handler that calls `apiDelete(.../selftune/overrides, { confirm })`, matching the remote MCP tool from #8660 and the CLI audit mirror from #7997.
- `confirm` is schema-enforced as `z.literal(true)` — omitted/false inputs are rejected before any DELETE is sent.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run build:mcp`
- [x] `npx vitest run test/unit/mcp-cli-clear-selftune-override.test.ts test/unit/mcp-tool-rename-aliases.test.ts` — 12 passed
- [x] Scoped `diff-cover` vs `origin/main` on `packages/loopover-mcp/bin/loopover-mcp.ts` — **100%** patch lines
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

CLI mirror of an existing REST/MCP tool; targeted MCP CLI + tool-count tests cover the happy path and confirm-rejection path. Full `test:ci` left for CI.

## Safety

- [x] If my change touches auth, CORS, CSRF, cookies, sessions, webhooks, or repo/path access: I added negative-path tests for unauthenticated, cross-repo/unauthorized, and browser-origin requests where applicable.
- [x] No secrets, wallets, hotkeys, trust scores, or reward values.
- [x] Does not touch `site/`, `CNAME`, `**/lovable/**`, or root `CHANGELOG.md`.

## UI Evidence

N/A — CLI/stdio MCP tool registration only; no visible UI change.

## Notes for reviewers / gate

- No OpenAPI regeneration (DELETE route unchanged).
- Tool-count assertion updated 101 → 102.


Made with [Cursor](https://cursor.com)