### PR TITLE
queue: generate-tests checkbox and text-command both missing the pr.state !== "open" guard #9020 added to their retrigger sibling

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -13478,6 +13478,12 @@ async function maybeProcessGenerateTestsCommand(env: Env, deliveryId: string, pa
     await recordGenerateTestsSkip(env, deliveryId, req.repoFullName, targetKey, req.actor, "cached_pr_missing");
     return true;
   }
+  // #9020 / #9311: mirrors maybeProcessPrPanelRetrigger's and maybeProcessPrPanelGenerateTests's identical guard --
+  // the text-command twin must not spend AI generation or attempt a commit on a closed/merged PR.
+  if (pr.state !== "open") {
+    await recordGenerateTestsSkip(env, deliveryId, req.repoFullName, targetKey, req.actor, "pr_not_open");
+    return true;
+  }
   const { authorization } = await authorizePrActionActor({ env, deliveryId, installationId: req.installationId, repoFullName: req.repoFullName, issue: payload.issue!, actor: req.actor, commandName: "generate-tests" as LoopOverMentionCommandName, settings, pr, needsMinerDetection: true });
   if (!authorization.authorized) {
     await recordAuditEvent(env, { eventType: "github_app.e2e_tests_generation_denied", actor: req.actor, targetKey, outcome: "denied", detail: authorization.reason, metadata: { deliveryId, repoFullName: req.repoFullName, allowedRoles: commandAuthorizationAllowedRoles(settings.commandAuthorization, "generate-tests") } });
@@ -14206,6 +14212,15 @@ async function maybeProcessPrPanelGenerateTests(
   ]);
   if (!pr) {
     await recordGenerateTestsSkip(env, deliveryId, repoFullName, targetKey, actor, "cached_pr_missing");
+    return true;
+  }
+  // #9020 / #9311: the panel comment is deliberately preserved after merge/close (#preserve-review-on-close) and its
+  // generate-tests checkbox stays interactive on GitHub forever, but every downstream step below assumes an OPEN PR --
+  // without this guard a post-merge click spends a real AI test-generation call (and in commit delivery mode can push
+  // onto an already-merged branch) before dying with no user-visible feedback. Mirrors
+  // maybeProcessPrPanelRetrigger's identical `pr.state !== "open"` guard (the sibling entry point).
+  if (pr.state !== "open") {
+    await recordGenerateTestsSkip(env, deliveryId, repoFullName, targetKey, actor, "pr_not_open");
     return true;
   }
 

