### PR TITLE
fix(openapi): document POST validate-linked-issue + check-before-start

### DIFF
--- a/apps/loopover-ui/public/openapi.json
+++ b/apps/loopover-ui/public/openapi.json
@@ -15386,6 +15386,119 @@
             "nullable": true
           }
         }
+      },
+      "ValidateLinkedIssueRequest": {
+        "type": "object",
+        "properties": {
+          "issueNumber": {
+            "type": "integer",
+            "minimum": 0,
+            "exclusiveMinimum": true
+          },
+          "plannedChange": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "changedFiles": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "contributorLogin": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "required": [
+          "issueNumber"
+        ]
+      },
+      "ValidateLinkedIssueResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string"
+          },
+          "repoFullName": {
+            "type": "string"
+          },
+          "issueNumber": {
+            "type": "number"
+          },
+          "found": {
+            "type": "boolean"
+          },
+          "multiplierStatus": {
+            "type": "string"
+          },
+          "multiplierWouldApply": {
+            "type": "boolean"
+          },
+          "blockingReason": {
+            "type": "string"
+          },
+          "reasons": {
+            "nullable": true
+          },
+          "report": {
+            "nullable": true
+          }
+        }
+      },
+      "CheckBeforeStartRequest": {
+        "type": "object",
+        "properties": {
+          "issueNumber": {
+            "type": "integer",
+            "minimum": 0,
+            "exclusiveMinimum": true
+          },
+          "title": {
+            "type": "string"
+          },
+          "plannedPaths": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "CheckBeforeStartResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string"
+          },
+          "repoFullName": {
+            "type": "string"
+          },
+          "found": {
+            "type": "boolean"
+          },
+          "claimStatus": {
+            "type": "string"
+          },
+          "duplicateClusterRisk": {
+            "type": "string"
+          },
+          "recommendation": {
+            "type": "string"
+          },
+          "reasons": {
+            "nullable": true
+          },
+          "blockers": {
+            "nullable": true
+          },
+          "report": {
+            "nullable": true
+          }
+        }
       }
     },
     "parameters": {},
@@ -20268,6 +20381,122 @@
           },
           "400": {
             "description": "Invalid scoring preview input or missing contributorLogin"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ]
+      }
+    },
+    "/v1/repos/{owner}/{repo}/validate-linked-issue": {
+      "post": {
+        "summary": "Validate a planned change's linked issue before starting work",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "owner",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "repo",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ValidateLinkedIssueRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Linked-issue validation report (found/multiplier status, blocking reason, reasons)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidateLinkedIssueResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid validate-linked-issue request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ]
+      }
+    },
+    "/v1/repos/{owner}/{repo}/check-before-start": {
+      "post": {
+        "summary": "Pre-work duplicate/claim check before starting on an issue",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "owner",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "repo",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CheckBeforeStartRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Pre-work check report (claim status, duplicate-cluster risk, recommendation, blockers)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CheckBeforeStartResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid check-before-start request"
+          },
+          "401": {
+            "description": "Unauthorized"
           }
         },
         "security": [

--- a/src/openapi/schemas.ts
+++ b/src/openapi/schemas.ts
@@ -1862,6 +1862,58 @@ export const ScorePreviewSchema = z
   })
   .openapi("ScorePreview");
 
