### PR TITLE
fix(engine): detect maxIterations/percentComplete changes in progressChanged (#9323)

### DIFF
--- a/packages/loopover-engine/src/loop-progress.ts
+++ b/packages/loopover-engine/src/loop-progress.ts
@@ -78,13 +78,21 @@ function activityChanged(prev: readonly LoopProgressActivity[], next: readonly L
 
 /** True when `next` differs from `prev` in a way worth pushing to the customer — so the surface streams
  *  ON CHANGE instead of polling on a fixed interval (#4800's acceptance). A null `prev` (the first snapshot)
- *  always pushes. Compares the displayed axes: phase, status, iteration, and the activity tail's contents. */
+ *  always pushes. Compares every displayed axis: phase, status, iteration, the iteration budget and the
+ *  percent through it (maxIterations/percentComplete), and the activity tail's contents.
+ *
+ *  maxIterations/percentComplete are displayed too but were originally left out of the diff (#9323): raising
+ *  the iteration budget mid-run (#6773's percentComplete is `iteration / maxIterations`) moves the customer's
+ *  percent while phase/status/iteration/activity all hold, so a budget-only change silently went unpushed and
+ *  the progress bar went stale. Both are compared so any change to a shown number streams. */
 export function progressChanged(prev: ProgressSnapshot | null, next: ProgressSnapshot): boolean {
   if (prev === null) return true;
   return (
     prev.phase !== next.phase ||
     prev.status !== next.status ||
     prev.iteration !== next.iteration ||
+    prev.maxIterations !== next.maxIterations ||
+    prev.percentComplete !== next.percentComplete ||
     activityChanged(prev.recentActivity, next.recentActivity)
   );
 }

--- a/test/unit/loop-progress.test.ts
+++ b/test/unit/loop-progress.test.ts
@@ -5,6 +5,7 @@ import {
   MAX_PROGRESS_ACTIVITY,
   type LoopProgressActivity,
   type LoopProgressState,
+  type ProgressSnapshot,
 } from "../../packages/loopover-engine/src/loop-progress";
 
 function running(overrides: Partial<LoopProgressState> = {}): LoopProgressState {
@@ -65,6 +66,35 @@ describe("progressChanged — push on change, not on a fixed interval (#4800)", 
 
   it("does not push when nothing displayed has changed", () => {
     expect(progressChanged(base, buildProgressSnapshot(running({ recentActivity: [{ step: "a" }] })))).toBe(false);
+  });
+
+  // #9323: maxIterations and percentComplete are displayed axes too, but were left out of the diff. Raising the
+  // iteration budget mid-run moves the customer's percent while phase/status/iteration/activity all hold — that
+  // must still push, or the progress bar shows a stale percent.
+  it("REGRESSION (#9323): pushes when only the iteration budget (maxIterations, and so percentComplete) changes", () => {
+    const widerBudget = buildProgressSnapshot(running({ maxIterations: 10, recentActivity: [{ step: "a" }] }));
+    // Everything `base` displays is held constant except the budget (5→10) and its derived percent (40→20).
+    expect(base).toMatchObject({ maxIterations: 5, percentComplete: 40 });
+    expect(widerBudget).toMatchObject({ phase: base.phase, status: base.status, iteration: base.iteration, maxIterations: 10, percentComplete: 20 });
+    expect(widerBudget.recentActivity).toEqual(base.recentActivity);
+    expect(progressChanged(base, widerBudget)).toBe(true);
+  });
+
+  // #9323 regression guard against over-triggering: identical on ALL six displayed axes (including the two new
+  // ones) must still not push.
+  it("does not push when maxIterations and percentComplete are identical alongside the other axes", () => {
+    const same = buildProgressSnapshot(running({ recentActivity: [{ step: "a" }] }));
+    expect(same).toMatchObject({ maxIterations: base.maxIterations, percentComplete: base.percentComplete });
+    expect(progressChanged(base, same)).toBe(false);
+  });
+
+  // #9323: percentComplete is compared as its own axis, so a change to just that shown number still pushes even
+  // if maxIterations is unchanged. It is normally derived from iteration/maxIterations, so isolate it by building
+  // the snapshot directly rather than through buildProgressSnapshot.
+  it("REGRESSION (#9323): pushes when only percentComplete differs, with maxIterations and every other axis held", () => {
+    const shiftedPercent: ProgressSnapshot = { ...base, percentComplete: (base.percentComplete ?? 0) + 1 };
+    expect(shiftedPercent.maxIterations).toBe(base.maxIterations);
+    expect(progressChanged(base, shiftedPercent)).toBe(true);
   });
 
   // #6171: the tail is capped, so past the cap every new event evicts the oldest and the LENGTH stops moving.


### PR DESCRIPTION
## Summary

`progressChanged` (`packages/loopover-engine/src/loop-progress.ts`) decides when a new `ProgressSnapshot` differs from the previous one enough to push to the customer's streaming surface — the on-change-not-polling design from #4800. Its doc comment says it compares the *displayed* axes, but it only checked `phase`, `status`, `iteration`, and the activity tail; it never compared `maxIterations` or the derived `percentComplete`.

So when an operator raises the iteration budget mid-run (`maxIterations` changes) while `iteration` / `phase` / `status` / `recentActivity` all stay the same, `percentComplete` (= `iteration / maxIterations`, #6773) silently changes value but `progressChanged` returned `false` — the surface never pushed the update, and the customer's progress bar went stale on a real, displayed number.

This adds both `maxIterations` and `percentComplete` to the existing OR-chain, so any change to a shown number streams on change. It is a pure diff function: `buildProgressSnapshot` is unchanged and no other behavior is touched. `progressChanged`'s only real consumer is the streaming surface, which benefits directly.

Closes #9323

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #9323`).

## Validation

- [x] `git diff --check` — clean
- [x] `npm run actionlint` — pass
- [x] `npm run typecheck` — pass (whole repo)
- [x] `npm run test:coverage` — measured on the changed file: **100% of changed lines AND branches (23/23 branches)**, no uncovered lines. Also ran `npm run test:changed` (every test whose import graph the diff touches): **237 files / 3427 tests pass**.
- [ ] `npm run test:workers` — not run; the diff touches no worker-runtime code.
- [x] `npm run build:mcp` — pass (also built `@loopover/engine`, `@loopover/miner`)
- [ ] `npm run test:mcp-pack` — not run; no MCP packaging surface change.
- [ ] `npm run ui:openapi:check` — n/a; no API / OpenAPI schema change.
- [ ] `npm run ui:lint` / `ui:typecheck` / `ui:build` — n/a; no UI (`apps/loopover-ui`) change.
- [ ] `npm audit --audit-level=moderate` — see note below.
- [x] New behavior has tests for new branches: three cases added — budget-only change pushes, `percentComplete`-only change pushes, and all-six-axes-identical does not push (over-trigger guard).

If any required check was skipped, explain why:

- The change is confined to one **pure function** in `packages/loopover-engine/src/loop-progress.ts`, with no API/OpenAPI, UI (`apps/loopover-ui`), Cloudflare-worker, `wrangler` binding, migration, or MCP-surface change — so `test:workers`, `test:mcp-pack`, `ui:*`, and `ui:openapi:check` cover subsystems this diff does not touch. Verified locally: `git diff --check`, `actionlint`, whole-repo `typecheck`, **patch coverage 100% on the changed file (23/23 branches)**, `test:changed` (237 files / 3427 tests green), `@loopover/engine` build + `engine-parity` (drift-check and contract test, both pass).
- `npm audit` flags only **pre-existing** advisories already present in the dependency tree; this PR changes **no dependency** (no `package.json` / `package-lock.json` diff), so it introduces none.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, private keys, raw trust scores, private rankings, or private maintainer evidence — pure logic + unit tests, none present.
- [x] Public GitHub text stays sanitized and low-noise — no public-surface text change.
- [ ] Auth / cookie / CORS / GitHub App / Cloudflare / session negative-path tests — n/a; no such change.
- [ ] API / OpenAPI / MCP behavior — n/a; no contract change.
- [ ] UI live-data / empty-error-loading states — n/a; no UI change.
- [ ] UI Evidence — n/a; no visible UI, frontend, or docs change (pure `@loopover/engine` logic).
- [ ] Public docs / changelog — n/a; no changelog edit.

## UI Evidence

Not applicable — this is a pure `@loopover/engine` diff-logic change with no visible UI, frontend, or docs surface.

## Notes

- `percentComplete` is derived from `iteration` / `maxIterations`, so in normal data it moves only when one of those does. It is compared as its own displayed axis defensively (and per the issue's requirement); the third regression test isolates that axis by constructing the `ProgressSnapshot` directly, since `buildProgressSnapshot` cannot produce a `percentComplete` change with `iteration` and `maxIterations` held equal.
