### PR TITLE
fix(engine): progressChanged must diff maxIterations and percentComplete too

### DIFF
--- a/packages/loopover-engine/src/loop-progress.ts
+++ b/packages/loopover-engine/src/loop-progress.ts
@@ -85,6 +85,11 @@ export function progressChanged(prev: ProgressSnapshot | null, next: ProgressSna
     prev.phase !== next.phase ||
     prev.status !== next.status ||
     prev.iteration !== next.iteration ||
+    // #9323: maxIterations and percentComplete are displayed axes too -- raising the iteration budget mid-run
+    // changes percentComplete (and maxIterations) while phase/status/iteration/activity stay the same, so
+    // without these the customer-facing progress bar goes stale on a real, displayed change.
+    prev.maxIterations !== next.maxIterations ||
+    prev.percentComplete !== next.percentComplete ||
     activityChanged(prev.recentActivity, next.recentActivity)
   );
 }

--- a/test/unit/loop-progress.test.ts
+++ b/test/unit/loop-progress.test.ts
@@ -113,3 +113,23 @@ describe("progressChanged — push on change, not on a fixed interval (#4800)", 
     });
   });
 });
+
+describe("progressChanged — maxIterations / percentComplete displayed axes (#9323)", () => {
+  it("pushes when maxIterations changes even though iteration/phase/status/activity are identical", () => {
+    // Raising the iteration budget mid-run: iteration stays 2, maxIterations 5 -> 10 (percentComplete 40 -> 20).
+    const prev = buildProgressSnapshot(running({ iteration: 2, maxIterations: 5 }));
+    const next = buildProgressSnapshot(running({ iteration: 2, maxIterations: 10 }));
+    expect(progressChanged(prev, next)).toBe(true);
+  });
+
+  it("pushes when only percentComplete differs, with every other displayed axis identical", () => {
+    // progressChanged compares the displayed field, not a recomputation — a percentComplete-only delta pushes.
+    const base = buildProgressSnapshot(running());
+    expect(progressChanged(base, { ...base, percentComplete: (base.percentComplete ?? 0) + 10 })).toBe(true);
+  });
+
+  it("does not push when maxIterations and percentComplete are both unchanged", () => {
+    const base = buildProgressSnapshot(running());
+    expect(progressChanged(base, { ...base })).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #9323

## What

`progressChanged` decides when a loop-progress snapshot has changed enough to push to the customer surface (the ON-CHANGE stream, #4800). It compared `phase`, `status`, `iteration`, and the activity tail — but **not** `maxIterations` or `percentComplete`, both of which are displayed axes of the same snapshot. So a snapshot where only the iteration *budget* changed (e.g. `maxIterations` revised mid-run, moving `percentComplete`) would not push, and the customer's progress bar would silently stall.

Fix adds both fields to the OR-chain:

```ts
prev.iteration !== next.iteration ||
prev.maxIterations !== next.maxIterations ||
prev.percentComplete !== next.percentComplete ||
activityChanged(prev.recentActivity, next.recentActivity)
```

## Tests

3 new cases in `test/unit/loop-progress.test.ts` (100% branch on the changed predicate): a `maxIterations`-only change pushes; a `percentComplete`-only change pushes; both-unchanged does not push. Full file: 16 passed. The test imports from `packages/loopover-engine/src/loop-progress` so coverage attributes to the source.