### PR TITLE
fix(api): document /v1/contributors/:login/watches in OpenAPI spec

### DIFF
--- a/apps/loopover-ui/public/openapi.json
+++ b/apps/loopover-ui/public/openapi.json
@@ -14856,6 +14856,78 @@
           "recommendation",
           "summary"
         ]
+      },
+      "WatchSubscriptionList": {
+        "type": "object",
+        "properties": {
+          "watching": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WatchSubscription"
+            }
+          }
+        },
+        "required": [
+          "watching"
+        ]
+      },
+      "WatchSubscription": {
+        "type": "object",
+        "properties": {
+          "repoFullName": {
+            "type": "string"
+          },
+          "labels": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "repoFullName",
+          "labels"
+        ]
+      },
+      "WatchSubscriptionChange": {
+        "type": "object",
+        "properties": {
+          "watching": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WatchSubscription"
+            }
+          },
+          "changed": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "watching",
+          "changed"
+        ]
+      },
+      "WatchSubscriptionRequest": {
+        "type": "object",
+        "properties": {
+          "repoFullName": {
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 200
+          },
+          "labels": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 100
+            },
+            "maxItems": 50
+          }
+        },
+        "required": [
+          "repoFullName"
+        ]
       }
     },
     "parameters": {},
@@ -19359,6 +19431,137 @@
           },
           "404": {
             "description": "No ledger row at that seq (never appended -- distinct from a row with empty fields)"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ]
+      }
+    },
+    "/v1/contributors/{login}/watches": {
+      "get": {
+        "summary": "List contributor issue-watch subscriptions",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "login",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The contributor's own issue-watch subscriptions (self-scoped), mirroring loopover_watch_issues action=list.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WatchSubscriptionList"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ]
+      },
+      "post": {
+        "summary": "Watch a repo for new grabbable issues",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "login",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WatchSubscriptionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Subscribes the contributor to repoFullName (optional label filter) and returns the updated watch list, mirroring loopover_watch_issues action=watch.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WatchSubscriptionChange"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid watch request body"
+          },
+          "403": {
+            "description": "Forbidden when the repo cannot be watched by this login"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ]
+      },
+      "delete": {
+        "summary": "Unwatch a repo",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "login",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WatchSubscriptionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Removes the contributor's subscription to repoFullName and returns the updated watch list, mirroring loopover_watch_issues action=unwatch.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WatchSubscriptionChange"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid watch request body"
+          },
+          "403": {
+            "description": "Forbidden when the repo cannot be watched by this login"
           }
         },
         "security": [

--- a/src/openapi/schemas.ts
+++ b/src/openapi/schemas.ts
@@ -539,6 +539,34 @@ export const NotificationsMarkedSchema = z
   })
   .openapi("NotificationsMarked");
 
