### PR TITLE
fix(rules): align isCodePath with isCodeFile module/JVM extensions

### DIFF
--- a/src/rules/advisory.ts
+++ b/src/rules/advisory.ts
@@ -551,7 +551,8 @@ function effectiveDisplaySeverity(finding: AdvisoryFinding, blockerCodes: Readon
 }
 
 function isCodePath(path: string): boolean {
-  return /\.(ts|tsx|js|jsx|py|go|rs|java|rb|php|cs|cpp|cc|c|h|hpp|swift|kt|m|sql|yaml|yml|json|toml|md|vue|svelte|astro|dart)$/i.test(path);
+  // Keep parity with isCodeFile / SOURCE_FILE_EXTENSION (#9322): include .mts/.cts/.mjs/.cjs/.kts/.scala/.groovy.
+  return /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|go|rs|java|rb|php|cs|cpp|cc|c|h|hpp|swift|kt|kts|scala|groovy|m|sql|yaml|yml|json|toml|md|vue|svelte|astro|dart)$/i.test(path);
 }
 
 function collisionClustersForPull(collisions: CollisionReport, pullNumber: number): CollisionCluster[] {

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -1638,6 +1638,37 @@ describe("advisory rules", () => {
     }
   });
 
+  it("flags Missing test evidence for .mts/.cts/.mjs/.cjs/.kts/.scala/.groovy via isCodePath + isCodeFile parity (#9322)", () => {
+    // Regression: isCodeFile recognizes these via SOURCE_FILE_EXTENSION, but isCodePath lagged — so
+    // annotatablePullRequestFiles dropped them before Missing test evidence annotations could land.
+    const advisory = buildPullRequestAdvisory(repo, {
+      repoFullName: repo.fullName, number: 26, title: "Add module/JVM sources without tests", state: "open",
+      authorLogin: "contributor", authorAssociation: "NONE", labels: [], linkedIssues: [],
+    });
+    const sourcePaths = [
+      "src/loader.mts",
+      "src/setup.cts",
+      "src/legacy.mjs",
+      "src/compat.cjs",
+      "build.kts",
+      "src/Main.scala",
+      "src/App.groovy",
+    ];
+    const files: PullRequestFileRecord[] = sourcePaths.map((path) => ({
+      repoFullName: repo.fullName, pullNumber: 26, path, additions: 10, deletions: 0, changes: 10, payload: {},
+    }));
+    const collisions: CollisionReport = {
+      repoFullName: repo.fullName, generatedAt: "2026-06-10T00:00:00.000Z",
+      summary: { clusterCount: 0, highRiskCount: 0, itemsReviewed: 0 }, clusters: [],
+    };
+
+    const { annotations } = buildCheckRunAnnotations(advisory, { files, collisions, pullNumber: 26 }, "standard");
+
+    for (const path of sourcePaths) {
+      expect(annotations.some((entry) => entry.title === "Missing test evidence" && entry.path === path)).toBe(true);
+    }
+  });
+
   it("buildCheckRunAnnotations uses notice level for medium-risk collisions and critical public finding text", () => {
     const advisory = {
       ...buildPullRequestAdvisory(repo, null),


### PR DESCRIPTION
## Summary

`isCodePath` in `src/rules/advisory.ts` lagged `SOURCE_FILE_EXTENSION` / `isCodeFile` for seven extensions (`.mts`, `.cts`, `.mjs`, `.cjs`, `.kts`, `.scala`, `.groovy`). `annotatablePullRequestFiles` gates on `isCodePath` before Missing test evidence annotations can land, so PRs whose only changed files use those extensions got zero inline annotations — the fourth instance of this same parity-drift class (Vue/Svelte/Astro, C++/hpp, Dart already fixed).

Adds the seven extensions to `isCodePath` (additive only) and a regression covering each path via `buildCheckRunAnnotations`.

## Test plan

- [x] `test/unit/rules.test.ts`: new `#9322` parity test asserts Missing test evidence annotations for all seven extensions
- [x] Adjacent Vue/Svelte/Astro + Dart parity tests still pass
- [x] Targeted vitest run green

Closes #9322