### PR TITLE
fix(openapi): document POST /v1/scoring/eligibility-plan + explain-breakdown

### DIFF
--- a/apps/loopover-ui/public/openapi.json
+++ b/apps/loopover-ui/public/openapi.json
@@ -14856,6 +14856,62 @@
           "login",
           "marked"
         ]
+      },
+      "EligibilityPlanResponse": {
+        "type": "object",
+        "properties": {
+          "eligible": {
+            "type": "boolean"
+          },
+          "linkedIssueStatus": {
+            "type": "string"
+          },
+          "branchEligibilityStatus": {
+            "type": "string"
+          },
+          "blockers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "cleanupPaths": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "linkedIssueProjection": {
+            "type": "string",
+            "nullable": true
+          },
+          "publicSummary": {
+            "type": "string"
+          }
+        }
+      },
+      "ScoreBreakdownResponse": {
+        "type": "object",
+        "properties": {
+          "repoFullName": {
+            "type": "string"
+          },
+          "scoreabilityStatus": {
+            "type": "string"
+          },
+          "effectiveEstimatedScore": {
+            "type": "number"
+          },
+          "components": {
+            "nullable": true
+          },
+          "gateHighlights": {
+            "nullable": true
+          },
+          "highestLeverageLever": {
+            "nullable": true
+          }
+        }
       }
     },
     "parameters": {},
@@ -19426,6 +19482,62 @@
           },
           "401": {
             "description": "Invalid internal token"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ]
