### PR TITLE
fix(miner): add blocked_own_open_pr to AttemptCliResult union

### DIFF
--- a/packages/loopover-miner/lib/attempt-cli.ts
+++ b/packages/loopover-miner/lib/attempt-cli.ts
@@ -107,6 +107,11 @@ export type AttemptCliResult =
       raiseReasons: string[];
     })
   | (CommonAttemptResultFields & {
+      outcome: "blocked_own_open_pr";
+      reason: string;
+      existingPullRequestNumber: number;
+    })
+  | (CommonAttemptResultFields & {
       outcome: `attempt_${RunMinerAttemptResult["outcome"]}`;
       submissionMode: "observe" | "enforce";
       totalTurnsUsed: number;


### PR DESCRIPTION
Closes #9331

## What

`blocked_own_open_pr` is a real runtime outcome — built as `duplicateResult` and cast `as AttemptCliResult` at `runAttempt`'s own-open-PR guard (added by #8808) — but it was never added to the exported `AttemptCliResult` union. `loop-cli.ts` re-exposes `AttemptCliResult["outcome"]`, so this is genuine `.d.ts` drift, exactly the kind `blocked_max_concurrent_claims` already flags inline.

This adds the missing union member, matching the exact shape of `duplicateResult` at its construction site:

```ts
| (CommonAttemptResultFields & {
    outcome: "blocked_own_open_pr";
    reason: string;
    existingPullRequestNumber: number;
  })
```

(`repoFullName`/`issueNumber`/`minerLogin`/`base`/`mode`/`attemptId` come from `CommonAttemptResultFields`.)

## Cast handling (Deliverable 2)

The `as AttemptCliResult` cast at the `options.onResult?.(...)` call site **remains**. I verified via `tsc --noEmit` that removing it produces `TS2345` — `const duplicateResult = { outcome: "blocked_own_open_pr", ... }` widens `outcome` to `string`, so the literal-discriminated union rejects it without a narrowing change, which is out of scope. This matches the sibling `blocked_max_concurrent_claims`, which keeps its cast for the same reason.

## Tests

No test changes: this is a type-definition-only change with no new runtime branch or behavior, so there is nothing new to exercise. Verified with the repo's type-check (`tsc --noEmit`), which passes; the diff is scoped to `attempt-cli.ts`'s type union only.