--- a/test/unit/queue-5.test.ts
+++ b/test/unit/queue-5.test.ts
@@ -4288,14 +4288,24 @@ describe("queue processors", () => {
       prNumber: number,
       headSha: string,
       authorLogin = "contributor",
-      opts: { headRef?: string; e2eTestDelivery?: "comment" | "commit" } = {},
+      opts: { headRef?: string; e2eTestDelivery?: "comment" | "commit"; state?: "open" | "closed" } = {},
     ) {
       const slash = repoFullName.indexOf("/");
       const owner = repoFullName.slice(0, slash);
       const name = repoFullName.slice(slash + 1);
       await upsertRepositoryFromGitHub(env, { name, full_name: repoFullName, private: false, owner: { login: owner } }, 123);
       await upsertRepositorySettings(env, { repoFullName, autoLabelEnabled: false, requireLinkedIssue: false });
-      await upsertPullRequestFromGitHub(env, repoFullName, { number: prNumber, title: "Add retry to checkout", state: "open", user: { login: authorLogin }, author_association: "CONTRIBUTOR", head: { sha: headSha, ref: opts.headRef ?? "feature/checkout-retry" }, labels: [], body: "Retries the payment call once on a 5xx." });
+      await upsertPullRequestFromGitHub(env, repoFullName, {
+        number: prNumber,
+        title: "Add retry to checkout",
+        state: opts.state ?? "open",
+        ...(opts.state === "closed" ? { merged_at: "2026-07-26T00:00:00.000Z" } : {}),
+        user: { login: authorLogin },
+        author_association: "CONTRIBUTOR",
+        head: { sha: headSha, ref: opts.headRef ?? "feature/checkout-retry" },
+        labels: [],
+        body: "Retries the payment call once on a 5xx.",
+      });
       await upsertPullRequestFile(env, { repoFullName, pullNumber: prNumber, path: "src/checkout.ts", status: "modified", additions: 3, deletions: 0, changes: 3, payload: { patch: "+function retryPayment() {\n+  return true;\n+}" } });
       // A renamed-with-no-patch file (GitHub omits `patch` for pure renames) -- exercises the
       // payload?.patch-is-not-a-string branch in the files.map() that builds E2eTestGenChangedFile[].
@@ -4574,6 +4584,39 @@ describe("queue processors", () => {
 
       const skipped = await env.DB.prepare("select detail from audit_events where event_type = ?").bind("github_app.e2e_tests_generation_skipped").first<{ detail: string }>();
       expect(skipped?.detail).toBe("cached_pr_missing");
+    });
+
+    // #9020 / #9311: mirrors the panel checkbox guard -- @loopover generate-tests on a closed/merged PR
+    // must short-circuit before authorization or AI generation.
+    it("skips immediately with pr_not_open when invoked on an already-merged PR, never calling AI", async () => {
+      const repoFullName = "JSONbored/gen-tests-9311-merged";
+      const run = vi.fn();
+      const env = createTestEnv({
+        GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(),
+        AI: { run } as unknown as Ai,
+        LOOPOVER_REVIEW_E2E_TESTS: "true",
+        AI_SUMMARIES_ENABLED: "true",
+        AI_PUBLIC_COMMENTS_ENABLED: "true",
+      });
+      await seedGenerateTestsPr(env, repoFullName, 9311, "gen-tests-9311-merged", "contributor", { state: "closed" });
+      let fetchCalls = 0;
+      vi.stubGlobal("fetch", async () => {
+        fetchCalls += 1;
+        return new Response("unexpected fetch", { status: 500 });
+      });
+
+      await processJob(env, generateTestsWebhook(repoFullName, 9311, "maintainer", { association: "MEMBER" }));
+
+      expect(fetchCalls).toBe(0);
+      expect(run).not.toHaveBeenCalled();
+      const skipped = await env.DB.prepare("select actor, target_key, detail from audit_events where event_type = ?")
+        .bind("github_app.e2e_tests_generation_skipped")
+        .first<{ actor: string | null; target_key: string; detail: string }>();
+      expect(skipped).toMatchObject({ actor: "maintainer", target_key: "JSONbored/gen-tests-9311-merged#9311", detail: "pr_not_open" });
+      const generated = await env.DB.prepare("select count(*) as n from audit_events where event_type = ?")
+        .bind("github_app.e2e_tests_generation")
+        .first<{ n: number }>();
+      expect(generated?.n).toBe(0);
     });
 
     it("declines (returns false) for a non-command comment, claiming nothing", async () => {
@@ -5399,7 +5442,7 @@ describe("queue processors", () => {
       repoFullName: string,
       prNumber: number,
       headSha: string,
-      opts: { e2eTests?: boolean } = {},
+      opts: { e2eTests?: boolean; state?: "open" | "closed" } = {},
     ) {
       const slash = repoFullName.indexOf("/");
       const owner = repoFullName.slice(0, slash);
@@ -5414,7 +5457,8 @@ describe("queue processors", () => {
       await upsertPullRequestFromGitHub(env, repoFullName, {
         number: prNumber,
         title: "Add retry to checkout",
-        state: "open",
+        state: opts.state ?? "open",
+        ...(opts.state === "closed" ? { merged_at: "2026-07-26T00:00:00.000Z" } : {}),
         user: { login: "contributor" },
         author_association: "CONTRIBUTOR",
         head: { sha: headSha, ref: "feature/checkout-retry" },
@@ -5709,6 +5753,40 @@ describe("queue processors", () => {
         .bind("github_app.e2e_tests_generation_skipped")
         .first<{ detail: string }>();
       expect(skipped?.detail).toBe("cached_pr_missing");
+    });
+
+    // #9020 / #9311: the panel comment is deliberately preserved after merge/close and its generate-tests
+    // checkbox stays interactive on a closed/merged PR forever. Without the guard, a post-merge click would
+    // spend a real AI generation call (and in commit mode could push onto the merged branch).
+    it("skips immediately with pr_not_open when a maintainer checks the box on an already-merged PR, never calling AI", async () => {
+      const repoFullName = "JSONbored/checkbox-4589-merged";
+      const run = vi.fn();
+      const env = createTestEnv({
+        GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(),
+        AI: { run } as unknown as Ai,
+        LOOPOVER_REVIEW_E2E_TESTS: "true",
+        AI_SUMMARIES_ENABLED: "true",
+        AI_PUBLIC_COMMENTS_ENABLED: "true",
+      });
+      await seedCheckboxPr(env, repoFullName, 6015, "checkbox-4589-merged-sha", { state: "closed" });
+      let fetchCalls = 0;
+      vi.stubGlobal("fetch", async () => {
+        fetchCalls += 1;
+        return new Response("unexpected fetch", { status: 500 });
+      });
+
+      await processJob(env, checkboxWebhook(repoFullName, 6015, 913, { login: "maintainer" }));
+
+      expect(fetchCalls).toBe(0);
+      expect(run).not.toHaveBeenCalled();
+      const skipped = await env.DB.prepare("select actor, target_key, detail from audit_events where event_type = ?")
+        .bind("github_app.e2e_tests_generation_skipped")
+        .first<{ actor: string | null; target_key: string; detail: string }>();
+      expect(skipped).toMatchObject({ actor: "maintainer", target_key: "JSONbored/checkbox-4589-merged#6015", detail: "pr_not_open" });
+      const generated = await env.DB.prepare("select count(*) as n from audit_events where event_type = ?")
+        .bind("github_app.e2e_tests_generation")
+        .first<{ n: number }>();
+      expect(generated?.n).toBe(0);
     });
 
     it("respects agentPaused — records a skip and never spends an LLM call, even though an authorized maintainer checked the box", async () => {


### PR DESCRIPTION
## Summary

`maybeProcessPrPanelRetrigger` in `src/queue/processors.ts` (~line 14016) has an explicit
`pr.state !== "open"` guard, added for **#9020** ("panel re-run checkbox on a closed/merged PR
does real work, then silently no-ops"). Its doc comment explains why: the PR-panel comment is
deliberately preserved after merge/close, its checkboxes stay interactive on GitHub forever, and
without the guard a post-merge click would spend a real gate evaluation and live CI reads before
dying deep in the pipeline with no user-visible feedback.

Two structurally identical handlers never got the same guard:

1. **`maybeProcessPrPanelGenerateTests`** (~line 14175, the checkbox handler, `#4589`) — goes
   straight from authorization → feature-flag check → mode check → `runE2eTestGenerationAndDeliver`,
   with no PR-state check anywhere in the function. On a merged/closed PR whose checkbox is still
   checkable, this spends a real AI test-generation call, and in `commit` delivery mode calls
   `commitE2eTestToPrBranch` (`src/github/e2e-test-commit.ts:43`), which only declines if the live
   head SHA/ref no longer matches the cached PR — it does **not** check PR state, so it can
   silently push a new commit onto an already-merged branch.
2. **`maybeProcessGenerateTestsCommand`** (~line 13466, the `@loopover generate-tests` text-command
   twin) has the identical gap: no `pr.state !== "open"` check before authorization/generation.

`test/unit/queue-5.test.ts`'s `"PR-panel generate-tests checkbox (#4589)"` block
(`seedCheckboxPr`) hardcodes `state: "open"` in every case — no test exercises a closed/merged PR
for either handler.

## Deliverables

- [x] `maybeProcessPrPanelGenerateTests` in `src/queue/processors.ts` gains the
      `pr.state !== "open"` guard with a `"pr_not_open"` skip outcome, mirroring
      `maybeProcessPrPanelRetrigger`'s #9020 fix exactly.
- [x] `maybeProcessGenerateTestsCommand` in `src/queue/processors.ts` gains the identical guard.
- [x] `test/unit/queue-5.test.ts`'s generate-tests checkbox suite gains a case with a closed/merged
      PR asserting the handler skips with `"pr_not_open"` and never calls the AI generation path.
- [x] The equivalent text-command test suite for `maybeProcessGenerateTestsCommand` gains the same
      closed/merged-PR skip assertion.

All four deliverables are required in this single PR.

## Test plan

This repo enforces 99%+ Codecov patch coverage, branch-counted, on every changed line/branch in
`src/**`. Both new guards and their two new test cases above must be covered.

Fixes #9311