+      }
+    },
+    "/v1/scoring/eligibility-plan": {
+      "post": {
+        "summary": "Eligibility plan derived from a scoring preview for a candidate contribution (#9301)",
+        "responses": {
+          "200": {
+            "description": "Eligibility plan (eligible, linked-issue/branch status, blockers, cleanup paths, public summary)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EligibilityPlanResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid scoring preview input"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ]
+      }
+    },
+    "/v1/scoring/explain-breakdown": {
+      "post": {
+        "summary": "Human-readable explanation of a scoring preview's score breakdown (#9301)",
+        "responses": {
+          "200": {
+            "description": "Score breakdown explanation (scoreability status, effective estimated score, components, gate highlights, highest-leverage lever)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ScoreBreakdownResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid scoring preview input"
           }
         },
         "security": [

--- a/src/openapi/schemas.ts
+++ b/src/openapi/schemas.ts
@@ -1862,6 +1862,33 @@ export const ScorePreviewSchema = z
   })
   .openapi("ScorePreview");
 
+// #9301: response shapes for the two documented-sibling scoring POST routes (/v1/scoring/eligibility-plan,
+// /v1/scoring/explain-breakdown). Field names/types mirror loopover_get_eligibility_plan /
+// loopover_explain_score_breakdown's own MCP outputSchemas (eligibilityPlanOutputSchema /
+// scoreBreakdownOutputSchema in src/mcp/server.ts) -- the same data these HTTP routes return.
+export const EligibilityPlanResponseSchema = z
+  .object({
+    eligible: z.boolean().optional(),
+    linkedIssueStatus: z.string().optional(),
+    branchEligibilityStatus: z.string().optional(),
+    blockers: z.array(z.string()).optional(),
+    cleanupPaths: z.array(z.string()).optional(),
+    linkedIssueProjection: z.string().nullable().optional(),
+    publicSummary: z.string().optional(),
+  })
+  .openapi("EligibilityPlanResponse");
+
+export const ScoreBreakdownResponseSchema = z
+  .object({
+    repoFullName: z.string().optional(),
+    scoreabilityStatus: z.string().optional(),
+    effectiveEstimatedScore: z.number().optional(),
+    components: z.unknown().optional(),
+    gateHighlights: z.unknown().optional(),
+    highestLeverageLever: z.unknown().optional(),
+  })
+  .openapi("ScoreBreakdownResponse");
+
 export const IssueQualityReportSchema = z
   .object({
     repoFullName: z.string(),

--- a/src/openapi/spec.ts
+++ b/src/openapi/spec.ts
@@ -37,6 +37,8 @@ import {
   IssueQualityReportSchema,
   IssueQualityResponseSchema,
   GateConfigEffectiveResponseSchema,
+  EligibilityPlanResponseSchema,
+  ScoreBreakdownResponseSchema,
   LabelAuditSchema,
   LaneAdviceSchema,
   LiveGateThresholdsResponseSchema,
@@ -163,6 +165,8 @@ export function buildOpenApiSpec() {
   registry.register("IssueQualityReport", IssueQualityReportSchema);
   registry.register("IssueQualityResponse", IssueQualityResponseSchema);
   registry.register("GateConfigEffectiveResponse", GateConfigEffectiveResponseSchema);
+  registry.register("EligibilityPlanResponse", EligibilityPlanResponseSchema);
+  registry.register("ScoreBreakdownResponse", ScoreBreakdownResponseSchema);
   registry.register("LiveGateThresholdsResponse", LiveGateThresholdsResponseSchema);
   registry.register("BurdenForecast", BurdenForecastSchema);
   registry.register("ContributorScoringProfile", ContributorScoringProfileSchema);
@@ -308,6 +312,24 @@ export function buildOpenApiSpec() {
     summary: "Generate a scoring preview artifact for a candidate contribution",
     responses: {
       200: { description: "Private scoring preview artifact", content: { "application/json": { schema: ScorePreviewSchema } } },
+      400: { description: "Invalid scoring preview input" },
+    },
+  });
+  registry.registerPath({
+    method: "post",
+    path: "/v1/scoring/eligibility-plan",
+    summary: "Eligibility plan derived from a scoring preview for a candidate contribution (#9301)",
+    responses: {
+      200: { description: "Eligibility plan (eligible, linked-issue/branch status, blockers, cleanup paths, public summary)", content: { "application/json": { schema: EligibilityPlanResponseSchema } } },
+      400: { description: "Invalid scoring preview input" },
+    },
+  });
+  registry.registerPath({
+    method: "post",
+    path: "/v1/scoring/explain-breakdown",
+    summary: "Human-readable explanation of a scoring preview's score breakdown (#9301)",
+    responses: {
+      200: { description: "Score breakdown explanation (scoreability status, effective estimated score, components, gate highlights, highest-leverage lever)", content: { "application/json": { schema: ScoreBreakdownResponseSchema } } },
       400: { description: "Invalid scoring preview input" },
     },
   });


### PR DESCRIPTION
Closes #9301

## What

`POST /v1/scoring/eligibility-plan` and `POST /v1/scoring/explain-breakdown` are live, tested routes in `src/api/routes.ts` (each backed by an MCP tool — `loopover_get_eligibility_plan` / `loopover_explain_score_breakdown`), but neither appeared in `src/openapi/spec.ts` or the generated `openapi.json`, unlike their documented siblings `/v1/scoring/model` and `/v1/scoring/preview`. Same gap class #6611 fixed for `gate-config/effective`.

- **`src/openapi/schemas.ts`** — `EligibilityPlanResponseSchema` and `ScoreBreakdownResponseSchema`, with field names/types taken from `eligibilityPlanOutputSchema` / `scoreBreakdownOutputSchema` (the MCP `outputSchema`s in `src/mcp/server.ts` that already validate this exact data), each `.openapi(...)`-named like every sibling schema.
- **`src/openapi/spec.ts`** — `registry.register(...)` both schemas, then a `registry.registerPath({...})` for each POST route (200 response + 400 error), matching the shape of the documented sibling `/v1/scoring/preview` (which likewise documents no explicit request body for these `scorePreviewSchema`-bodied scoring routes — kept consistent rather than diverging).
- **`apps/loopover-ui/public/openapi.json`** — regenerated from the schema (the contract), committed in the same PR. `ui:openapi:check` enforces it.

## Verification

`tsc --noEmit` clean; `openapi.test.ts` passes (3/3); regeneration is idempotent (stable output, matches what `ui:openapi:check` produces); both new source files are at 100% statement coverage under the openapi test. No new unit test is required — this is a spec-documentation change enforced by `ui:openapi:check`.