### PR TITLE
test(integrations): cover whitespace rejection in parseRepoFullName

### DIFF
--- a/test/unit/project-tracker-adapter.test.ts
+++ b/test/unit/project-tracker-adapter.test.ts
@@ -73,6 +73,9 @@ describe("GitHubMilestonesAdapter (#3183)", () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem() });
     await expect(adapter.listOpenMilestones({ env, installationId: 123, repoFullName: "invalid" })).rejects.toThrow(/Invalid repository full name/);
     await expect(adapter.attachToMilestone({ env, installationId: 123, repoFullName: "owner/repo/extra" }, 4, "14")).rejects.toThrow(/Invalid repository full name/);
+    for (const padded of ["owner/ repo", "owner /repo"]) {
+      await expect(adapter.listOpenMilestones({ env, installationId: 123, repoFullName: padded })).rejects.toThrow(/Invalid repository full name/);
+    }
   });
 
   it("listOpenMilestones fetches and maps open milestones from the REST API", async () => {
@@ -331,6 +334,9 @@ describe("GitHubProjectsAdapter (#3184)", () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem() });
     await expect(adapter.listOpenProjects({ env, installationId: 123, repoFullName: "invalid" })).rejects.toThrow(/Invalid repository full name/);
     await expect(adapter.attachToProject({ env, installationId: 123, repoFullName: "owner/repo/extra" }, 4, "PVT_1")).rejects.toThrow(/Invalid repository full name/);
+    for (const padded of ["owner/ repo", "owner /repo"]) {
+      await expect(adapter.listOpenProjects({ env, installationId: 123, repoFullName: padded })).rejects.toThrow(/Invalid repository full name/);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
Closes #9318. The whitespace guard the issue describes (`/\s/.test(repoFullName)` in `parseRepoFullName`, `src/integrations/project-tracker-adapter.ts:43`) is already present in the code, but the adapter's regression tests never exercised a whitespace-containing repo name — only `"invalid"` and `"owner/repo/extra"` were covered. This PR closes that gap by adding whitespace-containing cases (`"owner/ repo"`, `"owner /repo"`) to the existing invalid-repo-name tests for both `GitHubMilestonesAdapter` and `GitHubProjectsAdapter`, mirroring the pattern already used in `test/unit/github-pr-actions.test.ts`.

## Scope
- [x] Test-only change, one file: `test/unit/project-tracker-adapter.test.ts`
- [x] No production code changed (guard already existed)
- [x] No generated artifacts invalidated (no API/schema/migration/wrangler changes)

## Validation
- [x] `npx vitest run test/unit/project-tracker-adapter.test.ts` — 54/54 passed
- [x] `npx turbo run build --filter=@loopover/engine` — passed
- [x] `npx turbo run build --filter=@loopover/mcp` — passed
- [x] `npx turbo run build:tsc build:verify --filter=@loopover/miner` — passed
- [ ] Full unsharded `npm run test:ci` — not completed locally before submission (test-only diff, no src/** changes, low risk)

## Safety
- [x] No secrets, tokens, wallets, hotkeys, or trust/reward values anywhere in the diff
- [x] No changes to `site/`, `CNAME`, or `**/lovable/**`
- [x] No changelog edit

## Notes
This is a test-coverage-only PR; `test/**` is excluded from Codecov's `codecov/patch` gate, so there is no coverage obligation beyond the added assertions passing.