### PR TITLE
fix(api): document ai-review-findings pull request route in openapi spec

### DIFF
--- a/apps/loopover-ui/public/openapi.json
+++ b/apps/loopover-ui/public/openapi.json
@@ -14856,6 +14856,80 @@
           "recommendation",
           "summary"
         ]
+      },
+      "PullRequestAiReviewFindings": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "ready",
+              "not_found",
+              "ai_review_off"
+            ]
+          },
+          "repoFullName": {
+            "type": "string"
+          },
+          "pullNumber": {
+            "type": "number"
+          },
+          "login": {
+            "type": "string"
+          },
+          "headSha": {
+            "type": "string",
+            "nullable": true
+          },
+          "findings": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "category": {
+                  "type": "string"
+                },
+                "path": {
+                  "type": "string"
+                },
+                "severity": {
+                  "type": "string",
+                  "enum": [
+                    "blocker",
+                    "nit"
+                  ]
+                },
+                "line": {
+                  "type": "number"
+                },
+                "body": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "category",
+                "path",
+                "severity",
+                "line",
+                "body"
+              ]
+            }
+          },
+          "categoryCounts": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "number"
+            }
+          }
+        },
+        "required": [
+          "status",
+          "repoFullName",
+          "pullNumber",
+          "login",
+          "findings",
+          "categoryCounts"
+        ]
       }
     },
     "parameters": {},
@@ -19359,6 +19433,77 @@
           },
           "404": {
             "description": "No ledger row at that seq (never appended -- distinct from a row with empty fields)"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ]
+      }
+    },
+    "/v1/repos/{owner}/{repo}/pulls/{number}/ai-review-findings": {
+      "get": {
+        "summary": "A PR author's own structured, published AI-review findings",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "owner",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "repo",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "number",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "example": "jsonbored"
+            },
+            "required": true,
+            "description": "GitHub login of the pull request's author -- the caller must be this same login.",
+            "name": "login",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Structured, published AI-review findings for the caller's own pull request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PullRequestAiReviewFindings"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing login"
+          },
+          "403": {
+            "description": "The pull request belongs to a different contributor"
+          },
+          "404": {
+            "description": "Pull request not found"
           }
         },
         "security": [

--- a/src/openapi/schemas.ts
+++ b/src/openapi/schemas.ts
@@ -2822,6 +2822,26 @@ export const PullRequestReviewabilitySchema = z
   })
   .openapi("PullRequestReviewability");
 
