### PR TITLE
openapi: 5 repo maintainer-report routes missing from spec (maintainer-noise, ams-miner-cohort, gate-precision, outcome-calibration, activation-preview)

### DIFF
--- a/apps/loopover-ui/public/openapi.json
+++ b/apps/loopover-ui/public/openapi.json
@@ -14189,6 +14189,462 @@
           "shadowPending"
         ]
       },
+      "EligibilityPlanResponse": {
+        "type": "object",
+        "properties": {
+          "eligible": {
+            "type": "boolean"
+          },
+          "linkedIssueStatus": {
+            "type": "string"
+          },
+          "branchEligibilityStatus": {
+            "type": "string"
+          },
+          "blockers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "cleanupPaths": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "linkedIssueProjection": {
+            "type": "string",
+            "nullable": true
+          },
+          "publicSummary": {
+            "type": "string"
+          }
+        }
+      },
+      "ScoreBreakdownResponse": {
+        "type": "object",
+        "properties": {
+          "repoFullName": {
+            "type": "string"
+          },
+          "scoreabilityStatus": {
+            "type": "string"
+          },
+          "effectiveEstimatedScore": {
+            "type": "number"
+          },
+          "components": {
+            "nullable": true
+          },
+          "gateHighlights": {
+            "nullable": true
+          },
+          "highestLeverageLever": {
+            "nullable": true
+          }
+        }
+      },
+      "EvaluateEscalationRequest": {
+        "type": "object",
+        "properties": {
+          "runStatus": {
+            "type": "string",
+            "enum": [
+              "running",
+              "converged",
+              "abandoned",
+              "error"
+            ]
+          },
+          "healthStatus": {
+            "type": "string",
+            "enum": [
+              "healthy",
+              "degraded",
+              "critical"
+            ]
+          },
+          "customerFlagged": {
+            "type": "boolean"
+          },
+          "killRequested": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "runStatus"
+        ]
+      },
+      "EvaluateEscalationResponse": {
+        "type": "object",
+        "properties": {
+          "shouldEscalate": {
+            "type": "boolean"
+          },
+          "action": {
+            "type": "string",
+            "enum": [
+              "none",
+              "notify",
+              "human_review",
+              "stop"
+            ]
+          },
+          "severity": {
+            "type": "string",
+            "enum": [
+              "none",
+              "low",
+              "medium",
+              "high"
+            ]
+          },
+          "reasons": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "BuildResultsPayloadRequest": {
+        "type": "object",
+        "properties": {
+          "repoFullName": {
+            "type": "string",
+            "minLength": 1
+          },
+          "prNumber": {
+            "type": "integer",
+            "nullable": true
+          },
+          "title": {
+            "type": "string"
+          },
+          "changedFiles": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "path": {
+                  "type": "string"
+                },
+                "additions": {
+                  "type": "integer"
+                },
+                "deletions": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "path"
+              ]
+            },
+            "maxItems": 5000
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "open",
+              "merged",
+              "closed"
+            ]
+          }
+        },
+        "required": [
+          "repoFullName",
+          "title"
+        ]
+      },
+      "BuildResultsPayloadResponse": {
+        "type": "object",
+        "properties": {
+          "prLink": {
+            "type": "string",
+            "nullable": true
+          },
+          "summary": {
+            "type": "string"
+          },
+          "diffPreview": {
+            "nullable": true
+          },
+          "totals": {
+            "nullable": true
+          }
+        }
+      },
+      "BuildProgressSnapshotRequest": {
+        "type": "object",
+        "properties": {
+          "iteration": {
+            "type": "integer"
+          },
+          "maxIterations": {
+            "type": "integer",
+            "nullable": true
+          },
+          "phase": {
+            "type": "string",
+            "enum": [
+              "queued",
+              "claiming",
+              "coding",
+              "reviewing",
+              "submitting",
+              "done"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "running",
+              "converged",
+              "abandoned",
+              "error"
+            ]
+          },
+          "recentActivity": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "step": {
+                  "type": "string"
+                },
+                "detail": {
+                  "type": "string"
+                },
+                "at": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "step"
+              ]
+            },
+            "maxItems": 1000
+          }
+        },
+        "required": [
+          "iteration",
+          "phase",
+          "status"
+        ]
+      },
+      "BuildProgressSnapshotResponse": {
+        "type": "object",
+        "properties": {
+          "phase": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "iteration": {
+            "type": "number"
+          },
+          "maxIterations": {
+            "type": "number",
+            "nullable": true
+          },
+          "percentComplete": {
+            "type": "number",
+            "nullable": true
+          },
+          "recentActivity": {
+            "nullable": true
+          },
+          "done": {
+            "type": "boolean"
+          }
+        }
+      },
+      "IntakeIdeaRequest": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          },
+          "targetRepo": {
+            "type": "string"
+          },
+          "constraints": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 50
+          },
+          "acceptanceHints": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 50
+          },
+          "priority": {
+            "type": "string"
+          },
+          "decomposition": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "key": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "body": {
+                  "type": "string"
+                },
+                "dependsOn": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "maxItems": 50
+                }
+              },
+              "required": [
+                "key",
+                "title",
+                "body"
+              ]
+            },
+            "maxItems": 50
+          }
+        }
+      },
+      "IntakeIdeaResponse": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          },
+          "verdict": {
+            "type": "string",
+            "enum": [
+              "go",
+              "raise",
+              "avoid"
+            ]
+          },
+          "taskGraph": {
+            "nullable": true
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "ok"
+        ]
+      },
+      "PlanIdeaClaimsRequest": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          },
+          "targetRepo": {
+            "type": "string"
+          },
+          "constraints": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 50
+          },
+          "acceptanceHints": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 50
+          },
+          "priority": {
+            "type": "string"
+          },
+          "decomposition": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "key": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "body": {
+                  "type": "string"
+                },
+                "dependsOn": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "maxItems": 50
+                }
+              },
+              "required": [
+                "key",
+                "title",
+                "body"
+              ]
+            },
+            "maxItems": 50
+          }
+        }
+      },
+      "PlanIdeaClaimsResponse": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          },
+          "verdict": {
+            "type": "string",
+            "enum": [
+              "go",
+              "raise",
+              "avoid"
+            ]
+          },
+          "claimPlan": {
+            "nullable": true
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "ok"
+        ]
+      },
       "LiveGateThresholdsResponse": {
         "type": "object",
         "properties": {
@@ -14592,6 +15048,108 @@
           "humanCohort"
         ]
       },