+// #9304: request/response shapes for the two pre-work-check POST routes (validate-linked-issue,
+// check-before-start). Request fields mirror routes.ts's own body schemas (owner/repo come from the path,
+// not the body); response fields mirror the MCP tools' outputSchemas in src/mcp/server.ts.
+export const ValidateLinkedIssueRequestSchema = z
+  .object({
+    issueNumber: z.number().int().positive(),
+    plannedChange: z
+      .object({
+        title: z.string().optional(),
+        changedFiles: z.array(z.string()).optional(),
+        contributorLogin: z.string().optional(),
+      })
+      .optional(),
+  })
+  .openapi("ValidateLinkedIssueRequest");
+
+export const ValidateLinkedIssueResponseSchema = z
+  .object({
+    status: z.string().optional(),
+    repoFullName: z.string().optional(),
+    issueNumber: z.number().optional(),
+    found: z.boolean().optional(),
+    multiplierStatus: z.string().optional(),
+    multiplierWouldApply: z.boolean().optional(),
+    blockingReason: z.string().optional(),
+    reasons: z.unknown().optional(),
+    report: z.unknown().optional(),
+  })
+  .openapi("ValidateLinkedIssueResponse");
+
+export const CheckBeforeStartRequestSchema = z
+  .object({
+    issueNumber: z.number().int().positive().optional(),
+    title: z.string().optional(),
+    plannedPaths: z.array(z.string()).optional(),
+  })
+  .openapi("CheckBeforeStartRequest");
+
+export const CheckBeforeStartResponseSchema = z
+  .object({
+    status: z.string().optional(),
+    repoFullName: z.string().optional(),
+    found: z.boolean().optional(),
+    claimStatus: z.string().optional(),
+    duplicateClusterRisk: z.string().optional(),
+    recommendation: z.string().optional(),
+    reasons: z.unknown().optional(),
+    blockers: z.unknown().optional(),
+    report: z.unknown().optional(),
+  })
+  .openapi("CheckBeforeStartResponse");
+
 export const IssueQualityReportSchema = z
   .object({
     repoFullName: z.string(),

--- a/src/openapi/spec.ts
+++ b/src/openapi/spec.ts
@@ -93,6 +93,10 @@ import {
   ReviewRiskExplanationSchema,
   RewardRiskActionSchema,
   ScorePreviewSchema,
+  ValidateLinkedIssueRequestSchema,
+  ValidateLinkedIssueResponseSchema,
+  CheckBeforeStartRequestSchema,
+  CheckBeforeStartResponseSchema,
   ScoringModelSnapshotSchema,
   SignalFidelitySchema,
   SkippedPrAuditExportSchema,
@@ -173,6 +177,10 @@ export function buildOpenApiSpec() {
   registry.register("LaneAdvice", LaneAdviceSchema);
   registry.register("ScoringModelSnapshot", ScoringModelSnapshotSchema);
   registry.register("ScorePreview", ScorePreviewSchema);
+  registry.register("ValidateLinkedIssueRequest", ValidateLinkedIssueRequestSchema);
+  registry.register("ValidateLinkedIssueResponse", ValidateLinkedIssueResponseSchema);
+  registry.register("CheckBeforeStartRequest", CheckBeforeStartRequestSchema);
+  registry.register("CheckBeforeStartResponse", CheckBeforeStartResponseSchema);
   registry.register("IssueQualityReport", IssueQualityReportSchema);
   registry.register("IssueQualityResponse", IssueQualityResponseSchema);
   registry.register("GateConfigEffectiveResponse", GateConfigEffectiveResponseSchema);
@@ -1048,6 +1056,36 @@ export function buildOpenApiSpec() {
     responses: {
       200: { description: "Private local branch analysis for MCP clients", content: { "application/json": { schema: LocalBranchAnalysisSchema } } },
       400: { description: "Invalid local branch analysis input" },
+      401: { description: "Unauthorized" },
+    },
+  });
+  // #9304: two pre-work-check POST routes. owner/repo are path params; the JSON body mirrors routes.ts's own
+  // validateLinkedIssueSchema / checkBeforeStartSchema; the 200 response mirrors each route's MCP outputSchema.
+  registry.registerPath({
+    method: "post",
+    path: "/v1/repos/{owner}/{repo}/validate-linked-issue",
+    summary: "Validate a planned change's linked issue before starting work",
+    request: {
+      params: z.object({ owner: z.string(), repo: z.string() }),
+      body: { content: { "application/json": { schema: ValidateLinkedIssueRequestSchema } } },
+    },
+    responses: {
+      200: { description: "Linked-issue validation report (found/multiplier status, blocking reason, reasons)", content: { "application/json": { schema: ValidateLinkedIssueResponseSchema } } },
+      400: { description: "Invalid validate-linked-issue request" },
+      401: { description: "Unauthorized" },
+    },
+  });
+  registry.registerPath({
+    method: "post",
+    path: "/v1/repos/{owner}/{repo}/check-before-start",
+    summary: "Pre-work duplicate/claim check before starting on an issue",
+    request: {
+      params: z.object({ owner: z.string(), repo: z.string() }),
+      body: { content: { "application/json": { schema: CheckBeforeStartRequestSchema } } },
+    },
+    responses: {
+      200: { description: "Pre-work check report (claim status, duplicate-cluster risk, recommendation, blockers)", content: { "application/json": { schema: CheckBeforeStartResponseSchema } } },
+      400: { description: "Invalid check-before-start request" },
       401: { description: "Unauthorized" },
     },
   });

--- a/test/unit/openapi.test.ts
+++ b/test/unit/openapi.test.ts
@@ -167,6 +167,26 @@ describe("OpenAPI contract", () => {
     }
   });
 
+  // #9304: the two pre-work-check POST routes are live in routes.ts and each backed by an MCP tool. Assert both
+  // are documented POST paths with a request body + 200 response, and their request/response component schemas
+  // carry the discriminating fields of each route's MCP tool shape.
+  it("documents the validate-linked-issue and check-before-start pre-work-check routes (#9304)", () => {
+    const spec = buildOpenApiSpec();
+    for (const path of ["/v1/repos/{owner}/{repo}/validate-linked-issue", "/v1/repos/{owner}/{repo}/check-before-start"]) {
+      expect(spec.paths[path]?.post?.requestBody).toBeDefined();
+      expect(spec.paths[path]?.post?.responses?.[200]).toBeDefined();
+    }
+    const schemas = spec.components?.schemas ?? {};
+    for (const name of ["ValidateLinkedIssueRequest", "ValidateLinkedIssueResponse", "CheckBeforeStartRequest", "CheckBeforeStartResponse"]) {
+      expect(schemas[name]).toBeDefined();
+    }
+    const props = (n: string) => (schemas[n] as { properties?: Record<string, unknown> })?.properties ?? {};
+    expect(props("ValidateLinkedIssueRequest")).toHaveProperty("issueNumber");
+    expect(props("ValidateLinkedIssueResponse")).toHaveProperty("multiplierStatus");
+    expect(props("CheckBeforeStartRequest")).toHaveProperty("plannedPaths");
+    expect(props("CheckBeforeStartResponse")).toHaveProperty("claimStatus");
+  });
+
   // #9309: the five /v1/loop/* idea/task-graph composer routes are each backed by an MCP tool whose Zod
   // input/output shapes already live in src/mcp/server.ts. Assert every route is a documented POST path whose
   // request/response components stay field-for-field in parity with those tool shapes, so a future field added


### PR DESCRIPTION
Closes #9304

## What

`POST /v1/repos/{owner}/{repo}/validate-linked-issue` and `.../check-before-start` are live, tested pre-work-check routes in `src/api/routes.ts` (each backed by an MCP tool — `loopover_validate_linked_issue` / `loopover_check_before_start`), but neither appeared in the OpenAPI spec.

- **`schemas.ts`** — `ValidateLinkedIssueRequest`/`Response` and `CheckBeforeStartRequest`/`Response`. Request schemas mirror the routes' own body schemas (`validateLinkedIssueSchema` / `checkBeforeStartSchema` — note `owner`/`repo` come from the path, not the body); response schemas mirror the MCP tools' `outputSchema`s (the source of truth for this data).
- **`spec.ts`** — `register` all four + `registerPath` both routes with `owner`/`repo` path params, a request body, and a 200 response (plus 400/401), following the existing request-body pattern used by the `/v1/loop/*` routes.
- **`openapi.test.ts`** — regression test asserting both paths are documented POSTs with a request body + 200 response and that their component schemas carry the discriminating tool-shape fields.
- Regenerated `apps/loopover-ui/public/openapi.json` (enforced by `ui:openapi:check`).

## Verification

`tsc --noEmit` clean; all 6 `openapi.test.ts` tests pass (including the new #9304 case); regeneration idempotent; LF endings; spec.ts/schemas.ts changes covered by the openapi test.