### PR TITLE
fix(miner): make governor-run-halt's ledger recording a genuine transition detector

### DIFF
--- a/packages/loopover-miner/lib/governor-run-halt.ts
+++ b/packages/loopover-miner/lib/governor-run-halt.ts
@@ -63,7 +63,7 @@ export function evaluateRunLoopBoundaryGate(
   }
 
   const recorded =
-    newlyHalted || (!wasHalted && !verdict.shouldHalt)
+    wasHalted !== verdict.shouldHalt
       ? append(
           // Engine ledger events allow explicit `undefined` on optional fields; the miner append
           // contract uses exactOptionalPropertyTypes (`?: T` without `| undefined`).

--- a/test/unit/miner-governor-run-halt.test.ts
+++ b/test/unit/miner-governor-run-halt.test.ts
@@ -7,6 +7,7 @@ vi.mock("@loopover/engine", async () => {
   return import("../../packages/loopover-engine/src/index");
 });
 
+import * as engineModule from "@loopover/engine";
 import { evaluateRunLoopBoundaryGate } from "../../packages/loopover-miner/lib/governor-run-halt";
 import {
   closeDefaultGovernorLedger,
@@ -102,11 +103,11 @@ describe("evaluateRunLoopBoundaryGate (#2347)", () => {
     expect(halted.recorded?.reason).toBe("budget_cap_exceeded");
   });
 
-  it("never halts or records a halt for a healthy run under both signals", () => {
-    const root = mkdtempSync(join(tmpdir(), "loopover-miner-governor-run-halt-healthy-"));
-    roots.push(root);
-    const ledger = initGovernorLedger(join(root, "governor-ledger.sqlite3"));
-    ledgers.push(ledger);
+  // #9326: the steady (wasHalted=false, shouldHalt=false) case is not a transition -- it must not append a
+  // ledger row on every single healthy iteration. A vi.fn() append spy proves this directly (never called),
+  // not just that the returned `recorded` field is null.
+  it("never halts and never appends a ledger row for a healthy run under both signals", () => {
+    const append = vi.fn();
 
     const healthy = evaluateRunLoopBoundaryGate(
       {
@@ -115,13 +116,56 @@ describe("evaluateRunLoopBoundaryGate (#2347)", () => {
         limits: LIMITS,
         convergence: HEALTHY_CONVERGENCE,
       },
-      { append: (event) => ledger.appendGovernorEvent(event) },
+      { append },
     );
 
     expect(healthy.runHalted).toBe(false);
     expect(healthy.canClaimNext).toBe(true);
-    expect(healthy.recorded?.eventType).toBe("allowed");
+    expect(healthy.recorded).toBeNull();
     expect(healthy.releasedItem).toBeNull();
+    expect(append).not.toHaveBeenCalled();
+  });
+
+  // #9326: the resume transition (wasHalted=true, shouldHalt=false) -- symmetric with the halt-trip case
+  // above -- previously left no ledger trace at all. It must now record, the same way a halt trip does.
+  // evaluateRunLoopHalt's own real implementation latches shouldHalt:true unconditionally whenever
+  // runHalted:true is passed in (its "prior_halt" branch) -- a genuine resume only happens once an
+  // operator externally clears that latch outside this call, so this test forces the collaborator's verdict
+  // for one call to exercise evaluateRunLoopBoundaryGate's OWN transition-detection condition directly,
+  // independent of whether evaluateRunLoopHalt's current coupling makes this reachable today.
+  it("records a resume transition when a previously-halted run recovers", () => {
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-governor-run-halt-resume-"));
+    roots.push(root);
+    const ledger = initGovernorLedger(join(root, "governor-ledger.sqlite3"));
+    ledgers.push(ledger);
+
+    // A real, correctly-shaped "cleared" verdict (from the real function, runHalted:false) spliced in for
+    // the next call, rather than hand-constructing every nested cap/convergence field.
+    const clearedVerdict = engineModule.evaluateRunLoopHalt({
+      runHalted: false,
+      usage: HEALTHY_USAGE,
+      limits: LIMITS,
+      convergence: HEALTHY_CONVERGENCE,
+    });
+    expect(clearedVerdict.shouldHalt).toBe(false);
+    const spy = vi.spyOn(engineModule, "evaluateRunLoopHalt").mockReturnValueOnce(clearedVerdict);
+
+    const resumed = evaluateRunLoopBoundaryGate(
+      {
+        runHalted: true,
+        usage: HEALTHY_USAGE,
+        limits: LIMITS,
+        convergence: HEALTHY_CONVERGENCE,
+      },
+      { append: (event) => ledger.appendGovernorEvent(event) },
+    );
+    spy.mockRestore();
+
+    expect(resumed.runHalted).toBe(false);
+    expect(resumed.canClaimNext).toBe(true);
+    expect(resumed.recorded).not.toBeNull();
+    expect(resumed.recorded?.eventType).toBe("allowed");
+    expect(resumed.releasedItem).toBeNull();
   });
 
   it("does not re-append ledger rows while a prior halt remains latched", () => {
@@ -156,7 +200,7 @@ describe("evaluateRunLoopBoundaryGate (#2347)", () => {
     expect(append).toHaveBeenCalledTimes(1);
   });
 
-  it("forwards custom convergenceThresholds and records via the default ledger append", () => {
+  it("forwards custom convergenceThresholds to keep a run healthy, using the default ledger append (never invoked, steady state)", () => {
     const root = mkdtempSync(join(tmpdir(), "loopover-miner-governor-run-halt-thresholds-"));
     roots.push(root);
     previousConfigDirs.push(process.env.LOOPOVER_MINER_CONFIG_DIR);
@@ -172,7 +216,9 @@ describe("evaluateRunLoopBoundaryGate (#2347)", () => {
     });
     expect(healthy.runHalted).toBe(false);
     expect(healthy.canClaimNext).toBe(true);
-    expect(healthy.recorded?.eventType).toBe("allowed");
+    // #9326: steady never-halted state -- no transition, so nothing is recorded (would have used the
+    // default ledger append if it had recorded, but the whole point of the fix is that it doesn't).
+    expect(healthy.recorded).toBeNull();
     expect(healthy.releasedItem).toBeNull();
   });
 


### PR DESCRIPTION
## Summary

- `evaluateRunLoopBoundaryGate` in `packages/loopover-miner/lib/governor-run-halt.ts` decided whether to append a governor-ledger row using `newlyHalted || (!wasHalted && !verdict.shouldHalt)`. Tracing all four `(wasHalted, shouldHalt)` combinations: the steady "never halted, still not halted" case appended a row on **every single iteration** of a healthy run (pure ledger noise, no transition), while the resume transition `(wasHalted=true, shouldHalt=false)` — symmetric with the halt-trip case the old condition did correctly capture — was **never recorded at all**, leaving no ledger trace when a run recovered from a halted state.
- Replaced the condition with `wasHalted !== verdict.shouldHalt`: a genuine transition detector, true exactly on the halt-trip and resume cases, false on both steady states.
- Does not touch `evaluateRunLoopHalt`'s own halt/no-halt determination logic, `newlyHalted`, the `releasedItem`/`markFailed` logic, or `buildRunLoopHaltGovernorLedgerEvent`'s signature/contents — only the `recorded` condition.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (Closes #9326).

## Validation

- [x] `git diff --check`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries
- [x] `npm run actionlint`
- [x] `npm --workspace @loopover/miner run build` (typecheck + `check-syntax.mjs`)
- [x] A scoped `tsc --noEmit` (root `tsconfig.json`'s full flag set) against both changed files — clean
- [x] `npx vitest run test/unit/miner-governor-run-halt.test.ts test/unit/miner-loop-cli.test.ts` — 53/53 passing. Covers: the steady never-halted case appends nothing (asserted directly against a spy, not just the returned field); the resume transition now records (verified by forcing the collaborator's verdict for one call, since `evaluateRunLoopHalt`'s own real implementation latches `shouldHalt:true` unconditionally once `runHalted:true` is passed in — a genuine resume only happens once an operator externally clears that latch outside this call, so this isolates `evaluateRunLoopBoundaryGate`'s own transition-detection logic from that collaborator's current coupling); the existing halt-trip and still-halted-latched cases continue passing unmodified; `loop-cli.ts` (the one real caller) still passes its full 46-test suite unmodified.
- [x] Scoped coverage on `packages/loopover-miner/lib/governor-run-halt.ts` — 100% statements/branches/functions/lines

If any required check was skipped, explain why:

- The whole-repo `npm run typecheck`/`npm run test:coverage` (unsharded) reliably OOM in this sandbox regardless of diff size — a known sandbox resource constraint, not a signal about this change. `packages/loopover-miner/**` is not included in `vitest.config.ts`'s `coverage.include` (confirmed empirically), so it is not Codecov-gated; the gate here is `npm run test:ci` staying green with real branch coverage, which the checks above satisfy directly.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

This is a backend-only fix (`packages/loopover-miner/lib/governor-run-halt.ts`, a ledger-recording condition) with no rendered UI delta — before and after are the same production capture at each required viewport. `apps/loopover-ui` is dark-mode-only, so only the Dark row per viewport applies.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Dark | [![Desktop · Dark before](https://raw.githubusercontent.com/galuis116/gittensory/screenshots/governor-run-halt-9326-desktop-dark.png)](https://raw.githubusercontent.com/galuis116/gittensory/screenshots/governor-run-halt-9326-desktop-dark.png) | [![Desktop · Dark after](https://raw.githubusercontent.com/galuis116/gittensory/screenshots/governor-run-halt-9326-desktop-dark.png)](https://raw.githubusercontent.com/galuis116/gittensory/screenshots/governor-run-halt-9326-desktop-dark.png) |
| Tablet · Dark | [![Tablet · Dark before](https://raw.githubusercontent.com/galuis116/gittensory/screenshots/governor-run-halt-9326-tablet-dark.png)](https://raw.githubusercontent.com/galuis116/gittensory/screenshots/governor-run-halt-9326-tablet-dark.png) | [![Tablet · Dark after](https://raw.githubusercontent.com/galuis116/gittensory/screenshots/governor-run-halt-9326-tablet-dark.png)](https://raw.githubusercontent.com/galuis116/gittensory/screenshots/governor-run-halt-9326-tablet-dark.png) |
| Mobile · Dark | [![Mobile · Dark before](https://raw.githubusercontent.com/galuis116/gittensory/screenshots/governor-run-halt-9326-mobile-dark.png)](https://raw.githubusercontent.com/galuis116/gittensory/screenshots/governor-run-halt-9326-mobile-dark.png) | [![Mobile · Dark after](https://raw.githubusercontent.com/galuis116/gittensory/screenshots/governor-run-halt-9326-mobile-dark.png)](https://raw.githubusercontent.com/galuis116/gittensory/screenshots/governor-run-halt-9326-mobile-dark.png) |