+      "GatePrecisionResponse": {
+        "type": "object",
+        "properties": {
+          "repoFullName": {
+            "type": "string"
+          },
+          "generatedAt": {
+            "type": "string"
+          },
+          "windowDays": {
+            "type": "number",
+            "nullable": true
+          },
+          "perGateType": {
+            "type": "array",
+            "items": {
+              "nullable": true
+            }
+          },
+          "overall": {
+            "nullable": true
+          },
+          "signals": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "OutcomeCalibrationResponse": {
+        "type": "object",
+        "properties": {
+          "repoFullName": {
+            "type": "string"
+          },
+          "generatedAt": {
+            "type": "string"
+          },
+          "windowDays": {
+            "type": "number",
+            "nullable": true
+          },
+          "slop": {
+            "nullable": true
+          },
+          "recommendations": {
+            "nullable": true
+          },
+          "signals": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "status": {
+            "type": "string"
+          }
+        }
+      },
+      "ActivationPreviewResponse": {
+        "type": "object",
+        "properties": {
+          "repoFullName": {
+            "type": "string"
+          },
+          "generatedAt": {
+            "type": "string"
+          },
+          "currentReviewCheckMode": {
+            "type": "string"
+          },
+          "aiReviewConfigured": {
+            "type": "boolean"
+          },
+          "evaluatedCount": {
+            "type": "number"
+          },
+          "withFindingsCount": {
+            "type": "number"
+          },
+          "findingCodeCounts": {
+            "type": "array",
+            "items": {
+              "nullable": true
+            }
+          },
+          "samples": {
+            "type": "array",
+            "items": {
+              "nullable": true
+            }
+          },
+          "recommendedAction": {
+            "type": "string",
+            "nullable": true
+          },
+          "summary": {
+            "type": "string"
+          }
+        }
+      },
       "PullRequestReviewability": {
         "type": "object",
         "properties": {
@@ -14930,462 +15488,6 @@
           "login",
           "marked"
         ]
-      },
-      "EvaluateEscalationRequest": {
-        "type": "object",
-        "properties": {
-          "runStatus": {
-            "type": "string",
-            "enum": [
-              "running",
-              "converged",
-              "abandoned",
-              "error"
-            ]
-          },
-          "healthStatus": {
-            "type": "string",
-            "enum": [
-              "healthy",
-              "degraded",
-              "critical"
-            ]
-          },
-          "customerFlagged": {
-            "type": "boolean"
-          },
-          "killRequested": {
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "runStatus"
-        ]
-      },
-      "EvaluateEscalationResponse": {
-        "type": "object",
-        "properties": {
-          "shouldEscalate": {
-            "type": "boolean"
-          },
-          "action": {
-            "type": "string",
-            "enum": [
-              "none",
-              "notify",
-              "human_review",
-              "stop"
-            ]
-          },
-          "severity": {
-            "type": "string",
-            "enum": [
-              "none",
-              "low",
-              "medium",
-              "high"
-            ]
-          },
-          "reasons": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        }
-      },
-      "BuildResultsPayloadRequest": {
-        "type": "object",
-        "properties": {
-          "repoFullName": {
-            "type": "string",
-            "minLength": 1
-          },
-          "prNumber": {
-            "type": "integer",
-            "nullable": true
-          },
-          "title": {
-            "type": "string"
-          },
-          "changedFiles": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "path": {
-                  "type": "string"
-                },
-                "additions": {
-                  "type": "integer"
-                },
-                "deletions": {
-                  "type": "integer"
-                }
-              },
-              "required": [
-                "path"
-              ]
-            },
-            "maxItems": 5000
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "open",
-              "merged",
-              "closed"
-            ]
-          }
-        },
-        "required": [
-          "repoFullName",
-          "title"
-        ]
-      },
-      "BuildResultsPayloadResponse": {
-        "type": "object",
-        "properties": {
-          "prLink": {
-            "type": "string",
-            "nullable": true
-          },
-          "summary": {
-            "type": "string"
-          },
-          "diffPreview": {
-            "nullable": true
-          },
-          "totals": {
-            "nullable": true
-          }
-        }
-      },
-      "BuildProgressSnapshotRequest": {
-        "type": "object",
-        "properties": {
-          "iteration": {
-            "type": "integer"
-          },
-          "maxIterations": {
-            "type": "integer",
-            "nullable": true
-          },
-          "phase": {
-            "type": "string",
-            "enum": [
-              "queued",
-              "claiming",
-              "coding",
-              "reviewing",
-              "submitting",
-              "done"
-            ]
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "running",
-              "converged",
-              "abandoned",
-              "error"
-            ]
-          },
-          "recentActivity": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "step": {
-                  "type": "string"
-                },
-                "detail": {
-                  "type": "string"
-                },
-                "at": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "step"
-              ]
-            },
-            "maxItems": 1000
-          }
-        },
-        "required": [
-          "iteration",
-          "phase",
-          "status"
-        ]
-      },
-      "BuildProgressSnapshotResponse": {
-        "type": "object",
-        "properties": {
-          "phase": {
-            "type": "string"
-          },
-          "status": {
-            "type": "string"
-          },
-          "iteration": {
-            "type": "number"
-          },
-          "maxIterations": {
-            "type": "number",
-            "nullable": true
-          },
-          "percentComplete": {
-            "type": "number",
-            "nullable": true
-          },
-          "recentActivity": {
-            "nullable": true
-          },
-          "done": {
-            "type": "boolean"
-          }
-        }
-      },
-      "IntakeIdeaRequest": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          },
-          "body": {
-            "type": "string"
-          },
-          "targetRepo": {
-            "type": "string"
-          },
-          "constraints": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "maxItems": 50
-          },
-          "acceptanceHints": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "maxItems": 50
-          },
-          "priority": {
-            "type": "string"
-          },
-          "decomposition": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "key": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "body": {
-                  "type": "string"
-                },
-                "dependsOn": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "maxItems": 50
-                }
-              },
-              "required": [
-                "key",
-                "title",
-                "body"
-              ]
-            },
-            "maxItems": 50
-          }
-        }
-      },
-      "IntakeIdeaResponse": {
-        "type": "object",
-        "properties": {
-          "ok": {
-            "type": "boolean"
-          },
-          "verdict": {
-            "type": "string",
-            "enum": [
-              "go",
-              "raise",
-              "avoid"
-            ]
-          },
-          "taskGraph": {
-            "nullable": true
-          },
-          "errors": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "required": [
-          "ok"
-        ]
-      },
-      "PlanIdeaClaimsRequest": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          },
-          "body": {
-            "type": "string"
-          },
-          "targetRepo": {
-            "type": "string"
-          },
-          "constraints": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "maxItems": 50
-          },
-          "acceptanceHints": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "maxItems": 50
-          },
-          "priority": {
-            "type": "string"
-          },
-          "decomposition": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "key": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "body": {
-                  "type": "string"
-                },
-                "dependsOn": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "maxItems": 50
-                }
-              },
-              "required": [
-                "key",
-                "title",
-                "body"
-              ]
-            },
-            "maxItems": 50
-          }
-        }
-      },
-      "PlanIdeaClaimsResponse": {
-        "type": "object",
-        "properties": {
-          "ok": {
-            "type": "boolean"
-          },
-          "verdict": {
-            "type": "string",
-            "enum": [
-              "go",
-              "raise",
-              "avoid"
-            ]
-          },
-          "claimPlan": {
-            "nullable": true
-          },
-          "errors": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "required": [
-          "ok"
-        ]
-      },
-      "EligibilityPlanResponse": {
-        "type": "object",
-        "properties": {
-          "eligible": {
-            "type": "boolean"
-          },
-          "linkedIssueStatus": {
-            "type": "string"
-          },
-          "branchEligibilityStatus": {
-            "type": "string"
-          },
-          "blockers": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "cleanupPaths": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "linkedIssueProjection": {
-            "type": "string",
-            "nullable": true
-          },
-          "publicSummary": {
-            "type": "string"
-          }
-        }
-      },
-      "ScoreBreakdownResponse": {
-        "type": "object",
-        "properties": {
-          "repoFullName": {
-            "type": "string"
-          },
-          "scoreabilityStatus": {
-            "type": "string"
-          },
-          "effectiveEstimatedScore": {
-            "type": "number"
-          },
-          "components": {
-            "nullable": true
-          },
-          "gateHighlights": {
-            "nullable": true
-          },
-          "highestLeverageLever": {
-            "nullable": true
-          }
-        }
       }
     },
     "parameters": {},
