### PR TITLE
fix(selfhost): warn at boot when the public-score-terms allowlist is unset

### DIFF
--- a/src/queue-intelligence.ts
+++ b/src/queue-intelligence.ts
@@ -171,11 +171,39 @@ export async function analyzePRQueue(
  *  loopover itself), which the MCP read/actuation allowlists' analogous risk doesn't share.
  *  LOOPOVER_PUBLIC_SCORE_TERMS_ALLOWED_REPOS is the env var; config-as-code, never hardcoded per #config-as-code. */
 export function isPublicScoreTermSafeForRepo(env: { LOOPOVER_PUBLIC_SCORE_TERMS_ALLOWED_REPOS?: string }, repoFullName: string): boolean {
-  const entries = (env.LOOPOVER_PUBLIC_SCORE_TERMS_ALLOWED_REPOS ?? "")
+  return parsePublicScoreTermAllowedRepos(env.LOOPOVER_PUBLIC_SCORE_TERMS_ALLOWED_REPOS).includes(repoFullName.toLowerCase());
+}
+
+/** The parsed, lowercased allowlist entries. Takes the RAW env string (not an env object) so both callers can
+ *  share it regardless of how their own `env` parameter is typed — `exactOptionalPropertyTypes` forbids
+ *  re-wrapping a `string | undefined` back into an optional property. */
+function parsePublicScoreTermAllowedRepos(raw: string | undefined): string[] {
+  return (raw ?? "")
     .split(/[\s,]+/)
     .map((entry) => entry.trim().toLowerCase())
     .filter(Boolean);
-  return entries.includes(repoFullName.toLowerCase());
+}
+
+/**
+ * True when the bare-score exemption allowlist is EMPTY — i.e. the over-broad `\bscore\w*\b` check is enforced
+ * for every repo, so any AI review narrative using the ordinary word "score"/"scoring" has its WHOLE assessment
+ * discarded in favour of the generic "did not include a separate narrative summary" placeholder.
+ *
+ * This exists because the #public-score-terms-scoping fix is CONFIG-DEPENDENT: the code path shipped, but it is
+ * inert until an operator populates LOOPOVER_PUBLIC_SCORE_TERMS_ALLOWED_REPOS. Unset (the shipped default) the
+ * deployment silently behaves exactly like the pre-fix build that metagraphed#8038 was filed against, with no
+ * signal anywhere -- which is how that bug stayed live and "recurring" long after it was considered fixed. A
+ * unit test cannot catch this: it verifies the mechanism works WHEN enabled, never that a production env var
+ * was actually set. Warn-only, and deliberately not a hard boot failure: an empty allowlist is the correct,
+ * safe configuration for a deployment whose repos really do carry private trust/reward data -- the operator
+ * just needs to make that an informed choice rather than an unnoticed default. Pure predicate; the caller
+ * (server.ts) owns the actual shout, mirroring shouldWarnRagEmbedUnavailable.
+ */
+export function shouldWarnPublicScoreTermsAllowlistUnset(env: Record<string, string | undefined>): boolean {
+  // Same `Record<string, string | undefined>` shape as shouldWarnRagEmbedUnavailable so this accepts
+  // `process.env` directly at the boot-time call site (an optional-only object type does not structurally
+  // match Node's ProcessEnv).
+  return parsePublicScoreTermAllowedRepos(env.LOOPOVER_PUBLIC_SCORE_TERMS_ALLOWED_REPOS).length === 0;
 }
 
 /** `allowBareScoreTerm` (#public-score-terms-scoping, default false = today's unchanged behavior): the bare

--- a/src/server.ts
+++ b/src/server.ts
@@ -31,6 +31,7 @@ import {
   subscriptionCliEnv,
   withAiGenerationCapture,
 } from "./selfhost/ai";
+import { shouldWarnPublicScoreTermsAllowlistUnset } from "./queue-intelligence";
 import {
   cookieValue,
   credentialsToEnv,
@@ -609,6 +610,22 @@ async function main(): Promise<void> {
         provider: process.env.AI_PROVIDER,
         message:
           "LOOPOVER_REVIEW_RAG is enabled but no configured provider can serve embeddings — AI_EMBED_BASE_URL is unset and every AI_PROVIDER member is a CLI-subscription provider (they never embed). The RAG index will stay empty. Set AI_EMBED_BASE_URL (e.g. http://ollama:11434/v1 with AI_EMBED_MODEL=bge-m3) or add an OpenAI-compatible provider to the chain.",
+      }),
+    );
+  }
+  // #public-score-terms-scoping: the bare-`score` exemption is inert until an operator populates the repo
+  // allowlist, and unset (the shipped default) every AI review narrative that merely uses the word
+  // "score"/"scoring" is silently replaced by the generic "did not include a separate narrative summary"
+  // placeholder -- the exact metagraphed#8038 behaviour the exemption was written to fix. Shout once at boot so
+  // a config-dependent fix can't sit inert and unnoticed the way that one did. Warn-only: an empty allowlist is
+  // the correct setting for a deployment whose repos really do carry private trust/reward data.
+  if (shouldWarnPublicScoreTermsAllowlistUnset(process.env)) {
+    console.error(
+      JSON.stringify({
+        level: "error",
+        event: "selfhost_public_score_terms_allowlist_unset",
+        message:
+          "LOOPOVER_PUBLIC_SCORE_TERMS_ALLOWED_REPOS is unset, so the bare-\"score\" public-comment check is enforced for every repo. Any AI review whose narrative uses the ordinary word \"score\"/\"scoring\" will have its WHOLE summary dropped and replaced by the generic no-narrative placeholder. Set it to the repos whose own public schema legitimately uses score vocabulary (e.g. JSONbored/metagraphed). Explicit phrases (\"trust score\", \"reward\", wallet/hotkey/seed phrase, ...) stay blocked everywhere regardless.",
       }),
     );
   }

--- a/test/unit/queue-intelligence.test.ts
+++ b/test/unit/queue-intelligence.test.ts
@@ -3,6 +3,7 @@ import {
   analyzePRQueue,
   generatePublicComment,
   isPublicScoreTermSafeForRepo,
+  shouldWarnPublicScoreTermsAllowlistUnset,
   sanitizePublicComment,
   FORBIDDEN_PUBLIC_COMMENT_WORDS,
 } from "../../src/queue-intelligence";
@@ -420,5 +421,38 @@ describe("isPublicScoreTermSafeForRepo (#public-score-terms-scoping)", () => {
   it("denies a repo NOT present in the list — no '*'/'all' wildcard escape hatch, unlike the MCP allowlists", () => {
     const env = { LOOPOVER_PUBLIC_SCORE_TERMS_ALLOWED_REPOS: "*" };
     expect(isPublicScoreTermSafeForRepo(env, "JSONbored/loopover")).toBe(false);
+  });
+});
+
+// The #public-score-terms-scoping fix is CONFIG-DEPENDENT: the code path shipped, but stays inert until an
+// operator sets the env var, and unset the deployment behaves exactly like the pre-fix build metagraphed#8038
+// was filed against — every AI review narrative using the ordinary word "score"/"scoring" silently loses its
+// WHOLE summary, with no signal anywhere. No unit test can assert a production env var was set, so the boot
+// path shouts instead; these pin the predicate that drives that shout.
+describe("shouldWarnPublicScoreTermsAllowlistUnset", () => {
+  it("warns when the allowlist is unset, empty, or only separators (the inert-fix states)", () => {
+    expect(shouldWarnPublicScoreTermsAllowlistUnset({})).toBe(true);
+    expect(shouldWarnPublicScoreTermsAllowlistUnset({ LOOPOVER_PUBLIC_SCORE_TERMS_ALLOWED_REPOS: "" })).toBe(true);
+    expect(shouldWarnPublicScoreTermsAllowlistUnset({ LOOPOVER_PUBLIC_SCORE_TERMS_ALLOWED_REPOS: "   " })).toBe(true);
+    expect(shouldWarnPublicScoreTermsAllowlistUnset({ LOOPOVER_PUBLIC_SCORE_TERMS_ALLOWED_REPOS: " , ,  " })).toBe(true);
+  });
+
+  it("stays quiet once at least one repo is configured", () => {
+    expect(shouldWarnPublicScoreTermsAllowlistUnset({ LOOPOVER_PUBLIC_SCORE_TERMS_ALLOWED_REPOS: "JSONbored/metagraphed" })).toBe(false);
+    expect(
+      shouldWarnPublicScoreTermsAllowlistUnset({ LOOPOVER_PUBLIC_SCORE_TERMS_ALLOWED_REPOS: "JSONbored/loopover, JSONbored/metagraphed" }),
+    ).toBe(false);
+  });
+
+  // The warning and the exemption must agree on what "configured" means, or the shout could fire for a
+  // deployment that IS configured (noise) or stay silent for one that is not (the failure this exists to catch).
+  it("agrees with isPublicScoreTermSafeForRepo about what counts as configured", () => {
+    const env = { LOOPOVER_PUBLIC_SCORE_TERMS_ALLOWED_REPOS: "JSONbored/metagraphed" };
+    expect(shouldWarnPublicScoreTermsAllowlistUnset(env)).toBe(false);
+    expect(isPublicScoreTermSafeForRepo(env, "JSONbored/metagraphed")).toBe(true);
+    // "*" parses to a non-empty entry, so the warning is silent — but it grants NO repo the exemption.
+    const wildcard = { LOOPOVER_PUBLIC_SCORE_TERMS_ALLOWED_REPOS: "*" };
+    expect(shouldWarnPublicScoreTermsAllowlistUnset(wildcard)).toBe(false);
+    expect(isPublicScoreTermSafeForRepo(wildcard, "JSONbored/loopover")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Closes part of #9433.

The `#public-score-terms-scoping` fix is **config-dependent**: the code path shipped and is correctly wired at `ai-review.ts` (`allowBareScoreTerm: isPublicScoreTermSafeForRepo(env, input.repoFullName)`), but it stays inert until an operator sets `LOOPOVER_PUBLIC_SCORE_TERMS_ALLOWED_REPOS`.

Unset is the shipped default, and it was the state found in production. In that state the allowlist fails closed, so `BARE_SCORE_TERM_PATTERN = /\bscore\w*\b/i` is enforced for every repo. `sanitizePublicComment` **throws** on a match and `toPublicSafe` catches it and returns `null` — all-or-nothing — so any AI review narrative containing **score / scores / scoring / scored** had its **entire assessment discarded** in favour of the generic "did not include a separate narrative summary" placeholder. Nits survived, because those are filtered individually.

That is exactly the behaviour `composeAdvisoryNotes`' own doc comment already documents:

> "Metagraphed#8038-class bug: without this, ANY review of code with a legitimately-public `score`-named field ... had its entire narrative assessment silently discarded in favor of the generic 'did not include a separate narrative summary' fallback -- observed live, recurring."

So the fix shipped, was considered done, and then sat inert with no signal anywhere.

## Why a warning rather than a test

No unit test can catch this class. The existing tests verify the mechanism works *when enabled*; they cannot assert that a production env var was actually set. The failure mode is a correct code path plus an unset variable, which is invisible to CI by construction. Shouting once at boot is the only place this is observable.

## Design

Mirrors the existing `shouldWarnRagEmbedUnavailable` precedent exactly: a pure predicate in `queue-intelligence.ts` (next to the exemption it guards, so the two can never disagree about what "configured" means), and a single structured `console.error` at the boot site in `server.ts`.

**Warn-only, deliberately not a hard boot failure.** An empty allowlist is the *correct* configuration for a deployment whose repos genuinely carry private trust/reward data — the operator just needs to make that an informed choice rather than an unnoticed default.

## Test plan

- [x] New tests pin the inert-fix states (unset / empty / whitespace / separators-only) and the configured states
- [x] A test pins that the warning and `isPublicScoreTermSafeForRepo` agree on what counts as configured — if they drift, the shout either fires for a configured deployment (noise) or stays silent for an unconfigured one (the failure it exists to catch)
- [x] Covers the `"*"` case: it parses as a non-empty entry so the warning is silent, but it grants **no** repo the exemption (no wildcard escape hatch)
- [x] `npm run typecheck` clean
- [x] Full local suite: **1242 files / 23,358 tests, 0 failures**

## Note on scope

An earlier draft of this branch also changed `hasPublicReviewAssessment` to reject the persisted no-narrative placeholder. That was **reverted**: it made the orchestration hold PRs for manual review and discard the model's nits, which two existing tests correctly pin as unwanted. See the correction on #9432.