### PR TITLE
fix(rules): recognize .mts/.cts/.mjs/.cjs/.kts/.scala/.groovy in isCodePath

### DIFF
--- a/src/rules/advisory.ts
+++ b/src/rules/advisory.ts
@@ -551,7 +551,10 @@ function effectiveDisplaySeverity(finding: AdvisoryFinding, blockerCodes: Readon
 }
 
 function isCodePath(path: string): boolean {
-  return /\.(ts|tsx|js|jsx|py|go|rs|java|rb|php|cs|cpp|cc|c|h|hpp|swift|kt|m|sql|yaml|yml|json|toml|md|vue|svelte|astro|dart)$/i.test(path);
+  // #9322: keep in parity with SOURCE_FILE_EXTENSION/isCodeFile — the module-variant (.mts/.cts/.mjs/.cjs) and
+  // JVM (.kts/.scala/.groovy) extensions were missing, so a PR touching only those files was wrongly treated as
+  // non-code by the annotation gate. Purely additive.
+  return /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|go|rs|java|kt|kts|scala|groovy|rb|php|cs|cpp|cc|c|h|hpp|swift|m|sql|yaml|yml|json|toml|md|vue|svelte|astro|dart)$/i.test(path);
 }
 
 function collisionClustersForPull(collisions: CollisionReport, pullNumber: number): CollisionCluster[] {

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -1617,6 +1617,33 @@ describe("advisory rules", () => {
     }
   });
 
+  it("flags Missing test evidence for module-variant/JVM source via isCodePath + isCodeFile parity (#9322)", () => {
+    // Regression: isCodeFile/SOURCE_FILE_EXTENSION already admitted .mts/.cts/.mjs/.cjs and .kts/.scala/.groovy,
+    // but advisory.ts isCodePath lagged, so buildCheckRunAnnotations filtered those files out of annotatableFiles
+    // before missing_tests ran — a PR touching only those extensions was wrongly treated as non-code.
+    const advisory = buildPullRequestAdvisory(repo, {
+      repoFullName: repo.fullName, number: 26, title: "Add ESM/JVM source without tests", state: "open",
+      authorLogin: "contributor", authorAssociation: "NONE", labels: [], linkedIssues: [],
+    });
+    const sourcePaths = [
+      "src/loader.mts", "src/loader.cts", "src/loader.mjs", "src/loader.cjs",
+      "build.kts", "src/main/Widget.scala", "src/main/Task.groovy",
+    ];
+    const files: PullRequestFileRecord[] = sourcePaths.map((path) => ({
+      repoFullName: repo.fullName, pullNumber: 26, path, additions: 11, deletions: 0, changes: 11, payload: {},
+    }));
+    const collisions: CollisionReport = {
+      repoFullName: repo.fullName, generatedAt: "2026-06-10T00:00:00.000Z",
+      summary: { clusterCount: 0, highRiskCount: 0, itemsReviewed: 0 }, clusters: [],
+    };
+
+    const { annotations } = buildCheckRunAnnotations(advisory, { files, collisions, pullNumber: 26 }, "standard");
+
+    for (const path of sourcePaths) {
+      expect(annotations.some((entry) => entry.title === "Missing test evidence" && entry.path === path)).toBe(true);
+    }
+  });
+
   it("flags Missing test evidence for Dart source via isCodePath + isCodeFile parity", () => {
     const advisory = buildPullRequestAdvisory(repo, {
       repoFullName: repo.fullName, number: 25, title: "Add Dart widget without tests", state: "open",


### PR DESCRIPTION
## What

`isCodePath` in `src/rules/advisory.ts` — the extension gate `annotatablePullRequestFiles` uses to
decide which changed files `buildCheckRunAnnotations` may annotate — recognized `.ts/.tsx/.js/.jsx`,
`.kt`, `.java`, etc., but was missing the module-variant extensions `.mts/.cts/.mjs/.cjs` and the JVM
extensions `.kts/.scala/.groovy`.

`isCodeFile`/`SOURCE_FILE_EXTENSION` (`packages/loopover-engine/src/signals/test-evidence.ts:23`)
already admit all seven. Because `annotatablePullRequestFiles` gates on `isCodePath` **before** the
`isCodeFile` missing-test filter runs, a PR touching only those extensions was dropped from
`annotatableFiles` and never received the `Missing test evidence` annotation the parity contract
intends.

## Change

Add `mts`, `cts`, `mjs`, `cjs`, `kts`, `scala`, `groovy` to the `isCodePath` regex — purely additive.
No existing extension is removed or narrowed; the signature, callers, and the rest of
`buildCheckRunAnnotations`'s behavior are unchanged.

## Validation

- New test in `test/unit/rules.test.ts` (mirrors the existing Vue/Svelte/Astro and C++ parity tests):
  a source file at each of `.mts/.cts/.mjs/.cjs/.kts/.scala/.groovy`, shipped without a test, is now
  flagged `Missing test evidence` — proving `isCodePath` admits it. All four `isCodePath` parity tests
  pass.
- `npx vitest run test/unit/rules.test.ts` green; the changed line is a single regex literal executed
  by the passing tests.

Closes #9322
