### PR TITLE
fix(miner): add blocked_own_open_pr to the AttemptCliResult union (#9331)

### DIFF
--- a/packages/loopover-miner/lib/attempt-cli.ts
+++ b/packages/loopover-miner/lib/attempt-cli.ts
@@ -98,6 +98,7 @@ type CommonAttemptResultFields = {
 export type AttemptCliResult =
   | (CommonAttemptResultFields & { outcome: "dry_run" })
   | (CommonAttemptResultFields & { outcome: "blocked_rejection_signaled"; reason: string })
+  | (CommonAttemptResultFields & { outcome: "blocked_own_open_pr"; reason: string; existingPullRequestNumber: number })
   | (CommonAttemptResultFields & { outcome: "blocked_worktree_preparation_failed"; reason: string })
   | (CommonAttemptResultFields & {
       outcome: "blocked_infeasible";

--- a/test/unit/miner-attempt-cli.test.ts
+++ b/test/unit/miner-attempt-cli.test.ts
@@ -16,7 +16,7 @@ import { closeDefaultWorktreeAllocator, openWorktreeAllocator } from "../../pack
 import { closeDefaultPortfolioQueueStore } from "../../packages/loopover-miner/lib/portfolio-queue";
 import { closeDefaultGovernorState } from "../../packages/loopover-miner/lib/governor-state";
 import { buildAttemptDeps, parseAttemptArgs, runAttempt, resolveAttemptHouseRulesConfig } from "../../packages/loopover-miner/lib/attempt-cli";
-import type { RunAttemptOptions } from "../../packages/loopover-miner/lib/attempt-cli";
+import type { AttemptCliResult, RunAttemptOptions } from "../../packages/loopover-miner/lib/attempt-cli";
 import type { RuleFiredEvent, SignalStore } from "../../packages/loopover-engine/src/calibration/signal-tracking";
 import * as minerSentryModule from "../../packages/loopover-miner/lib/sentry";
 import * as liveIssueSnapshotModule from "../../packages/loopover-miner/lib/live-issue-snapshot";
@@ -141,6 +141,29 @@ afterEach(() => {
   vi.unstubAllEnvs();
   vi.restoreAllMocks();
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("AttemptCliResult union (#9331)", () => {
+  it("includes the blocked_own_open_pr outcome with the runtime duplicateResult shape", () => {
+    // Compile-time guard: this object is the exact shape runAttempt builds for a crash-retry duplicate
+    // (#8808). Before the union member was added it only type-checked behind an `as` cast; removing the
+    // member makes this assignment a type error, so the .d.ts drift can't silently return.
+    const result: AttemptCliResult = {
+      outcome: "blocked_own_open_pr",
+      reason: "this miner already has an open PR for this issue",
+      repoFullName: "acme/widgets",
+      issueNumber: 7,
+      existingPullRequestNumber: 42,
+      minerLogin: "miner",
+      base: "main",
+      mode: "live",
+      attemptId: "attempt-1",
+    };
+    expect(result.outcome).toBe("blocked_own_open_pr");
+    if (result.outcome === "blocked_own_open_pr") {
+      expect(result.existingPullRequestNumber).toBe(42);
+    }
+  });
 });
 
 describe("parseAttemptArgs (#5132)", () => {


### PR DESCRIPTION
## Problem

Closes #9331.

`runAttempt` in `packages/loopover-miner/lib/attempt-cli.ts` builds a `blocked_own_open_pr` result object (the #8808 crash-retry idempotency guard) and casts it to `AttemptCliResult`, but the exported `AttemptCliResult` union had **no `blocked_own_open_pr` member**. Since `loop-cli.ts` re-exposes `AttemptCliResult["outcome"]`, this is real `.d.ts` drift.

## Fix

Add a `blocked_own_open_pr` member with the exact field shape of the real `duplicateResult` object: `CommonAttemptResultFields` (already covering `repoFullName`, `issueNumber`, `minerLogin`, `base`, `mode`, `attemptId`) plus `reason: string` and `existingPullRequestNumber: number`.

The `as AttemptCliResult` cast at the call site is kept — verified via `tsc`: the `const duplicateResult = { outcome: "blocked_own_open_pr", … }` object literal widens `outcome` to `string`, which is not assignable without the cast. This is the uniform pattern at every sibling result site, including in-union outcomes like `dry_run`.

## Test

Adds a compile-time guard in `test/unit/miner-attempt-cli.test.ts`: an `AttemptCliResult` value with the exact `blocked_own_open_pr` shape is assignable **without** a cast, so removing the union member makes it a type error and the drift can't silently return.