@@ -15781,6 +15883,62 @@
           },
           "400": {
             "description": "Invalid scoring preview input"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ]
+      }
+    },
+    "/v1/scoring/eligibility-plan": {
+      "post": {
+        "summary": "Derive a contributor eligibility plan from a scoring preview — REST mirror of loopover_get_eligibility_plan (#9301)",
+        "responses": {
+          "200": {
+            "description": "Structured eligibility plan over a server-built score preview — mirrors the loopover_get_eligibility_plan MCP tool. Advisory only; it explains eligibility, it does not open issues or PRs",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EligibilityPlanResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid scoring preview input"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ]
+      }
+    },
+    "/v1/scoring/explain-breakdown": {
+      "post": {
+        "summary": "Explain a score breakdown from a scoring preview — REST mirror of loopover_explain_score_breakdown (#9301)",
+        "responses": {
+          "200": {
+            "description": "Score multiplier breakdown and gate highlights over a server-built score preview — mirrors the loopover_explain_score_breakdown MCP tool. Requires contributorLogin in the request body",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ScoreBreakdownResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid scoring preview input or missing contributorLogin"
           }
         },
         "security": [
@@ -16355,6 +16513,191 @@
         ]
       }
     },
+    "/v1/loop/evaluate-escalation": {
+      "post": {
+        "summary": "Evaluate whether a loop outcome should escalate — REST mirror of loopover_evaluate_escalation (#9309)",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EvaluateEscalationRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Escalation decision over caller-supplied loop outcome + health signals — mirrors the loopover_evaluate_escalation MCP tool. Pure, source-free evaluator; it decides, the caller wires the action",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvaluateEscalationResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid evaluate-escalation request body"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ]
+      }
+    },
+    "/v1/loop/results-payload": {
+      "post": {
+        "summary": "Compose a loop results-delivery payload — REST mirror of loopover_build_results_payload (#9309)",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BuildResultsPayloadRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Formatted results payload over caller-supplied iteration metadata — mirrors the loopover_build_results_payload MCP tool. Pure composer; it formats the result, it does not fetch, open, or deliver anything",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BuildResultsPayloadResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid results-payload request body"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ]
+      }
+    },
+    "/v1/loop/progress-snapshot": {
+      "post": {
+        "summary": "Compose a running-loop progress snapshot — REST mirror of loopover_build_progress_snapshot (#9309)",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BuildProgressSnapshotRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Formatted progress snapshot over caller-supplied loop state — mirrors the loopover_build_progress_snapshot MCP tool. Pure composer; it formats the snapshot, it does not fetch or stream anything",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BuildProgressSnapshotResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid progress-snapshot request body"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ]
+      }
+    },
+    "/v1/loop/intake-idea": {
+      "post": {
+        "summary": "Validate an idea submission and assemble its task-graph — REST mirror of loopover_intake_idea (#9309)",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IntakeIdeaRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Idea verdict + assembled task-graph — mirrors the loopover_intake_idea MCP tool. Pure composer over the caller-supplied idea and optional decomposition",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IntakeIdeaResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid intake-idea request body, or an empty/malformed idea submission (actionable error list returned)"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ]
+      }
+    },
+    "/v1/loop/plan-idea-claims": {
+      "post": {
+        "summary": "Disposition an idea's task-graph into a claim plan — REST mirror of loopover_plan_idea_claims (#9309)",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlanIdeaClaimsRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Idea verdict + claim plan (which constituent issues can be claimed now vs. deferred) — mirrors the loopover_plan_idea_claims MCP tool. Pure composer over the caller-supplied idea and optional decomposition",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlanIdeaClaimsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid plan-idea-claims request body, or an empty/malformed idea submission (actionable error list returned)"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ]
+      }
+    },
     "/v1/repos/{owner}/{repo}/live-gate-thresholds": {
       "get": {
         "summary": "Live self-tuned gate thresholds for AMS probe (#6486)",
@@ -16392,6 +16735,271 @@
           },
           "404": {
             "description": "No live or shadow gate override is active for this repo"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ]
+      }
+    },
+    "/v1/repos/{owner}/{repo}/maintainer-noise": {
+      "get": {
+        "summary": "Maintainer queue-noise triage report for a repository (#9302)",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "owner",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "repo",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Noise score/level, specific noise sources to clear first, and recommended maintainer actions — mirrors the loopover_get_maintainer_noise MCP tool. Maintainer-authenticated; advisory only",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MaintainerNoiseReport"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid static protected API token"
+          },
+          "403": {
+            "description": "Static mcp credential is outside MCP_READ_REPO_ALLOWLIST for this repo"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ]
+      }
+    },
+    "/v1/repos/{owner}/{repo}/ams-miner-cohort": {
+      "get": {
+        "summary": "AMS-vs-human contributor-mix cohort comparison for a repository (#9302)",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "owner",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "repo",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Submitter counts, PR volume, acceptance rate, review-cycle, and time-to-merge metrics for AMS-tracked vs human submitters — mirrors the loopover_get_ams_miner_cohort MCP tool. Maintainer-authenticated; advisory only",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AmsMinerCohortComparison"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid static protected API token"
+          },
+          "403": {
+            "description": "Static mcp credential is outside MCP_READ_REPO_ALLOWLIST for this repo"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ]
+      }
+    },
+    "/v1/repos/{owner}/{repo}/gate-precision": {
+      "get": {
+        "summary": "Per-gate-type false-positive precision measurement for a repository (#9302)",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "owner",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "repo",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true
+            },
+            "required": false,
+            "name": "windowDays",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Blocked / blocked-then-merged / overridden counts and false-positive rates with low-sample guards — mirrors the loopover_get_gate_precision MCP tool. Maintainer-authenticated; measurement only",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GatePrecisionResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid static protected API token"
+          },
+          "403": {
+            "description": "Static mcp credential is outside MCP_READ_REPO_ALLOWLIST for this repo"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ]
+      }
+    },
+    "/v1/repos/{owner}/{repo}/outcome-calibration": {
+      "get": {
+        "summary": "Slop-band and recommendation outcome calibration for a repository (#9302)",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "owner",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "repo",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true
+            },
+            "required": false,
+            "name": "windowDays",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Whether higher-slop bands merge less often and how agent recommendations are panning out — mirrors the loopover_get_outcome_calibration MCP tool. Maintainer-authenticated; measurement only",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OutcomeCalibrationResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid static protected API token"
+          },
+          "403": {
+            "description": "Static mcp credential is outside MCP_READ_REPO_ALLOWLIST for this repo"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ]
+      }
+    },
+    "/v1/repos/{owner}/{repo}/activation-preview": {
+      "get": {
+        "summary": "Deterministic maintainer activation preview for a repository (#9302)",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "owner",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "repo",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A deterministic \"here's what LoopOver would have surfaced\" run of the advisory engine over recent PRs — mirrors the loopover_get_activation_preview MCP tool. Maintainer-authenticated; advisory only, never runs AI",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivationPreviewResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid static protected API token"
+          },
+          "403": {
+            "description": "Static mcp credential is outside MCP_READ_REPO_ALLOWLIST for this repo"
           }
         },
         "security": [
@@ -20027,247 +20635,6 @@
           },
           "401": {
             "description": "Invalid internal token"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/loop/evaluate-escalation": {
-      "post": {
-        "summary": "Evaluate whether a loop outcome should escalate — REST mirror of loopover_evaluate_escalation (#9309)",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/EvaluateEscalationRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Escalation decision over caller-supplied loop outcome + health signals — mirrors the loopover_evaluate_escalation MCP tool. Pure, source-free evaluator; it decides, the caller wires the action",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EvaluateEscalationResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid evaluate-escalation request body"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/loop/results-payload": {
-      "post": {
-        "summary": "Compose a loop results-delivery payload — REST mirror of loopover_build_results_payload (#9309)",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BuildResultsPayloadRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Formatted results payload over caller-supplied iteration metadata — mirrors the loopover_build_results_payload MCP tool. Pure composer; it formats the result, it does not fetch, open, or deliver anything",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BuildResultsPayloadResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid results-payload request body"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/loop/progress-snapshot": {
-      "post": {
-        "summary": "Compose a running-loop progress snapshot — REST mirror of loopover_build_progress_snapshot (#9309)",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BuildProgressSnapshotRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Formatted progress snapshot over caller-supplied loop state — mirrors the loopover_build_progress_snapshot MCP tool. Pure composer; it formats the snapshot, it does not fetch or stream anything",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BuildProgressSnapshotResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid progress-snapshot request body"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/loop/intake-idea": {
-      "post": {
-        "summary": "Validate an idea submission and assemble its task-graph — REST mirror of loopover_intake_idea (#9309)",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/IntakeIdeaRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Idea verdict + assembled task-graph — mirrors the loopover_intake_idea MCP tool. Pure composer over the caller-supplied idea and optional decomposition",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IntakeIdeaResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid intake-idea request body, or an empty/malformed idea submission (actionable error list returned)"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/loop/plan-idea-claims": {
-      "post": {
-        "summary": "Disposition an idea's task-graph into a claim plan — REST mirror of loopover_plan_idea_claims (#9309)",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PlanIdeaClaimsRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Idea verdict + claim plan (which constituent issues can be claimed now vs. deferred) — mirrors the loopover_plan_idea_claims MCP tool. Pure composer over the caller-supplied idea and optional decomposition",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlanIdeaClaimsResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid plan-idea-claims request body, or an empty/malformed idea submission (actionable error list returned)"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/scoring/eligibility-plan": {
-      "post": {
-        "summary": "Derive a contributor eligibility plan from a scoring preview — REST mirror of loopover_get_eligibility_plan (#9301)",
-        "responses": {
-          "200": {
-            "description": "Structured eligibility plan over a server-built score preview — mirrors the loopover_get_eligibility_plan MCP tool. Advisory only; it explains eligibility, it does not open issues or PRs",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EligibilityPlanResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid scoring preview input"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/scoring/explain-breakdown": {
-      "post": {
-        "summary": "Explain a score breakdown from a scoring preview — REST mirror of loopover_explain_score_breakdown (#9301)",
-        "responses": {
-          "200": {
-            "description": "Score multiplier breakdown and gate highlights over a server-built score preview — mirrors the loopover_explain_score_breakdown MCP tool. Requires contributorLogin in the request body",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ScoreBreakdownResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid scoring preview input or missing contributorLogin"
           }
         },
         "security": [

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -967,7 +967,7 @@ const repoContextOutputSchema = {
   dataQuality: z.unknown().optional(),
 };
 
-const maintainerNoiseOutputSchema = {
+export const maintainerNoiseOutputSchema = {
   repoFullName: z.string().optional(),
   generatedAt: z.string().optional(),
   score: z.number().optional(),
@@ -978,7 +978,7 @@ const maintainerNoiseOutputSchema = {
   summary: z.string().optional(),
 };
 
-const amsMinerCohortOutputSchema = {
+export const amsMinerCohortOutputSchema = {
   present: z.boolean().optional(),
   windowDays: z.number().optional(),
   totalSubmitterCount: z.number().optional(),
@@ -996,7 +996,7 @@ const repoFocusManifestOutputSchema = {
 
 // (#7799) Repo-specific "here's what LoopOver would have surfaced" activation preview over recent PRs.
 // Mirrors buildMaintainerActivationPreview's shape; deterministic, maintainer-authenticated, advisory only.
-const activationPreviewOutputSchema = {
+export const activationPreviewOutputSchema = {
   repoFullName: z.string().optional(),
   generatedAt: z.string().optional(),
   currentReviewCheckMode: z.string().optional(),
@@ -1114,7 +1114,7 @@ const repoSettingsOutputSchema = {
   slopGateMode: z.string().optional(),
 };
 
-const maintainerMeasurementReportOutputSchema = {
+export const maintainerMeasurementReportOutputSchema = {
   repoFullName: z.string().optional(),
   generatedAt: z.string().optional(),
   windowDays: z.number().nullable().optional(),
@@ -1127,7 +1127,7 @@ const maintainerMeasurementReportOutputSchema = {
 // #2220 - gate-precision measurement surfaced over MCP. Mirrors the
 // maintainerMeasurementReportOutputSchema pattern: report fields optional, structured sub-reports as
 // z.unknown() (buildGatePrecisionReport is the single source of truth for their shape).
-const gatePrecisionOutputSchema = {
+export const gatePrecisionOutputSchema = {
   repoFullName: z.string().optional(),
   generatedAt: z.string().optional(),
   windowDays: z.number().nullable().optional(),

--- a/src/openapi/schemas.ts
+++ b/src/openapi/schemas.ts
@@ -3001,6 +3001,59 @@ export const AmsMinerCohortComparisonSchema = z
   })
   .openapi("AmsMinerCohortComparison");
 
+/**
+ * Response body for GET /v1/repos/{owner}/{repo}/gate-precision. Field-level parity with
+ * `gatePrecisionOutputSchema` (the `loopover_get_gate_precision` MCP tool `outputSchema`) in
+ * src/mcp/server.ts — #9302.
+ */
+export const GatePrecisionResponseSchema = z
+  .object({
+    repoFullName: z.string().optional(),
+    generatedAt: z.string().optional(),
+    windowDays: z.number().nullable().optional(),
+    perGateType: z.array(z.unknown()).optional(),
+    overall: z.unknown().optional(),
+    signals: z.array(z.string()).optional(),
+  })
+  .openapi("GatePrecisionResponse");
+
+/**
+ * Response body for GET /v1/repos/{owner}/{repo}/outcome-calibration. Field-level parity with
+ * `maintainerMeasurementReportOutputSchema` (the `loopover_get_outcome_calibration` MCP tool
+ * `outputSchema`) in src/mcp/server.ts — #9302.
+ */
+export const OutcomeCalibrationResponseSchema = z
+  .object({
+    repoFullName: z.string().optional(),
+    generatedAt: z.string().optional(),
+    windowDays: z.number().nullable().optional(),
+    slop: z.unknown().optional(),
+    recommendations: z.unknown().optional(),
+    signals: z.array(z.string()).optional(),
+    status: z.string().optional(),
+  })
+  .openapi("OutcomeCalibrationResponse");
+
+/**
+ * Response body for GET /v1/repos/{owner}/{repo}/activation-preview. Field-level parity with
+ * `activationPreviewOutputSchema` (the `loopover_get_activation_preview` MCP tool `outputSchema`) in
+ * src/mcp/server.ts — #9302.
+ */
+export const ActivationPreviewResponseSchema = z
+  .object({
+    repoFullName: z.string().optional(),
+    generatedAt: z.string().optional(),
+    currentReviewCheckMode: z.string().optional(),
+    aiReviewConfigured: z.boolean().optional(),
+    evaluatedCount: z.number().optional(),
+    withFindingsCount: z.number().optional(),
+    findingCodeCounts: z.array(z.unknown()).optional(),
+    samples: z.array(z.unknown()).optional(),
+    recommendedAction: z.string().nullable().optional(),
+    summary: z.string().optional(),
+  })
+  .openapi("ActivationPreviewResponse");
+
 export const PullRequestReviewabilitySchema = z
   .object({
     repoFullName: z.string(),

--- a/src/openapi/spec.ts
+++ b/src/openapi/spec.ts
@@ -59,6 +59,9 @@ import {
   MaintainerLaneReportSchema,
   MaintainerNoiseReportSchema,
   AmsMinerCohortComparisonSchema,
+  GatePrecisionResponseSchema,
+  OutcomeCalibrationResponseSchema,
+  ActivationPreviewResponseSchema,
   McpCompatibilitySchema,
   PullRequestAiReviewFindingsSchema,
   PullRequestMaintainerPacketSchema,
@@ -197,6 +200,9 @@ export function buildOpenApiSpec() {
   registry.register("ContributorRewardRiskStrategy", ContributorRewardRiskStrategySchema);
   registry.register("MaintainerNoiseReport", MaintainerNoiseReportSchema);
   registry.register("AmsMinerCohortComparison", AmsMinerCohortComparisonSchema);
+  registry.register("GatePrecisionResponse", GatePrecisionResponseSchema);
+  registry.register("OutcomeCalibrationResponse", OutcomeCalibrationResponseSchema);
+  registry.register("ActivationPreviewResponse", ActivationPreviewResponseSchema);
   registry.register("PullRequestReviewability", PullRequestReviewabilitySchema);
   registry.register("PullRequestAiReviewFindings", PullRequestAiReviewFindingsSchema);
 
@@ -620,6 +626,87 @@ export function buildOpenApiSpec() {
       },
       403: { description: "Static mcp credential is outside MCP_READ_REPO_ALLOWLIST for this repo" },
       404: { description: "No live or shadow gate override is active for this repo" },
+    },
+  });
+  registry.registerPath({
+    method: "get",
+    path: "/v1/repos/{owner}/{repo}/maintainer-noise",
+    summary: "Maintainer queue-noise triage report for a repository (#9302)",
+    request: { params: z.object({ owner: z.string(), repo: z.string() }) },
+    responses: {
+      200: {
+        description:
+          "Noise score/level, specific noise sources to clear first, and recommended maintainer actions — mirrors the loopover_get_maintainer_noise MCP tool. Maintainer-authenticated; advisory only",
+        content: { "application/json": { schema: MaintainerNoiseReportSchema } },
+      },
+      401: { description: "Missing or invalid static protected API token" },
+      403: { description: "Static mcp credential is outside MCP_READ_REPO_ALLOWLIST for this repo" },
+    },
+  });
+  registry.registerPath({
+    method: "get",
+    path: "/v1/repos/{owner}/{repo}/ams-miner-cohort",
+    summary: "AMS-vs-human contributor-mix cohort comparison for a repository (#9302)",
+    request: { params: z.object({ owner: z.string(), repo: z.string() }) },
+    responses: {
+      200: {
+        description:
+          "Submitter counts, PR volume, acceptance rate, review-cycle, and time-to-merge metrics for AMS-tracked vs human submitters — mirrors the loopover_get_ams_miner_cohort MCP tool. Maintainer-authenticated; advisory only",
+        content: { "application/json": { schema: AmsMinerCohortComparisonSchema } },
+      },
+      401: { description: "Missing or invalid static protected API token" },
+      403: { description: "Static mcp credential is outside MCP_READ_REPO_ALLOWLIST for this repo" },
+    },
+  });
+  registry.registerPath({
+    method: "get",
+    path: "/v1/repos/{owner}/{repo}/gate-precision",
+    summary: "Per-gate-type false-positive precision measurement for a repository (#9302)",
+    request: {
+      params: z.object({ owner: z.string(), repo: z.string() }),
+      query: z.object({ windowDays: z.coerce.number().int().positive().optional() }),
+    },
+    responses: {
+      200: {
+        description:
+          "Blocked / blocked-then-merged / overridden counts and false-positive rates with low-sample guards — mirrors the loopover_get_gate_precision MCP tool. Maintainer-authenticated; measurement only",
+        content: { "application/json": { schema: GatePrecisionResponseSchema } },
+      },
+      401: { description: "Missing or invalid static protected API token" },
+      403: { description: "Static mcp credential is outside MCP_READ_REPO_ALLOWLIST for this repo" },
+    },
+  });
+  registry.registerPath({
+    method: "get",
+    path: "/v1/repos/{owner}/{repo}/outcome-calibration",
+    summary: "Slop-band and recommendation outcome calibration for a repository (#9302)",
+    request: {
+      params: z.object({ owner: z.string(), repo: z.string() }),
+      query: z.object({ windowDays: z.coerce.number().int().positive().optional() }),
+    },
+    responses: {
+      200: {
+        description:
+          "Whether higher-slop bands merge less often and how agent recommendations are panning out — mirrors the loopover_get_outcome_calibration MCP tool. Maintainer-authenticated; measurement only",
+        content: { "application/json": { schema: OutcomeCalibrationResponseSchema } },
+      },
+      401: { description: "Missing or invalid static protected API token" },
+      403: { description: "Static mcp credential is outside MCP_READ_REPO_ALLOWLIST for this repo" },
+    },
+  });
+  registry.registerPath({
+    method: "get",
+    path: "/v1/repos/{owner}/{repo}/activation-preview",
+    summary: "Deterministic maintainer activation preview for a repository (#9302)",
+    request: { params: z.object({ owner: z.string(), repo: z.string() }) },
+    responses: {
+      200: {
+        description:
+          "A deterministic \"here's what LoopOver would have surfaced\" run of the advisory engine over recent PRs — mirrors the loopover_get_activation_preview MCP tool. Maintainer-authenticated; advisory only, never runs AI",
+        content: { "application/json": { schema: ActivationPreviewResponseSchema } },
+      },
+      401: { description: "Missing or invalid static protected API token" },
+      403: { description: "Static mcp credential is outside MCP_READ_REPO_ALLOWLIST for this repo" },
     },
   });
   registry.registerPath({

--- a/test/unit/openapi.test.ts
+++ b/test/unit/openapi.test.ts
@@ -12,6 +12,11 @@ import {
   planIdeaClaimsOutputSchema,
   eligibilityPlanOutputSchema,
   scoreBreakdownOutputSchema,
+  maintainerNoiseOutputSchema,
+  amsMinerCohortOutputSchema,
+  gatePrecisionOutputSchema,
+  maintainerMeasurementReportOutputSchema,
+  activationPreviewOutputSchema,
 } from "../../src/mcp/server";
 
 describe("OpenAPI contract", () => {
@@ -30,6 +35,11 @@ describe("OpenAPI contract", () => {
     expect(spec.paths["/v1/repos/{owner}/{repo}/issue-quality"]).toBeDefined();
     expect(spec.paths["/v1/repos/{owner}/{repo}/outcome-patterns"]).toBeDefined();
     expect(spec.paths["/v1/repos/{owner}/{repo}/gate-config/effective"]).toBeDefined();
+    expect(spec.paths["/v1/repos/{owner}/{repo}/maintainer-noise"]).toBeDefined();
+    expect(spec.paths["/v1/repos/{owner}/{repo}/ams-miner-cohort"]).toBeDefined();
+    expect(spec.paths["/v1/repos/{owner}/{repo}/gate-precision"]).toBeDefined();
+    expect(spec.paths["/v1/repos/{owner}/{repo}/outcome-calibration"]).toBeDefined();
+    expect(spec.paths["/v1/repos/{owner}/{repo}/activation-preview"]).toBeDefined();
     expect(spec.paths["/v1/repos/{owner}/{repo}/registration-readiness"]).toBeDefined();
     expect(spec.paths["/v1/repos/{owner}/{repo}/gittensor-config-recommendation"]).toBeDefined();
     expect(spec.paths["/v1/repos/{owner}/{repo}/pulls/{number}/maintainer-packet"]).toBeDefined();
@@ -94,7 +104,6 @@ describe("OpenAPI contract", () => {
       "/v1/repos/{owner}/{repo}/burden-forecast",
       "/v1/repos/{owner}/{repo}/registry-drift",
       "/v1/repos/{owner}/{repo}/maintainer-lane",
-      "/v1/repos/{owner}/{repo}/maintainer-noise",
       "/v1/repos/{owner}/{repo}/pulls/{number}/review-intelligence",
       "/v1/repos/{owner}/{repo}/pulls/{number}/scoring-preview",
       "/v1/internal/jobs/generate-signal-snapshots/run",
@@ -114,6 +123,11 @@ describe("OpenAPI contract", () => {
     expect(spec.components?.schemas?.RepoOutcomePatterns).toBeDefined();
     expect(spec.components?.schemas?.RegistrationReadiness).toBeDefined();
     expect(spec.components?.schemas?.GittensorConfigRecommendation).toBeDefined();
+    expect(spec.components?.schemas?.GatePrecisionResponse).toBeDefined();
+    expect(spec.components?.schemas?.OutcomeCalibrationResponse).toBeDefined();
+    expect(spec.components?.schemas?.ActivationPreviewResponse).toBeDefined();
+    expect(spec.components?.schemas?.MaintainerNoiseReport).toBeDefined();
+    expect(spec.components?.schemas?.AmsMinerCohortComparison).toBeDefined();
     expect(spec.components?.schemas?.PullRequestMaintainerPacket).toBeDefined();
     expect(spec.components?.schemas?.PullRequestReviewability).toBeDefined();
     expect(spec.components?.schemas?.PullRequestAiReviewFindings).toBeDefined();
@@ -260,6 +274,53 @@ describe("OpenAPI contract", () => {
       const op = spec.paths[path]?.post;
       expect(op, `${path} should be a documented POST path`).toBeDefined();
       expect(op?.responses?.["200"], `${path} should document a 200 response`).toBeDefined();
+
+      expect(schemas[response], `${response} component should be registered`).toBeDefined();
+      expect(propKeys(response)).toEqual(Object.keys(outputShape).sort());
+    }
+  });
+
+  // #9302: five maintainer-report GET routes are each backed by an MCP tool whose Zod output shape already
+  // lives in src/mcp/server.ts. Assert every route is a documented GET path whose response component keys
+  // stay field-for-field in parity with those tool shapes.
+  it("documents the repo maintainer-report route family with tool-parity schemas (#9302)", () => {
+    const spec = buildOpenApiSpec();
+    const schemas = spec.components?.schemas ?? {};
+
+    const propKeys = (name: string) =>
+      Object.keys((schemas[name] as { properties?: Record<string, unknown> }).properties ?? {}).sort();
+
+    const cases = [
+      {
+        path: "/v1/repos/{owner}/{repo}/maintainer-noise",
+        response: "MaintainerNoiseReport",
+        outputShape: maintainerNoiseOutputSchema,
+      },
+      {
+        path: "/v1/repos/{owner}/{repo}/ams-miner-cohort",
+        response: "AmsMinerCohortComparison",
+        outputShape: amsMinerCohortOutputSchema,
+      },
+      {
+        path: "/v1/repos/{owner}/{repo}/gate-precision",
+        response: "GatePrecisionResponse",
+        outputShape: gatePrecisionOutputSchema,
+      },
+      {
+        path: "/v1/repos/{owner}/{repo}/outcome-calibration",
+        response: "OutcomeCalibrationResponse",
+        outputShape: maintainerMeasurementReportOutputSchema,
+      },
+      {
+        path: "/v1/repos/{owner}/{repo}/activation-preview",
+        response: "ActivationPreviewResponse",
+        outputShape: activationPreviewOutputSchema,
+      },
+    ];
+
+    for (const { path, response, outputShape } of cases) {
+      const op = spec.paths[path]?.get;
+      expect(op, `${path} should be a documented GET path`).toBeDefined();
 
       expect(schemas[response], `${response} component should be registered`).toBeDefined();
       expect(propKeys(response)).toEqual(Object.keys(outputShape).sort());


### PR DESCRIPTION
## Summary

Re-opened after #9422 was closed for base-branch conflicts (rebased onto `main` after #9421 merged).

Five `GET /v1/repos/:owner/:repo/*` maintainer-report routes are live and MCP-mirrored but were missing from the OpenAPI spec. This PR adds:

- `registerPath` entries for all five routes in `src/openapi/spec.ts`
- Three new response schemas in `src/openapi/schemas.ts` (`gate-precision`, `outcome-calibration`, `activation-preview`)
- Wires existing `MaintainerNoiseReport` / `AmsMinerCohortComparison` components to their paths
- Regenerated `apps/loopover-ui/public/openapi.json` via `npm run ui:openapi`
- Regression tests in `test/unit/openapi.test.ts` (tool-parity for all five routes; scoring-route tests from #9421 retained)

## Scope

- [x] Backend / OpenAPI only — no visible UI change
- [x] Linked open issue: Fixes #9302

## Validation

- [x] `npm run ui:openapi` + `npm run ui:openapi:check`
- [x] `npx vitest run test/unit/openapi.test.ts` (6 tests)

## UI Evidence

N/A — schema/doc-only change; no visible UI change. Regenerated `openapi.json` is the OpenAPI artifact, not a UI screenshot.

Fixes #9302

Made with [Cursor](https://cursor.com)