### PR TITLE
openapi: /v1/scoring/eligibility-plan + /v1/scoring/explain-breakdown missing from spec (MCP tools + schemas already exist)

### DIFF
--- a/apps/loopover-ui/public/openapi.json
+++ b/apps/loopover-ui/public/openapi.json
@@ -15256,6 +15256,62 @@
         "required": [
           "ok"
         ]
+      },
+      "EligibilityPlanResponse": {
+        "type": "object",
+        "properties": {
+          "eligible": {
+            "type": "boolean"
+          },
+          "linkedIssueStatus": {
+            "type": "string"
+          },
+          "branchEligibilityStatus": {
+            "type": "string"
+          },
+          "blockers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "cleanupPaths": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "linkedIssueProjection": {
+            "type": "string",
+            "nullable": true
+          },
+          "publicSummary": {
+            "type": "string"
+          }
+        }
+      },
+      "ScoreBreakdownResponse": {
+        "type": "object",
+        "properties": {
+          "repoFullName": {
+            "type": "string"
+          },
+          "scoreabilityStatus": {
+            "type": "string"
+          },
+          "effectiveEstimatedScore": {
+            "type": "number"
+          },
+          "components": {
+            "nullable": true
+          },
+          "gateHighlights": {
+            "nullable": true
+          },
+          "highestLeverageLever": {
+            "nullable": true
+          }
+        }
       }
     },
     "parameters": {},
@@ -20011,6 +20067,62 @@
           },
           "400": {
             "description": "Invalid plan-idea-claims request body, or an empty/malformed idea submission (actionable error list returned)"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ]
