### PR TITLE
hotfix(manifest): restore the loopover-ui path rename and bundled-fallback sync lost in #9455's squash-merge

### DIFF
--- a/.loopover.yml
+++ b/.loopover.yml
@@ -113,20 +113,20 @@ settings:
   draftPrClosePolicy: close
   # Before/after screenshot-table gate (#2006), re-enabled after the 2026-07-26 false-close incident --
   # config-as-code this time so the scoping survives DB moves and is reviewable in git history. The incident:
-  # the gate was enabled with over-broad path scoping that swept in apps/gittensory-ui/public/**, and
+  # the gate was enabled with over-broad path scoping that swept in apps/loopover-ui/public/**, and
   # public/openapi.json is a GENERATED artifact this repo's own contribution rules require regenerating on
   # every API change (`npm run ui:openapi`) -- so perfectly good non-visual API PRs were auto-closed for
   # missing screenshots (5 PRs recovered by hand). whenPaths below therefore names only paths whose changes
-  # are genuinely visual, and deliberately EXCLUDES apps/gittensory-ui/public/** (generated + static assets)
+  # are genuinely visual, and deliberately EXCLUDES apps/loopover-ui/public/** (generated + static assets)
   # and src/routeTree.gen.ts (generated, sits outside routes/). A PR touching only excluded paths is simply
   # out of scope -- the gate never evaluates it.
   screenshotTableGate:
     enabled: true
     action: close
     whenPaths:
-      - "apps/gittensory-ui/src/components/**"
-      - "apps/gittensory-ui/src/routes/**"
-      - "apps/gittensory-ui/src/styles.css"
+      - "apps/loopover-ui/src/components/**"
+      - "apps/loopover-ui/src/routes/**"
+      - "apps/loopover-ui/src/styles.css"
   # Agent-layer autonomy dial (#773): without this block every action class defaults to "observe"
   # (deny-by-default) -- loopover had NO repository_settings DB row at all, so merge/close/approve
   # actions were silently never taken regardless of review verdict (#6401, #6402 sat fully reviewed,

--- a/src/config/loopover-repo-focus-manifest.ts
+++ b/src/config/loopover-repo-focus-manifest.ts
@@ -115,6 +115,22 @@ settings:
         trustMaintainerAuthoredIssueForReward: true
   reviewEvasionProtection: close
   draftPrClosePolicy: close
+  # Before/after screenshot-table gate (#2006), re-enabled after the 2026-07-26 false-close incident --
+  # config-as-code this time so the scoping survives DB moves and is reviewable in git history. The incident:
+  # the gate was enabled with over-broad path scoping that swept in apps/loopover-ui/public/**, and
+  # public/openapi.json is a GENERATED artifact this repo's own contribution rules require regenerating on
+  # every API change (\`npm run ui:openapi\`) -- so perfectly good non-visual API PRs were auto-closed for
+  # missing screenshots (5 PRs recovered by hand). whenPaths below therefore names only paths whose changes
+  # are genuinely visual, and deliberately EXCLUDES apps/loopover-ui/public/** (generated + static assets)
+  # and src/routeTree.gen.ts (generated, sits outside routes/). A PR touching only excluded paths is simply
+  # out of scope -- the gate never evaluates it.
+  screenshotTableGate:
+    enabled: true
+    action: close
+    whenPaths:
+      - "apps/loopover-ui/src/components/**"
+      - "apps/loopover-ui/src/routes/**"
+      - "apps/loopover-ui/src/styles.css"
   # Agent-layer autonomy dial (#773): without this block every action class defaults to "observe"
   # (deny-by-default) -- loopover had NO repository_settings DB row at all, so merge/close/approve
   # actions were silently never taken regardless of review verdict (#6401, #6402 sat fully reviewed,


### PR DESCRIPTION
## What broke

#9455 (re-enable the screenshot-table gate) had two commits on its branch: the initial add, and a follow-up fixup that (a) corrected `whenPaths` from the pre-rename `apps/gittensory-ui` to `apps/loopover-ui`, and (b) synced `src/config/loopover-repo-focus-manifest.ts` (the bundled fallback manifest) to match `.loopover.yml`, since `npm run manifest:drift-check` requires the two to agree.

The merged commit on `main` contains **only the first commit's content** — both follow-up corrections were lost in the squash.

## Impact — this blocks CI repo-wide

- `.loopover.yml`'s `screenshotTableGate.whenPaths` still names `apps/gittensory-ui/**`, which was renamed away on 2026-07-14. The gate has been live but **silently inert** on every real PR since merging — ironically the exact "config-dependent fix ships inert" failure mode tracked in #9433.
- `src/config/loopover-repo-focus-manifest.ts` has **no** `screenshotTableGate` block at all, so it no longer matches `.loopover.yml`. `npm run manifest:drift-check` — a required step in `test:ci` — now fails on **every** PR against this repo, including the two I have open right now (#9459, and this one's sibling investigation).

## Fix

Restores both corrections: the `apps/loopover-ui` path prefix in `.loopover.yml`, and the matching `screenshotTableGate` block in the bundled fallback.

Verified:
- `npm run manifest:drift-check` passes clean
- The six whenPaths cases (openapi.json excluded, routeTree.gen.ts excluded, components/routes/styles.css in scope) re-checked against the engine's own `matchesAny`
- `npm run typecheck` clean

This is a maintainer hotfix for a self-inflicted CI break, filed as its own PR since it's unrelated to my other open PR and needs to land first.