### PR TITLE
fix(miner): surface verification payload in attempt-cli JSON for verification_failed

### DIFF
--- a/packages/loopover-miner/lib/attempt-cli.ts
+++ b/packages/loopover-miner/lib/attempt-cli.ts
@@ -117,6 +117,9 @@ export type AttemptCliResult =
       decision?: unknown;
       spec?: LocalWriteActionSpec;
       execResult?: unknown;
+      // #9328: surfaced from the AttemptResult "verification_failed" outcome (#8807's target-repo gate),
+      // mirroring the other optional sibling fields' conditional spread in finalResult below.
+      verification?: unknown;
       claimConflict?: ClaimConflictResult;
     });
 
@@ -1018,6 +1021,8 @@ export async function runAttempt(args: string[], options: RunAttemptOptions = {}
       ...("decision" in result ? { decision: result.decision } : {}),
       ...("spec" in result ? { spec: result.spec } : {}),
       ...("execResult" in result ? { execResult: result.execResult } : {}),
+      // #9328: the "verification_failed" outcome carries a `verification` payload the CLI JSON was dropping.
+      ...("verification" in result ? { verification: result.verification } : {}),
       // Present only on a real "submitted" outcome whose PR number was recoverable from execResult -- omitted
       // (not fabricated as "checked: false") on every other outcome, and on a submitted outcome where the new
       // PR's number genuinely couldn't be parsed (an honest gap, not silently swallowed).

--- a/test/unit/miner-attempt-cli.test.ts
+++ b/test/unit/miner-attempt-cli.test.ts
@@ -535,6 +535,35 @@ describe("runAttempt (#5132)", () => {
     });
   });
 
+  it("surfaces the verification payload in the CLI JSON for a verification_failed outcome (#9328)", async () => {
+    const { allocator, claimLedger, eventLedger, attemptLog, governorLedger } = tempLedgers();
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const verification = { ok: false, expectedRepo: "acme/widgets", observedRepo: "acme/other" };
+    const runMinerAttemptSpy = vi.fn().mockResolvedValue({
+      outcome: "verification_failed",
+      verification,
+      loopResult: fakeLoopResult(),
+    });
+
+    await runAttempt(["acme/widgets", "7", "--miner-login", "alice", "--json"], {
+      env: { MINER_CODING_AGENT_PROVIDER: "noop" },
+      attemptId: "fixed-attempt-id",
+      openWorktreeAllocator: () => allocator,
+      openClaimLedger: () => claimLedger,
+      initEventLedger: () => eventLedger,
+      initAttemptLog: () => attemptLog,
+      initGovernorLedger: () => governorLedger,
+      ...readyPipelineOptions({ runMinerAttempt: runMinerAttemptSpy }),
+    });
+
+    const printed = JSON.parse(
+      String(log.mock.calls.map((call) => call[0]).find((arg) => String(arg).includes("attempt_verification_failed"))),
+    );
+    expect(printed.outcome).toBe("attempt_verification_failed");
+    // The verification payload the "verification_failed" outcome carries is now present, not dropped.
+    expect(printed.verification).toEqual(verification);
+  });
+
   it("schedules an AMS attempt-started notification before the attempt runs, and no failure notification on submit (#7657)", async () => {
     const { allocator, claimLedger, eventLedger, attemptLog, governorLedger } = tempLedgers();
     vi.spyOn(console, "log").mockImplementation(() => undefined);


### PR DESCRIPTION
## What

`attempt-runner.ts`'s `AttemptResult` union includes a `verification_failed` outcome (added by #8807's
target-repo verification gate):

```ts
| { outcome: "verification_failed"; verification: unknown; loopResult: IterateLoopResult }
```

But `attempt-cli.ts`'s `runAttempt` built its `finalResult` by conditionally spreading the sibling
optional fields — `reason`, `decision`, `spec`, `execResult` — via
`...("field" in result ? { field: result.field } : {})`, with **no** equivalent for `verification`.
So on a `verification_failed` outcome the CLI's `--json` output (and `options.onResult` payload) silently
dropped the verification detail.

## Change

- `finalResult` now spreads `verification` with the same conditional-spread pattern already used for its
  siblings: `...("verification" in result ? { verification: result.verification } : {})`.
- `AttemptCliResult`'s `attempt_${RunMinerAttemptResult["outcome"]}` union member gains an optional
  `verification?: unknown` field, matching the shape of the other optional fields already there
  (`execResult?: unknown`).

`attempt-runner.ts`'s `AttemptResult`/`verification_failed` outcome is untouched — this only changes
`attempt-cli.ts`'s consumption of it. No other outcome's fields change.

## Validation

- New test in `test/unit/miner-attempt-cli.test.ts`: with `runMinerAttempt` mocked to return a
  `verification_failed` outcome carrying a `verification` payload, `runAttempt`'s `--json` output has
  `outcome: "attempt_verification_failed"` and the exact `verification` object — dropped before this fix.
- `npx vitest run test/unit/miner-attempt-cli.test.ts -t "verification payload"` passes. Both branches of
  the new conditional spread are covered (this test drives the present side; the existing
  submitted/abandon/handoff outcome tests drive the absent side). Every changed line is line+branch covered.

(Three unrelated tests in this file — `#5185 broken appendAttemptLogEvent`, `unexpected allocator
failure`, `#8808 null resolution` — fail identically on clean `main` on this Windows dev box, i.e.
pre-existing platform-baseline failures, not touched by this change.)

Closes #9328
