### PR TITLE
fix(miner): add blocked_own_open_pr to AttemptCliResult union

### DIFF
--- a/packages/loopover-miner/lib/attempt-cli.ts
+++ b/packages/loopover-miner/lib/attempt-cli.ts
@@ -98,6 +98,7 @@ type CommonAttemptResultFields = {
 export type AttemptCliResult =
   | (CommonAttemptResultFields & { outcome: "dry_run" })
   | (CommonAttemptResultFields & { outcome: "blocked_rejection_signaled"; reason: string })
+  | (CommonAttemptResultFields & { outcome: "blocked_own_open_pr"; reason: string; existingPullRequestNumber: number })
   | (CommonAttemptResultFields & { outcome: "blocked_worktree_preparation_failed"; reason: string })
   | (CommonAttemptResultFields & {
       outcome: "blocked_infeasible";


### PR DESCRIPTION
The own-open-PR idempotency guard added in #8808 constructs and emits a `blocked_own_open_pr` outcome (packages/loopover-miner/lib/attempt-cli.ts, around the `duplicateResult` object), but `AttemptCliResult` never declared that member — a real runtime outcome missing from its own exported type, so any `onResult` consumer typed against the union silently lost the shape (including `existingPullRequestNumber`).

This adds the missing union member with the exact shape the call site already constructs (`reason: string`, `existingPullRequestNumber: number`, plus the common fields). I checked whether the existing `as AttemptCliResult` cast at that call site could now be dropped, per the issue's second requirement — it can't: TypeScript widens the plain object literal's `outcome` field to `string`, so the cast is still needed to narrow it back to the literal type. This matches every other sibling call site in the file (e.g. `blocked_rejection_signaled`, `blocked_worktree_preparation_failed`), which keep the same cast even though their outcomes are already declared in the union, so I left it as-is rather than removing it.

Pure type-definition change, no runtime behavior touched — confirmed by `git diff --stat` (1 line, 1 file). No new tests added per the issue's own guidance (type-only change, no runtime modification).

Closes #9331

### Validation
- `npx turbo run build --filter=@loopover/engine` — pass
- `npx turbo run build --filter=@loopover/mcp` — pass
- `npx turbo run build:tsc build:verify --filter=@loopover/miner` — pass
- `npx vitest run --changed=upstream/main --passWithNoTests` — 186/186 pass (incl. all 107 in test/unit/miner-attempt-cli.test.ts)
- `npm test` (full suite) — 6 pre-existing failures unrelated to this change (test/unit/check-ui-kit-package.test.ts, test/unit/salvageability.test.ts, test/unit/selfhost-metrics.test.ts, test/unit/selfhost-pg-retention.test.ts ×2, test/unit/worker-entry-boundary.test.ts), verified to fail identically with this commit stashed out