### PR TITLE
chore(infra): cut the Cloudflare Worker's D1 binding over to a fresh loopover database

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -290,9 +290,18 @@
   ],
   "d1_databases": [
     {
+      // #9435/#9459 cutover (2026-07-27): the previous database_id (b2c79dd6-7771-4b1f-aa6b-085d5f3e9528,
+      // internally named "gittensory" pre-rename) had grown to 8.96 GB of its 10 GB cap -- D1 never runs
+      // VACUUM (cloudflare/workerd#1618), so a large batch of now-pruned rows (contributor-decision-pack,
+      // #9459) left the file bloated with reusable-but-never-reclaimed free pages that would only grow back.
+      // This id (da7537cc-ab54-4dc1-8c38-2713f03f1130) is a fresh database, correctly named "loopover"
+      // throughout (matching the 2026-07-14 repo/app rename), populated from a verified export of the old
+      // database taken AFTER the decision-pack prune: every table's row count matched exactly except for
+      // ordinary live-write drift on actively-written tables (webhook/audit/usage logs), confirmed against
+      // d1_migrations (202/202) and the retention-pruned signal type (213/213 rows).
       "binding": "DB",
       "database_name": "loopover",
-      "database_id": "b2c79dd6-7771-4b1f-aa6b-085d5f3e9528",
+      "database_id": "da7537cc-ab54-4dc1-8c38-2713f03f1130",
       "migrations_dir": "migrations",
     },
   ],


### PR DESCRIPTION
## Why

The Worker's D1 database (`b2c79dd6-7771-4b1f-aa6b-085d5f3e9528`, internally still named `gittensory` from before the 2026-07-14 repo/app rename) had grown to **8.96 GB of its 10 GB cap**. #9459 found and fixed the dominant cause — `contributor-decision-pack` signal snapshots accumulating unbounded (6.3 GB / 71% of the file) — and I pruned the already-accumulated 18,336 stale rows directly against the live database.

That prune shrank the *live* size (8.96 GB → 2.24 GB, confirmed via `wrangler d1 info`), which was better than expected — but D1 does not run `VACUUM` ([cloudflare/workerd#1618](https://github.com/cloudflare/workerd/issues/1618)), so the file was never guaranteed to fully return to its logical size, and any future large one-off bloat has the same risk. Since a rename was overdue anyway (`gittensory` → `loopover`, matching the 2026-07-14 app rename), this cuts over to a fresh, correctly-named database rather than just living with the old one.

## What I verified before opening this

- **Full 103-table row-count sweep**, source (`gittensory`) vs new (`loopover`): every mismatch is explained by ordinary live-write drift on actively-written tables (webhook/audit/usage logs — the source database never stopped taking writes between the export and the comparison). One delta (`github_rate_limit_observations`, exactly −250,000) is the automatic hourly `retention.prune` job's per-table cap firing once on the source after the export — not data loss.
- **`d1_migrations`**: 202/202 rows, same max id, on both databases.
- **`contributor-decision-pack`** (the table #9459 fixed): 213/213 rows on the new database, exactly one row per contributor.
- **206 oversized rows** (`payload_json` large enough to exceed D1's ~100KB single-statement text limit, `SQLITE_TOOBIG`) were re-imported via a chunked `INSERT` + `payload_json ||= UPDATE` sequence instead of a raw literal insert. I verified this chunking byte-identical against the source data via a local SQLite reconstruction test before running it against the real database.
- **`cf-typegen:check`**: unaffected — the binding name/shape is unchanged, only the `database_id`.
- **typecheck**: clean.
- Grepped the whole repo: `wrangler.jsonc` is the only file referencing the old `database_id`.

## What this does NOT do

- Does not delete the old database. It stays intact and readable until this is confirmed working in production.
- Does not touch the ORB server (`edge-nl-01`) — that deployment uses its own Postgres, unrelated to this Cloudflare D1.
- Does not update `CLOUDFLARE_D1_MONITOR_DATABASE_ID` (the #9458 size-alerting probe) — that's an env var on the self-host side, currently unset, and is a separate follow-up once this cutover is confirmed.

## Deploy mechanics — please read before merging

This repo's Worker (`loopover-api`) deploys via **Cloudflare Workers Builds**, git-connected to `main` — merging this PR triggers a live production deploy pointing the Worker at the new database. There is a brief window during the deploy where in-flight webhook-relay writes could be affected. I'm holding this for an explicit go rather than merging it myself, given it's the highest-blast-radius change in this batch.

Refs #9435