+// #9306: mirrors watchIssuesOutputSchema's `watching` shape (src/mcp/server.ts) for the REST surface.
+export const WatchSubscriptionSchema = z
+  .object({
+    repoFullName: z.string(),
+    labels: z.array(z.string()),
+  })
+  .openapi("WatchSubscription");
+
+export const WatchSubscriptionListSchema = z
+  .object({
+    watching: z.array(WatchSubscriptionSchema),
+  })
+  .openapi("WatchSubscriptionList");
+
+export const WatchSubscriptionChangeSchema = z
+  .object({
+    watching: z.array(WatchSubscriptionSchema),
+    changed: z.string(),
+  })
+  .openapi("WatchSubscriptionChange");
+
+export const WatchSubscriptionRequestSchema = z
+  .object({
+    repoFullName: z.string().min(3).max(200),
+    labels: z.array(z.string().min(1).max(100)).max(50).optional(),
+  })
+  .openapi("WatchSubscriptionRequest");
+
 export const ContributorOpportunitySchema = z
   .object({
     repoFullName: z.string(),

--- a/src/openapi/spec.ts
+++ b/src/openapi/spec.ts
@@ -87,6 +87,9 @@ import {
   UpstreamDriftReportSchema,
   UpstreamRulesetSnapshotSchema,
   UpstreamStatusSchema,
+  WatchSubscriptionChangeSchema,
+  WatchSubscriptionListSchema,
+  WatchSubscriptionRequestSchema,
   WorkboardItemSchema,
 } from "./schemas";
 
@@ -839,6 +842,52 @@ export function buildOpenApiSpec() {
         content: { "application/json": { schema: NotificationsMarkedSchema } },
       },
       400: { description: "Invalid mark-read body" },
+    },
+  });
+  registry.registerPath({
+    method: "get",
+    path: "/v1/contributors/{login}/watches",
+    summary: "List contributor issue-watch subscriptions",
+    request: { params: z.object({ login: z.string() }) },
+    responses: {
+      200: {
+        description: "The contributor's own issue-watch subscriptions (self-scoped), mirroring loopover_watch_issues action=list.",
+        content: { "application/json": { schema: WatchSubscriptionListSchema } },
+      },
+    },
+  });
+  registry.registerPath({
+    method: "post",
+    path: "/v1/contributors/{login}/watches",
+    summary: "Watch a repo for new grabbable issues",
+    request: {
+      params: z.object({ login: z.string() }),
+      body: { content: { "application/json": { schema: WatchSubscriptionRequestSchema } } },
+    },
+    responses: {
+      200: {
+        description: "Subscribes the contributor to repoFullName (optional label filter) and returns the updated watch list, mirroring loopover_watch_issues action=watch.",
+        content: { "application/json": { schema: WatchSubscriptionChangeSchema } },
+      },
+      400: { description: "Invalid watch request body" },
+      403: { description: "Forbidden when the repo cannot be watched by this login" },
+    },
+  });
+  registry.registerPath({
+    method: "delete",
+    path: "/v1/contributors/{login}/watches",
+    summary: "Unwatch a repo",
+    request: {
+      params: z.object({ login: z.string() }),
+      body: { content: { "application/json": { schema: WatchSubscriptionRequestSchema } } },
+    },
+    responses: {
+      200: {
+        description: "Removes the contributor's subscription to repoFullName and returns the updated watch list, mirroring loopover_watch_issues action=unwatch.",
+        content: { "application/json": { schema: WatchSubscriptionChangeSchema } },
+      },
+      400: { description: "Invalid watch request body" },
+      403: { description: "Forbidden when the repo cannot be watched by this login" },
     },
   });
   registry.registerPath({

--- a/test/unit/openapi.test.ts
+++ b/test/unit/openapi.test.ts
@@ -25,6 +25,9 @@ describe("OpenAPI contract", () => {
     expect(spec.paths["/v1/contributors/{login}/decision-pack"]).toBeDefined();
     expect(spec.paths["/v1/contributors/{login}/open-pr-monitor"]).toBeDefined();
     expect(spec.paths["/v1/contributors/{login}/pr-outcomes"]).toBeDefined();
+    expect(spec.paths["/v1/contributors/{login}/watches"]?.get).toBeDefined();
+    expect(spec.paths["/v1/contributors/{login}/watches"]?.post).toBeDefined();
+    expect(spec.paths["/v1/contributors/{login}/watches"]?.delete).toBeDefined();
     expect(spec.paths["/v1/contributors/{login}/repos/{owner}/{repo}/decision"]).toBeDefined();
     expect(spec.paths["/v1/preflight/pr"]).toBeDefined();
     expect(spec.paths["/v1/preflight/review-risk"]).toBeDefined();
@@ -101,6 +104,12 @@ describe("OpenAPI contract", () => {
     expect(spec.components?.schemas?.PullRequestMaintainerPacket).toBeDefined();
     expect(spec.components?.schemas?.PullRequestReviewability).toBeDefined();
     expect(spec.components?.schemas?.LocalBranchAnalysis).toBeDefined();
+    expect(spec.components?.schemas?.WatchSubscriptionList).toBeDefined();
+    expect(spec.components?.schemas?.WatchSubscriptionChange).toBeDefined();
+    expect(spec.components?.schemas?.WatchSubscriptionRequest).toBeDefined();
+    expect(JSON.stringify(spec.components?.schemas?.WatchSubscriptionList)).toContain("watching");
+    expect(JSON.stringify(spec.components?.schemas?.WatchSubscriptionChange)).toContain("changed");
+    expect(JSON.stringify(spec.components?.schemas?.WatchSubscriptionRequest)).toContain("repoFullName");
     expect(spec.components?.schemas?.RepoSettingsPreview).toBeDefined();
     expect(spec.components?.schemas?.InstallationRepair).toBeDefined();
     expect(spec.components?.schemas?.CommandPreviewResponse).toBeDefined();
@@ -161,5 +170,27 @@ describe("OpenAPI contract", () => {
         }
       }
     }
+  });
+
+  // #9306: /v1/contributors/{login}/watches (GET/POST/DELETE) mirrors loopover_watch_issues (watchIssuesOutputSchema
+  // in src/mcp/server.ts) but had no OpenAPI documentation. Pin all three verbs plus their response schema refs.
+  it("documents all three verbs of /v1/contributors/{login}/watches with matching response schemas", () => {
+    const spec = buildOpenApiSpec();
+    const refName = (schema: unknown) => (schema as { $ref?: string }).$ref?.split("/").pop();
+    const watches = spec.paths["/v1/contributors/{login}/watches"] as {
+      get?: { responses: Record<string, { content?: Record<string, { schema: unknown }> }> };
+      post?: { responses: Record<string, { content?: Record<string, { schema: unknown }> }>; requestBody?: { content: Record<string, { schema: unknown }> } };
+      delete?: { responses: Record<string, { content?: Record<string, { schema: unknown }> }>; requestBody?: { content: Record<string, { schema: unknown }> } };
+    };
+
+    expect(refName(watches.get?.responses["200"]?.content?.["application/json"]?.schema)).toBe("WatchSubscriptionList");
+    expect(refName(watches.post?.responses["200"]?.content?.["application/json"]?.schema)).toBe("WatchSubscriptionChange");
+    expect(refName(watches.post?.requestBody?.content["application/json"]?.schema)).toBe("WatchSubscriptionRequest");
+    expect(watches.post?.responses["400"]).toBeDefined();
+    expect(watches.post?.responses["403"]).toBeDefined();
+    expect(refName(watches.delete?.responses["200"]?.content?.["application/json"]?.schema)).toBe("WatchSubscriptionChange");
+    expect(refName(watches.delete?.requestBody?.content["application/json"]?.schema)).toBe("WatchSubscriptionRequest");
+    expect(watches.delete?.responses["400"]).toBeDefined();
+    expect(watches.delete?.responses["403"]).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary

- `/v1/contributors/:login/watches` (GET/POST/DELETE) was implemented and validated at runtime but missing from the OpenAPI spec, so `apps/loopover-ui/public/openapi.json` and generated clients had no record of it.
- Adds `WatchSubscriptionSchema`, `WatchSubscriptionListSchema`, `WatchSubscriptionChangeSchema`, and `WatchSubscriptionRequestSchema` to `src/openapi/schemas.ts`, mirroring the shape already validated by the MCP tool's `watchIssuesOutputSchema` (`src/mcp/server.ts`).
- Registers all three verbs in `src/openapi/spec.ts` following the pattern of the neighboring `/v1/contributors/{login}/notifications` and `/notifications/read` paths (same security scheme, same 400/403 documentation style).
- Regenerates and commits `apps/loopover-ui/public/openapi.json` via `npm run ui:openapi`.

Closes #9306

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #9306`).

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` (no workflow files changed; skipped)
- [x] `npm run typecheck` (via engine/mcp/miner builds + vitest typecheck path)
- [x] `npm run test:coverage` — ran targeted + `vitest run --changed=upstream/main` (134 files, 1723 tests passed); src/openapi/** changes are fully covered by the new/updated assertions in test/unit/openapi.test.ts
- [ ] `npm run test:workers` (not run this session; change does not touch Workers-specific code)
- [ ] `npm run build:mcp` (ran `turbo run build --filter=@loopover/mcp` directly instead — passed)
- [ ] `npm run test:mcp-pack` (not run this session; no MCP tool surface changed)
- [x] `npm run ui:openapi:check`
- [ ] `npm run ui:lint` (not run; no UI source files changed, only the generated `openapi.json`)
- [ ] `npm run ui:typecheck` (not run; no UI source files changed)
- [ ] `npm run ui:build` (not run; no UI source files changed)
- [ ] `npm audit --audit-level=moderate` (not run this session)
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — added assertions in `test/unit/openapi.test.ts` pinning all three verbs and their response/request `$ref` schema names.

If any required check was skipped, explain why:

- This is a pure OpenAPI-documentation change (no route/handler behavior changed), so the UI build/lint/typecheck and mcp-pack/workers/actionlint checks were judged low-risk and not re-run locally in this pass; `ui:openapi:check` (the check that directly gates this diff) was run and passes.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session code changed.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI source changed, only generated `openapi.json`.)
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots. (N/A — no visible UI/frontend change; this is a backend OpenAPI-spec-only documentation change.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (No changelog edit made.)

## Notes

- No behavior change to the actual route handlers in `src/api/routes.ts` — they already implement and validate GET/POST/DELETE `/v1/contributors/:login/watches` correctly; this PR only adds the missing OpenAPI documentation layer.