### PR TITLE
fix(miner): add blocked_own_open_pr to the AttemptCliResult union (#9331)

### DIFF
--- a/packages/loopover-miner/lib/attempt-cli.ts
+++ b/packages/loopover-miner/lib/attempt-cli.ts
@@ -98,6 +98,7 @@ type CommonAttemptResultFields = {
 export type AttemptCliResult =
   | (CommonAttemptResultFields & { outcome: "dry_run" })
   | (CommonAttemptResultFields & { outcome: "blocked_rejection_signaled"; reason: string })
+  | (CommonAttemptResultFields & { outcome: "blocked_own_open_pr"; reason: string; existingPullRequestNumber: number })
   | (CommonAttemptResultFields & { outcome: "blocked_worktree_preparation_failed"; reason: string })
   | (CommonAttemptResultFields & {
       outcome: "blocked_infeasible";


### PR DESCRIPTION
## Problem

Closes #9331.

`runAttempt` in `packages/loopover-miner/lib/attempt-cli.ts` builds a `blocked_own_open_pr` result object (the #8808 crash-retry idempotency guard, ~line 511) and casts it to `AttemptCliResult`, but the exported `AttemptCliResult` union had **no `blocked_own_open_pr` member**. Since `loop-cli.ts` re-exposes `AttemptCliResult["outcome"]` in its own type, this is real `.d.ts` drift — the type omits a genuine runtime outcome.

## Fix

Add a `blocked_own_open_pr` member to the union with the exact field shape of the real `duplicateResult` object: `CommonAttemptResultFields` (which already covers `repoFullName`, `issueNumber`, `minerLogin`, `base`, `mode`, `attemptId`) plus the two outcome-specific fields `reason: string` and `existingPullRequestNumber: number`.

### On the cast (deliverable 2)

The `as AttemptCliResult` cast at the call site is **kept**, verified via `tsc`: removing it fails because the `const duplicateResult = { outcome: "blocked_own_open_pr", … }` object literal widens `outcome` to `string`, which is not assignable to the union's string-literal member. This is the identical, uniform pattern at **every** sibling result site — including in-union outcomes like `dry_run`, whose object is also cast for the same widening reason. So the cast is not redundant, and per deliverable 2's condition it stays.

Type-definition-only change; no runtime logic touched, no other files. Per the issue, no new test is required (no new runtime branch).