### PR TITLE
review/content-lane: duplicates.ts's block-scalar detection lags source-evidence.ts's hardened version (comment-tolerance, digit order)

### DIFF
--- a/src/review/content-lane/duplicates.ts
+++ b/src/review/content-lane/duplicates.ts
@@ -40,6 +40,20 @@ export type ContentDuplicateReview = {
   relatedCandidates: ContentDuplicateMatch[];
 };
 
+function stripYamlComment(value: string): string {
+  return value.replace(/\s+#.*$/, "").trim();
+}
+
+// A YAML block-scalar header indicator: `|` or `>` with an optional chomping (`+`/`-`) and/or a single indentation
+// digit, in EITHER order — `|`, `>`, `|-`, `>+`, `|2`, `|2-`, `|-2`, `>2+`. Mirrors source-evidence.ts (#8016).
+const BLOCK_SCALAR_INDICATOR = /^[|>](?:[+-]?\d?|\d[+-]?)$/;
+
+// True when a raw frontmatter value is a block-scalar header. Comment-tolerant: a header may carry a trailing inline
+// comment (`| # sources below`), which normalizes away before the indicator is matched.
+function isBlockScalarHeader(raw: string): boolean {
+  return BLOCK_SCALAR_INDICATOR.test(stripYamlComment(raw));
+}
+
 function unquoteYamlScalar(value: string): string {
   const trimmed = value.trim();
   if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
@@ -74,7 +88,7 @@ export function parseSimpleFrontmatter(source: string): Record<string, string> {
     /* v8 ignore next -- noUncheckedIndexedAccess fallback: capture group 2 (.*) always participates when head matches, so head[2] is never undefined */
     const inline = (head[2] ?? "").trim();
     i += 1;
-    if (/^[|>][+-]?\d*$/.test(inline)) {
+    if (isBlockScalarHeader(inline)) {
       // Block literal (`|`) / folded (`>`) scalar: gather the indented block that follows.
       const block: string[] = [];
       /* v8 ignore next -- noUncheckedIndexedAccess fallback: i < lines.length guards the index; split() elements are always strings */
@@ -129,7 +143,7 @@ export function findDuplicateFrontmatterKeys(source: string): string[] {
     /* v8 ignore next -- noUncheckedIndexedAccess fallback: capture group 2 (.*) always participates when head matches, so head[2] is never undefined */
     const inline = (head[2] ?? "").trim();
     i += 1;
-    if (/^[|>][+-]?\d*$/.test(inline)) {
+    if (isBlockScalarHeader(inline)) {
       /* v8 ignore next -- noUncheckedIndexedAccess fallback: i < lines.length guards the index; split() elements are always strings */
       while (i < lines.length && ((lines[i] ?? "").trim() === "" || /^\s/.test(lines[i] ?? ""))) i += 1;
     } else if (inline === "") {

--- a/test/unit/content-lane-duplicates.test.ts
+++ b/test/unit/content-lane-duplicates.test.ts
@@ -58,6 +58,27 @@ describe("parseSimpleFrontmatter", () => {
     expect(f.title).toBe("Real");
     expect(Object.keys(f)).toEqual(["title"]);
   });
+
+  it("reads a |2- block-scalar header (digit-before-chomp order) and its indented body (#9290)", () => {
+    const src = ["---", "description: |2-", "  line one", "  line two", "title: T", "---", "", "body"].join("\n");
+    const f = parseSimpleFrontmatter(src);
+    expect(f.description).toBe("line one\nline two");
+    expect(f.title).toBe("T");
+  });
+
+  it("reads a |- # comment block-scalar header and its indented body (#9290)", () => {
+    const src = ["---", "description: |- # trailing note", "  hidden content", "title: T", "---", "", "body"].join("\n");
+    const f = parseSimpleFrontmatter(src);
+    expect(f.description).toBe("hidden content");
+    expect(f.title).toBe("T");
+  });
+
+  it("reads a > # comment folded block-scalar header and joins its indented body (#9290)", () => {
+    const src = ["---", "description: > # folded note", "  word one", "  word two", "title: T", "---", "", "body"].join("\n");
+    const f = parseSimpleFrontmatter(src);
+    expect(f.description).toBe("word one word two");
+    expect(f.title).toBe("T");
+  });
 });
 
 describe("findDuplicateFrontmatterKeys", () => {
@@ -282,6 +303,49 @@ describe("findDuplicateFrontmatterKeys — block-scalar + sequence skipping", ()
     const src = ["---", "", "# comment line", "title: A", "slug: a", "---", "", "body"].join("\n");
     // The blank + comment lines fail the key regex → the `if (!head) continue` branch runs; no dupes.
     expect(findDuplicateFrontmatterKeys(src)).toEqual([]);
+  });
+
+  it("skips a |2- block-scalar body without false-flagging indented pseudo-keys (#9290)", () => {
+    const src = [
+      "---",
+      "description: |2-",
+      "  title: not-a-real-key",
+      "  another: line",
+      "title: Real",
+      "title: DupReal",
+      "---",
+      "",
+      "body",
+    ].join("\n");
+    expect(findDuplicateFrontmatterKeys(src)).toEqual(["title"]);
+  });
+
+  it("skips a |- # comment block-scalar body without false-flagging indented pseudo-keys (#9290)", () => {
+    const src = [
+      "---",
+      "description: |- # trailing note",
+      "  title: not-a-real-key",
+      "slug: a",
+      "slug: b",
+      "---",
+      "",
+      "body",
+    ].join("\n");
+    expect(findDuplicateFrontmatterKeys(src)).toEqual(["slug"]);
+  });
+
+  it("skips a > # comment folded block-scalar body without false-flagging indented pseudo-keys (#9290)", () => {
+    const src = [
+      "---",
+      "description: > # folded note",
+      "  title: not-a-real-key",
+      "category: x",
+      "category: y",
+      "---",
+      "",
+      "body",
+    ].join("\n");
+    expect(findDuplicateFrontmatterKeys(src)).toEqual(["category"]);
   });
 });
 


### PR DESCRIPTION
## Summary

`src/review/content-lane/duplicates.ts` has two call sites (`parseSimpleFrontmatter` at line ~77
and `findDuplicateFrontmatterKeys` at line ~132) that detect a YAML block-scalar header (`|`, `>`,
`|-`, `|2-`, etc.) using:

```ts
/^[|>][+-]?\d*$/.test(inline)
```

The sibling parser in `src/review/content-lane/source-evidence.ts` was previously hardened (in
#8016) into a shared, more correct check:

```ts
const BLOCK_SCALAR_INDICATOR = /^[|>](?:[+-]?\d?|\d[+-]?)$/;
function isBlockScalarHeader(raw: string): boolean {
  return BLOCK_SCALAR_INDICATOR.test(stripYamlComment(raw));
}
```

This hardened version (a) accepts the indentation digit before *or* after the chomping indicator
(`|2-` as well as `|-2`), and (b) strips a trailing inline comment first, so `| # sources below`
is still recognized as a block-scalar header. `duplicates.ts`'s regex has neither fix.

**Concretely, `duplicates.ts` fails to recognize:** `|2-` (digit-then-chomp order), and any
block-scalar header with a trailing comment (`| # note`, `|- # note`, `|2- # trailing`). When that
happens, the header line collapses to the literal string `"|"` and the real indented block content
that follows is silently skipped by the parser loop (indented lines don't match the `key:` regex).

This directly undermines `duplicates.ts`'s own stated purpose (per its file-level doc comment: "a
regex parser that silently drops block/folded/list values would let a contributor hide a
protected-field edit and bypass the protected-edit + duplicate gates"). A protected field written
as `description: | # note` followed by indented content would parse to `"|"` both before and after
an edit, so `protectedFrontmatterChanges` would never detect the real content change, and two
semantically-different entries using this style would collide as "same normalized description" in
the duplicate detector.

This is the same cross-file divergence class already fixed twice between these exact two files:
**#7250** and **#8016** (both closed) — this issue is the same class of gap, this time in the
opposite direction (`source-evidence.ts` is ahead, `duplicates.ts` lags).

## Deliverables

- [ ] `duplicates.ts`'s `parseSimpleFrontmatter` recognizes `|2-`-style and comment-trailing
      block-scalar headers identically to `source-evidence.ts`.
- [ ] `duplicates.ts`'s `findDuplicateFrontmatterKeys` recognizes the same headers identically.
- [ ] New test cases (in the existing `duplicates.ts` test file under `test/unit/`) covering: a
      `|2-` header, a `|- # comment` header, and a `> # comment` header, each asserting the
      indented block content that follows is correctly captured (for `parseSimpleFrontmatter`) or
      correctly skipped without producing a spurious duplicate/parse error (for
      `findDuplicateFrontmatterKeys`).

All three deliverables are required in this single PR.

## Test plan

This repo enforces 99%+ Codecov patch coverage, branch-counted, on every changed line/branch in
`src/**`. The new test cases above must exercise both fixed call sites.

Fixes #9290