+      }
+    },
+    "/v1/scoring/eligibility-plan": {
+      "post": {
+        "summary": "Derive a contributor eligibility plan from a scoring preview — REST mirror of loopover_get_eligibility_plan (#9301)",
+        "responses": {
+          "200": {
+            "description": "Structured eligibility plan over a server-built score preview — mirrors the loopover_get_eligibility_plan MCP tool. Advisory only; it explains eligibility, it does not open issues or PRs",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EligibilityPlanResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid scoring preview input"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ]
+      }
+    },
+    "/v1/scoring/explain-breakdown": {
+      "post": {
+        "summary": "Explain a score breakdown from a scoring preview — REST mirror of loopover_explain_score_breakdown (#9301)",
+        "responses": {
+          "200": {
+            "description": "Score multiplier breakdown and gate highlights over a server-built score preview — mirrors the loopover_explain_score_breakdown MCP tool. Requires contributorLogin in the request body",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ScoreBreakdownResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid scoring preview input or missing contributorLogin"
           }
         },
         "security": [

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1697,7 +1697,7 @@ const remediationPlanOutputSchema = {
   items: z.unknown().optional(),
 };
 
-const scoreBreakdownOutputSchema = {
+export const scoreBreakdownOutputSchema = {
   repoFullName: z.string().optional(),
   scoreabilityStatus: z.string().optional(),
   effectiveEstimatedScore: z.number().optional(),
@@ -1706,7 +1706,7 @@ const scoreBreakdownOutputSchema = {
   highestLeverageLever: z.unknown().optional(),
 };
 
-const eligibilityPlanOutputSchema = {
+export const eligibilityPlanOutputSchema = {
   eligible: z.boolean().optional(),
   linkedIssueStatus: z.string().optional(),
   branchEligibilityStatus: z.string().optional(),

--- a/src/openapi/schemas.ts
+++ b/src/openapi/schemas.ts
@@ -1927,6 +1927,37 @@ export const GateConfigEffectiveResponseSchema = z
   .openapi("GateConfigEffectiveResponse");
 
 /**
+ * Response body for POST /v1/scoring/eligibility-plan. Field-level parity with `eligibilityPlanOutputSchema`
+ * (the `loopover_get_eligibility_plan` MCP tool `outputSchema`) in src/mcp/server.ts — #9301.
+ */
+export const EligibilityPlanResponseSchema = z
+  .object({
+    eligible: z.boolean().optional(),
+    linkedIssueStatus: z.string().optional(),
+    branchEligibilityStatus: z.string().optional(),
+    blockers: z.array(z.string()).optional(),
+    cleanupPaths: z.array(z.string()).optional(),
+    linkedIssueProjection: z.string().nullable().optional(),
+    publicSummary: z.string().optional(),
+  })
+  .openapi("EligibilityPlanResponse");
+
+/**
+ * Response body for POST /v1/scoring/explain-breakdown. Field-level parity with `scoreBreakdownOutputSchema`
+ * (the `loopover_explain_score_breakdown` MCP tool `outputSchema`) in src/mcp/server.ts — #9301.
+ */
+export const ScoreBreakdownResponseSchema = z
+  .object({
+    repoFullName: z.string().optional(),
+    scoreabilityStatus: z.string().optional(),
+    effectiveEstimatedScore: z.number().optional(),
+    components: z.unknown().optional(),
+    gateHighlights: z.unknown().optional(),
+    highestLeverageLever: z.unknown().optional(),
+  })
+  .openapi("ScoreBreakdownResponse");
+
+/**
  * Request body for POST /v1/loop/evaluate-escalation. Field-level parity with `evaluateEscalationShape`
  * (the `loopover_evaluate_escalation` MCP tool `inputSchema`) in src/mcp/server.ts — #9309.
  */

--- a/src/openapi/spec.ts
+++ b/src/openapi/spec.ts
@@ -37,6 +37,8 @@ import {
   IssueQualityReportSchema,
   IssueQualityResponseSchema,
   GateConfigEffectiveResponseSchema,
+  EligibilityPlanResponseSchema,
+  ScoreBreakdownResponseSchema,
   EvaluateEscalationRequestSchema,
   EvaluateEscalationResponseSchema,
   BuildResultsPayloadRequestSchema,
@@ -173,6 +175,8 @@ export function buildOpenApiSpec() {
   registry.register("IssueQualityReport", IssueQualityReportSchema);
   registry.register("IssueQualityResponse", IssueQualityResponseSchema);
   registry.register("GateConfigEffectiveResponse", GateConfigEffectiveResponseSchema);
+  registry.register("EligibilityPlanResponse", EligibilityPlanResponseSchema);
+  registry.register("ScoreBreakdownResponse", ScoreBreakdownResponseSchema);
   registry.register("EvaluateEscalationRequest", EvaluateEscalationRequestSchema);
   registry.register("EvaluateEscalationResponse", EvaluateEscalationResponseSchema);
   registry.register("BuildResultsPayloadRequest", BuildResultsPayloadRequestSchema);
@@ -329,6 +333,32 @@ export function buildOpenApiSpec() {
     responses: {
       200: { description: "Private scoring preview artifact", content: { "application/json": { schema: ScorePreviewSchema } } },
       400: { description: "Invalid scoring preview input" },
+    },
+  });
+  registry.registerPath({
+    method: "post",
+    path: "/v1/scoring/eligibility-plan",
+    summary: "Derive a contributor eligibility plan from a scoring preview — REST mirror of loopover_get_eligibility_plan (#9301)",
+    responses: {
+      200: {
+        description:
+          "Structured eligibility plan over a server-built score preview — mirrors the loopover_get_eligibility_plan MCP tool. Advisory only; it explains eligibility, it does not open issues or PRs",
+        content: { "application/json": { schema: EligibilityPlanResponseSchema } },
+      },
+      400: { description: "Invalid scoring preview input" },
+    },
+  });
+  registry.registerPath({
+    method: "post",
+    path: "/v1/scoring/explain-breakdown",
+    summary: "Explain a score breakdown from a scoring preview — REST mirror of loopover_explain_score_breakdown (#9301)",
+    responses: {
+      200: {
+        description:
+          "Score multiplier breakdown and gate highlights over a server-built score preview — mirrors the loopover_explain_score_breakdown MCP tool. Requires contributorLogin in the request body",
+        content: { "application/json": { schema: ScoreBreakdownResponseSchema } },
+      },
+      400: { description: "Invalid scoring preview input or missing contributorLogin" },
     },
   });
   registry.registerPath({

--- a/test/unit/openapi.test.ts
+++ b/test/unit/openapi.test.ts
@@ -10,6 +10,8 @@ import {
   intakeIdeaShape,
   intakeIdeaOutputSchema,
   planIdeaClaimsOutputSchema,
+  eligibilityPlanOutputSchema,
+  scoreBreakdownOutputSchema,
 } from "../../src/mcp/server";
 
 describe("OpenAPI contract", () => {
@@ -49,6 +51,8 @@ describe("OpenAPI contract", () => {
     expect(spec.paths["/v1/agent/explain-blockers"]).toBeDefined();
     expect(spec.paths["/v1/scoring/model"]).toBeDefined();
     expect(spec.paths["/v1/scoring/preview"]).toBeDefined();
+    expect(spec.paths["/v1/scoring/eligibility-plan"]).toBeDefined();
+    expect(spec.paths["/v1/scoring/explain-breakdown"]).toBeDefined();
     expect(spec.paths["/v1/upstream/status"]).toBeDefined();
     expect(spec.paths["/v1/upstream/ruleset"]).toBeDefined();
     expect(spec.paths["/v1/upstream/drift"]).toBeDefined();
@@ -224,6 +228,39 @@ describe("OpenAPI contract", () => {
 
     // request-apr-transfer is explicitly out of scope for this batch and must stay undocumented here.
     expect(spec.paths["/v1/loop/request-apr-transfer"]).toBeUndefined();
+  });
+
+  // #9301: the two /v1/scoring/* composer routes backed by loopover_get_eligibility_plan and
+  // loopover_explain_score_breakdown. Assert each is a documented POST path whose 200 response
+  // component stays field-for-field in parity with the MCP tool outputSchema.
+  it("documents the /v1/scoring/eligibility-plan and /v1/scoring/explain-breakdown routes with tool-parity schemas (#9301)", () => {
+    const spec = buildOpenApiSpec();
+    const schemas = spec.components?.schemas ?? {};
+
+    const propKeys = (name: string) =>
+      Object.keys((schemas[name] as { properties?: Record<string, unknown> }).properties ?? {}).sort();
+
+    const cases = [
+      {
+        path: "/v1/scoring/eligibility-plan",
+        response: "EligibilityPlanResponse",
+        outputShape: eligibilityPlanOutputSchema,
+      },
+      {
+        path: "/v1/scoring/explain-breakdown",
+        response: "ScoreBreakdownResponse",
+        outputShape: scoreBreakdownOutputSchema,
+      },
+    ];
+
+    for (const { path, response, outputShape } of cases) {
+      const op = spec.paths[path]?.post;
+      expect(op, `${path} should be a documented POST path`).toBeDefined();
+      expect(op?.responses?.["200"], `${path} should document a 200 response`).toBeDefined();
+
+      expect(schemas[response], `${response} component should be registered`).toBeDefined();
+      expect(propKeys(response)).toEqual(Object.keys(outputShape).sort());
+    }
   });
 
   it("declares an `in: path` parameter for every {templated} path segment (Cloudflare schema-validation warning 30046)", () => {


### PR DESCRIPTION
## Summary

`src/api/routes.ts` has two live, tested `/v1/scoring/*` POST routes, each already backed by an MCP
tool with its own Zod output shape in `src/mcp/server.ts`:

- `POST /v1/scoring/eligibility-plan` → `loopover_get_eligibility_plan` (`outputSchema:
  eligibilityPlanOutputSchema`)
- `POST /v1/scoring/explain-breakdown` → `loopover_explain_score_breakdown` (`outputSchema:
  scoreBreakdownOutputSchema`)

Neither route appears anywhere in `src/openapi/spec.ts` — grep for `"/v1/scoring/eligibility-plan"`
and `"/v1/scoring/explain-breakdown"` in that file returns nothing, and neither route is reachable
from the generated `apps/loopover-ui/public/openapi.json`. Their sibling `/v1/scoring/*` routes
(`/v1/scoring/model`, `/v1/scoring/preview`) ARE documented. This is the same class of gap #6611
fixed for `/v1/repos/{owner}/{repo}/gate-config/effective` ("OpenAPI spec is missing GET
.../gate-config/effective (documented sibling: live-gate-thresholds)").

## Deliverables

- [ ] `EligibilityPlanResponseSchema` and `ScoreBreakdownResponseSchema` added to
      `src/openapi/schemas.ts`, matching the MCP tools' existing output shapes field-for-field.
- [ ] Both routes registered as OpenAPI paths in `src/openapi/spec.ts`.
- [ ] `apps/loopover-ui/public/openapi.json` regenerated via `npm run ui:openapi` and committed.
- [ ] `npm run ui:openapi:check` passes in CI.

All deliverables are required in this one PR — there is no follow-up issue.

## Test plan

99%+ Codecov patch target (`codecov/patch`, unsharded via `npm run test:coverage`) on any new schema
helper code. Add a regression test (or extend an existing OpenAPI-spec snapshot/shape test) asserting
both new paths are present in `buildOpenApiSpec()`'s output with the correct method and a response
schema whose keys match `eligibilityPlanOutputSchema`/`scoreBreakdownOutputSchema`.

Fixes #9301