+export const PullRequestAiReviewFindingsSchema = z
+  .object({
+    status: z.enum(["ready", "not_found", "ai_review_off"]),
+    repoFullName: z.string(),
+    pullNumber: z.number(),
+    login: z.string(),
+    headSha: z.string().nullable().optional(),
+    findings: z.array(
+      z.object({
+        category: z.string(),
+        path: z.string(),
+        severity: z.enum(["blocker", "nit"]),
+        line: z.number(),
+        body: z.string(),
+      }),
+    ),
+    categoryCounts: z.record(z.string(), z.number()),
+  })
+  .openapi("PullRequestAiReviewFindings");
+
 export const RegistryChangeReportSchema = z
   .object({
     generatedAt: z.string(),

--- a/src/openapi/spec.ts
+++ b/src/openapi/spec.ts
@@ -48,6 +48,7 @@ import {
   MaintainerNoiseReportSchema,
   AmsMinerCohortComparisonSchema,
   McpCompatibilitySchema,
+  PullRequestAiReviewFindingsSchema,
   PullRequestMaintainerPacketSchema,
   PullRequestReviewIntelligenceSchema,
   PullRequestReviewabilitySchema,
@@ -173,6 +174,7 @@ export function buildOpenApiSpec() {
   registry.register("MaintainerNoiseReport", MaintainerNoiseReportSchema);
   registry.register("AmsMinerCohortComparison", AmsMinerCohortComparisonSchema);
   registry.register("PullRequestReviewability", PullRequestReviewabilitySchema);
+  registry.register("PullRequestAiReviewFindings", PullRequestAiReviewFindingsSchema);
 
   registry.registerPath({
     method: "get",
@@ -756,6 +758,26 @@ export function buildOpenApiSpec() {
     request: { params: z.object({ owner: z.string(), repo: z.string(), number: z.string() }) },
     responses: {
       200: { description: "Private PR reviewability score and maintainer action", content: { "application/json": { schema: PullRequestReviewabilitySchema } } },
+    },
+  });
+  registry.registerPath({
+    method: "get",
+    path: "/v1/repos/{owner}/{repo}/pulls/{number}/ai-review-findings",
+    summary: "A PR author's own structured, published AI-review findings",
+    request: {
+      params: z.object({ owner: z.string(), repo: z.string(), number: z.string() }),
+      query: z.object({
+        login: z.string().min(1).openapi({
+          param: { description: "GitHub login of the pull request's author -- the caller must be this same login." },
+          example: "jsonbored",
+        }),
+      }),
+    },
+    responses: {
+      200: { description: "Structured, published AI-review findings for the caller's own pull request", content: { "application/json": { schema: PullRequestAiReviewFindingsSchema } } },
+      400: { description: "Missing login" },
+      403: { description: "The pull request belongs to a different contributor" },
+      404: { description: "Pull request not found" },
     },
   });
   registry.registerPath({

--- a/test/unit/openapi.test.ts
+++ b/test/unit/openapi.test.ts
@@ -21,6 +21,7 @@ describe("OpenAPI contract", () => {
     expect(spec.paths["/v1/repos/{owner}/{repo}/gittensor-config-recommendation"]).toBeDefined();
     expect(spec.paths["/v1/repos/{owner}/{repo}/pulls/{number}/maintainer-packet"]).toBeDefined();
     expect(spec.paths["/v1/repos/{owner}/{repo}/pulls/{number}/reviewability"]).toBeDefined();
+    expect(spec.paths["/v1/repos/{owner}/{repo}/pulls/{number}/ai-review-findings"]).toBeDefined();
     expect(spec.paths["/v1/contributors/{login}/profile"]).toBeDefined();
     expect(spec.paths["/v1/contributors/{login}/decision-pack"]).toBeDefined();
     expect(spec.paths["/v1/contributors/{login}/open-pr-monitor"]).toBeDefined();
@@ -100,6 +101,8 @@ describe("OpenAPI contract", () => {
     expect(spec.components?.schemas?.GittensorConfigRecommendation).toBeDefined();
     expect(spec.components?.schemas?.PullRequestMaintainerPacket).toBeDefined();
     expect(spec.components?.schemas?.PullRequestReviewability).toBeDefined();
+    expect(spec.components?.schemas?.PullRequestAiReviewFindings).toBeDefined();
+    expect(JSON.stringify(spec.components?.schemas?.PullRequestAiReviewFindings)).toContain("categoryCounts");
     expect(spec.components?.schemas?.LocalBranchAnalysis).toBeDefined();
     expect(spec.components?.schemas?.RepoSettingsPreview).toBeDefined();
     expect(spec.components?.schemas?.InstallationRepair).toBeDefined();


### PR DESCRIPTION
## Summary

The `GET /v1/repos/{owner}/{repo}/pulls/{number}/ai-review-findings` route has existed for a while, but it was never registered in the OpenAPI spec — unlike its `maintainer-packet` and `reviewability` siblings under the same `/pulls/{number}/*` path prefix.

This adds the missing documentation:
- `PullRequestAiReviewFindingsSchema` in `src/openapi/schemas.ts`, built from the route's actual response shape (reusing the same fields as the existing `prAiReviewFindingsOutputSchema` MCP tool shape).
- The path registration in `src/openapi/spec.ts`, including the `login` query parameter the route requires and its 400/403/404 responses.
- Regenerated `apps/loopover-ui/public/openapi.json` (`npm run ui:openapi`).
- A regression assertion in `test/unit/openapi.test.ts` so the path/schema can't silently disappear again.

Closes #9305

## Scope

- [x] Conventional Commit title.
- [x] Focused change — only `src/openapi/**`, the regenerated `openapi.json`, and its test.
- [x] No `site/`/`CNAME`/VitePress touched.
- [x] Linked open issue: Closes #9305.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run ui:openapi:check`
- [x] `npx vitest run test/unit/openapi.test.ts`
- [x] `npx vitest run --changed=upstream/main --passWithNoTests` (136 files / 1736 tests passed, run after rebasing onto latest main)
- [x] engine/mcp/miner builds (`turbo run build --filter=@loopover/engine`, `--filter=@loopover/mcp`, `build:tsc build:verify --filter=@loopover/miner`)

## Safety

- [x] No secrets/wallet/hotkey/trust-score/reward data anywhere.
- [x] No auth/cookie/CORS/session changes.
- [x] OpenAPI contract updated and tested.
- [x] No UI/visual change — this only documents an existing, already-gated backend route.
- [x] No changelog edit.

## UI Evidence

N/A — no visible UI change. This is purely an OpenAPI schema/path registration for an already-live backend route, plus the regenerated `openapi.json` artifact.

## Notes

The route itself already existed with its access checks in place (`requireContributorAccess` + `assertContributorOwnsPullRequest` in `src/api/routes.ts`); this PR only closes the documentation gap so it shows up in the OpenAPI contract like its siblings.