### PR TITLE
fix(content-lane,federated,apr): close the seven pre-flag defects — scrub bypass, probe OOM, self-corroboration, identity farming, peer takeover, tenant binding (#9490)

### DIFF
--- a/src/orb/apr-repo-binding.ts
+++ b/src/orb/apr-repo-binding.ts
@@ -1,0 +1,31 @@
+// Trusted server-side APR repo→customer binding lookup for transfer authorization (#9490).
+//
+// `installationId`, `repoFullName` and `newOwner` are ALL caller-supplied on the transfer route, so without a
+// server-side record binding an APR repo to the customer it belongs to, any authorized caller could transfer
+// any completed APR repo — including another customer's — to themselves the moment #7664 starts persisting
+// completion records. This gate exists NOW, while the route is still inert, precisely so completion landing
+// later cannot silently arm an unauthorized-transfer primitive.
+//
+// Until #7664 persists a binding record, this ALWAYS returns null (fail closed) and
+// `requestAprRepoTransfer` rejects on a null binding. A client-supplied binding must never substitute for
+// this — same contract, same replace-the-body-keep-the-signature instruction, and the same reasoning as
+// ./apr-idea-completion.ts (whose shape this module deliberately mirrors, down to living in its own file so
+// the route's trusted lookup is replaceable at the import seam).
+
+export type AprRepoBinding = {
+  /** The GitHub login of the customer whose OAuth session created (or owns) this APR repo. */
+  customerLogin: string;
+  /** The installation the APR repo actually belongs to. */
+  installationId: number;
+};
+
+export type AprRepoBindingLookup = (env: Env, input: { repoFullName: string }) => Promise<AprRepoBinding | null>;
+
+/**
+ * Resolve the tenant binding for an APR repo (#9490). Fail-closed until a persisted record exists: today's
+ * body always returns null. Declared return is `AprRepoBinding | null` so a future persisted lookup (and test
+ * doubles) can return a real binding; a null always rejects the transfer.
+ */
+export async function loadAprRepoBinding(_env: Env, _input: { repoFullName: string }): Promise<AprRepoBinding | null> {
+  return null;
+}

--- a/src/orb/apr-repo-transfer.ts
+++ b/src/orb/apr-repo-transfer.ts
@@ -13,10 +13,14 @@ import { upsertRepositorySettings } from "../db/repositories";
 import { createInstallationToken } from "../github/app";
 import { githubHeaders, timeoutFetch } from "../github/client";
 import { loadAprIdeaCompletion, type AprIdeaCompletionLookup } from "./apr-idea-completion";
+import { loadAprRepoBinding as loadAprRepoBindingDefault, type AprRepoBinding, type AprRepoBindingLookup } from "./apr-repo-binding";
 // `Env` is the ambient Cloudflare Worker binding interface (worker-configuration.d.ts) — a global, not imported.
 
 export type { AprIdeaCompletionLookup, AprIdeaCompletionLookupInput } from "./apr-idea-completion";
 export { loadAprIdeaCompletion } from "./apr-idea-completion";
+
+export type { AprRepoBinding, AprRepoBindingLookup } from "./apr-repo-binding";
+export { loadAprRepoBinding } from "./apr-repo-binding";
 
 /**
  * Result of initiating an APR repo transfer.
@@ -54,9 +58,35 @@ export type RequestAprRepoTransferInput = {
  *   GitHub accepted a *pending* transfer (see {@link AprRepoTransferResult}), never "transfer done".
  */
 export type RequestAprRepoTransferResult =
-  | { status: "rejected"; reason: "idea_not_complete" }
+  | { status: "rejected"; reason: "idea_not_complete" | AprRepoTransferBindingRejection }
   | { status: "initiated"; transfer: Extract<AprRepoTransferResult, { initiated: true }> }
   | { status: "failed"; transfer: Extract<AprRepoTransferResult, { initiated: false }> };
+
+/** #9490: the three ways the tenant binding can refuse a transfer. Distinct reasons on purpose — an operator
+ *  debugging a refused transfer needs to know WHICH leg failed, and none of them leak anything the caller did
+ *  not already supply. */
+export type AprRepoTransferBindingRejection =
+  /** No server-side binding record exists for this repo at all — either not an APR repo, or #7664 has not
+   *  persisted its record. Fail closed: an unbound repo is never transferable. */
+  | "repo_not_apr_bound"
+  /** The caller-supplied `newOwner` is not the customer this APR repo is bound to. The whole point: a transfer
+   *  may only ever move a repo to its OWN customer, never to whoever asked. */
+  | "new_owner_not_bound_customer"
+  /** The caller-supplied `installationId` is not the installation the binding records for this repo. */
+  | "installation_not_bound";
+
+/** #9490: pure tenant-binding check, separated from the completion gate so each is independently testable. */
+export function evaluateAprRepoTransferBinding(
+  input: Pick<RequestAprRepoTransferInput, "installationId" | "repoFullName" | "newOwner">,
+  binding: AprRepoBinding | null,
+): { allowed: true } | { allowed: false; reason: AprRepoTransferBindingRejection } {
+  if (binding === null) return { allowed: false, reason: "repo_not_apr_bound" };
+  if (binding.customerLogin.toLowerCase() !== input.newOwner.trim().toLowerCase()) {
+    return { allowed: false, reason: "new_owner_not_bound_customer" };
+  }
+  if (binding.installationId !== input.installationId) return { allowed: false, reason: "installation_not_bound" };
+  return { allowed: true };
+}
 
 /** Decide whether a customer may request an APR repo transfer right now (#7742). Pure and deterministic. */
 export function evaluateAprRepoTransferRequestEligibility(input: {
@@ -116,6 +146,8 @@ export async function requestAprRepoTransfer(
       newOwner: string,
     ) => Promise<AprRepoTransferResult>;
     loadCompletion?: AprIdeaCompletionLookup;
+    /** #9490 seam: the tenant-binding lookup; injectable for tests, fail-closed default. */
+    loadBinding?: AprRepoBindingLookup;
     /** #7741 deliverable 2 seam: how to freeze AMS dispatch once a transfer is pending. Injectable for tests. */
     pauseDispatch?: (env: Env, repoFullName: string) => Promise<void>;
   } = {},
@@ -124,6 +156,15 @@ export async function requestAprRepoTransfer(
   const { ideaComplete } = await loadCompletion(env, { repoFullName: input.repoFullName, ideaId: input.ideaId });
   const eligibility = evaluateAprRepoTransferRequestEligibility({ ideaComplete });
   if (!eligibility.allowed) return { status: "rejected", reason: eligibility.reason };
+
+  // #9490: the tenant binding gates AFTER completion (cheapest rejection first is irrelevant here -- both are
+  // local lookups -- but completion-first keeps today's observable behaviour byte-identical: an incomplete
+  // idea still rejects with the same reason it always did) and BEFORE any GitHub call: a transfer request
+  // that fails authorization must never reach GitHub at all, not even to fail there.
+  const loadBinding = options.loadBinding ?? loadAprRepoBindingDefault;
+  const binding = await loadBinding(env, { repoFullName: input.repoFullName });
+  const bindingCheck = evaluateAprRepoTransferBinding(input, binding);
+  if (!bindingCheck.allowed) return { status: "rejected", reason: bindingCheck.reason };
 
   const initiate = options.initiate ?? initiateAprRepoTransfer;
   const transfer = await initiate(env, input.installationId, input.repoFullName, input.newOwner);
@@ -217,7 +258,21 @@ export async function probeAprRepoTransfer(
     const response = await timeoutFetch(`https://api.github.com/repos/${transfer.repoFullName}`, {
       headers: githubHeaders({ token }),
     });
-    if (response.status === 404) return { state: "access_departed" };
+    // #9490: a plain 404 at the original path is AMBIGUOUS -- ownership moved away, OR the repo was simply
+    // deleted / the App uninstalled. Recording "accepted_departed" (a terminal SUCCESS) for a deleted repo is
+    // a false outcome in the transfer ledger, so departure is only declared once the repo demonstrably
+    // resolves under the TARGET owner. When that corroboration cannot be obtained (a private repo the App can
+    // no longer see), the transfer stays "pending" and the existing expiry clock resolves it -- a bounded,
+    // late, truthful answer over a fast wrong one.
+    if (response.status === 404) {
+      const repoName = transfer.repoFullName.split("/")[1] ?? "";
+      const relocated = repoName ? await timeoutFetch(`https://api.github.com/repos/${transfer.newOwner}/${repoName}`, { headers: githubHeaders({ token }) }).catch(() => null) : null;
+      if (relocated?.ok) {
+        const relocatedBody = (await relocated.json().catch(() => null)) as { owner?: { login?: string } } | null;
+        if (relocatedBody?.owner?.login?.toLowerCase() === transfer.newOwner.toLowerCase()) return { state: "access_departed" };
+      }
+      return { state: "pending" };
+    }
     if (!response.ok) return { state: "pending" };
     const body = (await response.json().catch(() => null)) as { owner?: { login?: string } } | null;
     const owner = body?.owner?.login;

--- a/src/orb/federated-import.ts
+++ b/src/orb/federated-import.ts
@@ -47,6 +47,10 @@ const MAX_BUNDLE_AGE_MS = 7 * 86_400_000;
  *  self-hosted instances without opening a meaningful backdating/replay window. */
 const MAX_CLOCK_SKEW_MS = 5 * 60_000;
 
+/** #9490: hard cap on `instanceId` length -- see isBundleBodyShaped's own comment for why this is a
+ *  persistence-integrity bound, not a cosmetic one. */
+export const MAX_INSTANCE_ID_CHARS = 128;
+
 /** How many DISTINCT `instanceId`s a single verifying key may ever contribute to the accepted set (#9148).
  *  Without this, one allowlisted key can mint an unbounded number of fabricated instanceIds and dominate the
  *  peer median outright — the allowlist bounds which KEYS are trusted, not how many PEERS a key may claim to
@@ -90,6 +94,11 @@ export type FederatedRejectionReason =
    *  otherwise-valid bundle (#9148, the persisted high-water mark). Only ever produced by
    *  {@link applyFederatedPeerWatermarks}, which is the one place this pipeline touches the DB. */
   | "replayed_or_rollback"
+  /** #9490: this `instanceId` is already bound to a DIFFERENT verifying key. First-writer-wins: the id was
+   *  admitted under one key's fingerprint, and a bundle for the same id verifying under any other allowlisted
+   *  key is rejected outright — the takeover primitive (shadow an honest peer's id, ratchet its watermark,
+   *  suppress its genuine bundles) must not exist even between two currently-trusted keys. */
+  | "instance_key_conflict"
   /** This `instanceId` is new, and admitting it would push its verifying key over MAX_INSTANCES_PER_KEY —
    *  the per-key Sybil cap (#9148). Only ever produced by {@link applyFederatedPeerWatermarks}. */
   | "sybil_cap_exceeded";
@@ -136,6 +145,13 @@ function isBundleBodyShaped(bundle: FederatedSignalBundle): boolean {
   const nullableNumeric = (value: unknown): boolean => value === null || numeric(value);
   return (
     typeof bundle.instanceId === "string" &&
+    // #9490: bounded, because instanceIds are PERSISTED into the single system_flags peer-state blob. Nothing
+    // else bounded them, and the pull body cap is 1 MB total -- so roughly 3-4 bundles carrying ~600 KB ids
+    // pushed that blob past D1's ~2 MB value limit, writeFederatedPeerState swallowed the failure, and replay/
+    // rollback watermarks silently stopped persisting for EVERY peer. 128 chars fits every reasonable id
+    // scheme (a UUID is 36, a hex fingerprint 64) with headroom.
+    bundle.instanceId.length > 0 &&
+    bundle.instanceId.length <= MAX_INSTANCE_ID_CHARS &&
     typeof bundle.generatedAt === "string" &&
     typeof bundle.signature === "string" &&
     numeric(bundle.windowDays) &&
@@ -345,7 +361,22 @@ async function writeFederatedPeerState(db: D1Database, state: FederatedPeerState
     .prepare("INSERT OR REPLACE INTO system_flags (key, value, updated_at) VALUES (?, ?, CURRENT_TIMESTAMP)")
     .bind(FEDERATED_PEER_STATE_FLAG_KEY, JSON.stringify(state))
     .run()
-    .catch(() => undefined);
+    .catch((error: unknown) => {
+      // #9490: still fail-open (a write failure must never fail the sync tick), but LOUDLY. This blob carries
+      // the replay/rollback watermarks and the Sybil cap's instance ledger for every peer -- a persistent
+      // write failure silently regresses all of #9148's protections, which an operator needs to SEE, not
+      // infer. error level so the structured-log forwarder picks it up, same convention as
+      // regate_repair_exhausted.
+      console.error(
+        JSON.stringify({
+          level: "error",
+          event: "federated_peer_state_write_failed",
+          instances: Object.keys(state).length,
+          approxBytes: JSON.stringify(state).length,
+          message: error instanceof Error ? error.message.slice(0, 200) : String(error).slice(0, 200),
+        }),
+      );
+    });
 }
 
 /**
@@ -394,6 +425,19 @@ export async function applyFederatedPeerWatermarks(
     const generatedAtMs = Date.parse(bundle.generatedAt); // already validated finite by importPeerBundles' rejectionFor
     const existing = state[bundle.instanceId];
     if (existing) {
+      // #9490: an instanceId is BOUND to the first key that verified it. Without this, any hostile-but-
+      // allowlisted peer B could claim honest peer A's id: shadow A's bundle in-batch (last-wins dedup keys
+      // on id alone), overwrite the watermark entry's keyFingerprint, then ratchet lastGeneratedAtMs forward
+      // so A's genuine bundles reject as replayed_or_rollback forever -- targeted suppression plus stat
+      // replacement, and a bypass of B's own MAX_INSTANCES_PER_KEY cap (only NEW ids are counted against it).
+      // That sits squarely inside #9148's declared threat model: bound the damage one still-trusted key can
+      // do. The binding is first-writer-wins and permanent for the life of the state entry; a peer that
+      // legitimately rotates keys re-enters under a new id (or after PEER_STATE_PRUNE_AFTER_MS frees the old
+      // one), which is the cheap, honest path -- as opposed to any takeover path existing at all.
+      if (existing.keyFingerprint !== fingerprint) {
+        rejected.push(reject(bundle.instanceId, "instance_key_conflict"));
+        continue;
+      }
       if (generatedAtMs <= existing.lastGeneratedAtMs) {
         rejected.push(reject(bundle.instanceId, "replayed_or_rollback"));
         continue;

--- a/src/review/content-lane/orchestrator.ts
+++ b/src/review/content-lane/orchestrator.ts
@@ -72,8 +72,34 @@ export function diffAppendedSurfaceEntries(headRaw: string | null, baseRaw: stri
   const headEntries = surfacesOf(safeParseJson(headRaw), field);
   if (headEntries === null) return null;
   const baseEntries = surfacesOf(safeParseJson(baseRaw), field) ?? [];
-  const baseKeys = new Set(baseEntries.map((entry) => JSON.stringify(entry)));
-  return headEntries.filter((entry) => !baseKeys.has(JSON.stringify(entry)));
+  const baseKeys = new Set(baseEntries.map((entry) => canonicalEntryKey(entry)));
+  return headEntries.filter((entry) => !baseKeys.has(canonicalEntryKey(entry)));
+}
+
+/**
+ * #9490: entry identity, KEY-ORDER INVARIANT. Both structural diffs below used raw `JSON.stringify(entry)` as
+ * the identity key, and JSON.stringify preserves insertion order -- so reordering an existing entry's keys
+ * (`{url, kind}` -> `{kind, url}`) read as a FRESH append while simultaneously removing the entry's prior self
+ * from survivingExistingEntries' scope, taking it out of the duplicate check too. That is a recipe for
+ * unbounded content-free auto-merged registry PRs: each one "contributes" a reorder, farms a merge, and leaves
+ * the registry byte-different but semantically identical. Sorting keys recursively makes a reorder read as
+ * exactly what it is -- zero appended entries. Arrays keep their order (order IS meaning there, same rule as
+ * decision-record.ts's canonicalJson).
+ */
+export function canonicalEntryKey(entry: unknown): string {
+  return JSON.stringify(sortKeysDeep(entry));
+}
+
+function sortKeysDeep(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortKeysDeep);
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.keys(value as Record<string, unknown>)
+        .sort()
+        .map((key) => [key, sortKeysDeep((value as Record<string, unknown>)[key])]),
+    );
+  }
+  return value;
 }
 
 /**
@@ -100,8 +126,10 @@ export function survivingExistingEntries(headRaw: string | null, baseRaw: string
   const headEntries = surfacesOf(safeParseJson(headRaw), field);
   if (headEntries === null) return [];
   const baseEntries = surfacesOf(safeParseJson(baseRaw), field) ?? [];
-  const headKeys = new Set(headEntries.map((entry) => JSON.stringify(entry)));
-  return baseEntries.filter((entry) => headKeys.has(JSON.stringify(entry)));
+  // #9490: same canonical key as diffAppendedSurfaceEntries, and for the same reason -- a key-reordered entry
+  // must still count as "surviving" so its identity stays inside the duplicate check's scope.
+  const headKeys = new Set(headEntries.map((entry) => canonicalEntryKey(entry)));
+  return baseEntries.filter((entry) => headKeys.has(canonicalEntryKey(entry)));
 }
 
 function fromProvider(assessment: ProviderAssessment): SurfaceReviewResult {
@@ -212,15 +240,38 @@ function pickAggregateAssessment(assessments: Assessment[]): Assessment {
  * for review instead. `makeSurfaceEntryVerifier` is itself written not to throw, so this is a belt-and-braces
  * guard against a future/third-party verifier that is less careful.
  */
+/**
+ * #9490: hard ceiling on live verifications per review run. Each verification fetches up to 2 URLs, each
+ * following up to 5 hops with a 10s per-hop timeout -- so an uncapped run over a spec with
+ * `maxAppendedEntries: Infinity` (metagraphed's documented policy) let a 500-entry PR command thousands of
+ * outbound subrequests from the bot: a request-amplification primitive, and on Workers a subrequest-exhaustion
+ * path that converts into bulk `probe_fetch_failed` holds for everyone else in the isolate. Ten matches
+ * source-evidence.ts's own fan-out cap. Entries past the cap are HELD for a human, never merged unverified --
+ * the cap bounds spend, it must not become a way to sneak entry #11 through unprobed.
+ */
+export const MAX_VERIFIED_ENTRIES_PER_RUN = 10;
+
 async function verifyMergedEntries(
   staticAssessments: Assessment[],
   appendedEntries: readonly unknown[],
   verifyEntry: SurfaceReviewInput["verifyEntry"],
 ): Promise<Assessment[]> {
   if (!verifyEntry) return staticAssessments;
+  let verificationsStarted = 0;
   return await Promise.all(
     staticAssessments.map(async (assessment, idx) => {
       if (assessment.verdict !== "merged") return assessment;
+      // Counted SYNCHRONOUSLY, before any await, so the concurrent map cannot race the budget check --
+      // .map's callbacks run their synchronous prefix in order, so exactly the first N merged entries verify.
+      if (verificationsStarted >= MAX_VERIFIED_ENTRIES_PER_RUN) {
+        return {
+          verdict: "manual-review" as const,
+          summary: `This PR appends more than ${MAX_VERIFIED_ENTRIES_PER_RUN} entries needing live verification; this entry is past that per-run probe budget, so it is routed to review rather than accepted unverified.`,
+          candidate: assessment.candidate,
+          reason: "verification-capacity",
+        };
+      }
+      verificationsStarted += 1;
       try {
         return (await verifyEntry(appendedEntries[idx])) ?? assessment;
       } catch {

--- a/src/review/content-lane/registry-logic.ts
+++ b/src/review/content-lane/registry-logic.ts
@@ -282,9 +282,6 @@ export function computeGrounding(
   const sourceText = evidenceText(source);
   const allText = `${targetText}\n${sourceText}`;
 
-  const netuid = String(candidate?.netuid ?? "").trim();
-  const netuidMentioned = !!netuid && netuidGroundingRegex(netuid).test(allText);
-
   const sourceUrl =
     (candidate?.source_url as string) || (candidate?.source_urls as string[] | undefined)?.[0] || "";
   // A source that is the SAME resource as the url cannot independently corroborate the claim — owner +
@@ -296,6 +293,17 @@ export function computeGrounding(
   const targetKey = stripScheme(candidate?.url);
   const sourceKey = stripScheme(sourceUrl);
   const independentSource = !!sourceUrl && (targetKey == null || sourceKey == null || targetKey !== sourceKey);
+
+  // #9490: netuid was the one signal matched against `allText` -- which INCLUDES the submitted url's own page
+  // -- with no independence requirement, while owner and host both demand one. Since MIN_STRONG is 1, a
+  // submitter's own page asserting "netuid 64" passed grounding entirely self-corroborated. The netuid is the
+  // single highest-value claim here (it IS the subnet identity), so it now holds to the STRICTEST standard of
+  // the three: the mention must come from the INDEPENDENT source's own text, not merely coexist with one.
+  // (owner/host keep their existing allText/source semantics -- their tokens derive from URLs, not from the
+  // claim under test, so the self-corroboration loop this closes does not exist for them.)
+  const netuid = String(candidate?.netuid ?? "").trim();
+  const netuidMentioned = independentSource && !!netuid && netuidGroundingRegex(netuid).test(sourceText);
+
   const tokens = [...new Set([...ownerTokens(sourceUrl), ...ownerTokens(candidate?.url)])];
   const ownerMentioned = independentSource && tokens.some((t) => new RegExp(`\\b${escapeRe(t)}\\b`, "i").test(allText));
 
@@ -640,6 +648,15 @@ export function probeFunctionalSurface(
 ): { served: boolean; detail: string } {
   const k = String(kind);
   const ct = contentType ?? "";
+  // #9490: `ct` comes verbatim from the SUBMITTER'S OWN server, and the details below flow into a finding the
+  // wire marks `alreadyPublicSafe: true` -- the flag that skips sanitizeForCheckRun and the forbidden-terms
+  // scrub, on the stated invariant that surface-lane summaries "come solely from a fixed assessment
+  // vocabulary". Echoing the raw header made that invariant false: a PR author's server answering with an
+  // arbitrary Content-Type got its text posted verbatim by the bot. Only a strictly mime-shaped token
+  // (`type/subtype`, RFC 6838 charset) is ever echoed; anything else renders as "unrecognized". This is an
+  // ALLOWLIST match from the start of the header, not a scrub of it -- there is nothing a hostile header can
+  // contain that survives into the echo beyond word characters, dots, pluses and dashes.
+  const echoedCt = /^[\w.+-]{1,64}\/[\w.+-]{1,64}/.exec(ct.trim())?.[0] ?? (ct.trim() === "" ? "none" : "unrecognized");
   if (k === "openapi") {
     const looksSpec = /"(?:openapi|swagger)"\s*:/i.test(body) || /^\s*(?:openapi|swagger)\s*:/im.test(body);
     const hasPaths = /"paths"\s*:/i.test(body) || /^\s*paths\s*:/im.test(body);
@@ -649,11 +666,11 @@ export function probeFunctionalSurface(
   }
   if (k === "subnet-api") {
     const isJson = /\bjson\b/i.test(ct) || /^\s*[{[]/.test(body);
-    return isJson ? { served: true, detail: "json api surface" } : { served: false, detail: `not a json api surface (content-type:${ct || "none"})` };
+    return isJson ? { served: true, detail: "json api surface" } : { served: false, detail: `not a json api surface (content-type:${echoedCt})` };
   }
   if (k === "sse") {
     const served = /text\/event-stream/i.test(ct);
-    return { served, detail: served ? "text/event-stream" : `not an event stream (content-type:${ct || "none"})` };
+    return { served, detail: served ? "text/event-stream" : `not an event stream (content-type:${echoedCt})` };
   }
   return { served: true, detail: "n/a" };
 }

--- a/src/review/content-lane/surface-verification.ts
+++ b/src/review/content-lane/surface-verification.ts
@@ -96,6 +96,34 @@ const unreachableProbe = (error: string, httpStatus: number | null = null): Surf
   error,
 });
 
+/**
+ * #9490: read at most `maxChars` characters, CANCELLING the stream past the cap. The previous
+ * `(await response.text()).slice(...)` buffered the FULL hostile body before slicing -- a streamed
+ * multi-hundred-MB response OOMed the isolate before the fail-closed path could ever run. Same shape as
+ * grounding-wire.ts's readTextWithLimit (the house pattern), inlined rather than imported so the content-lane
+ * module keeps its "no imports from the review pipeline" isolation.
+ */
+async function readProbeBodyBounded(response: Response, maxChars: number): Promise<string> {
+  if (!response.body) {
+    const text = await response.text();
+    return text.slice(0, maxChars);
+  }
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let text = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    text += decoder.decode(value, { stream: true });
+    if (text.length >= maxChars) {
+      await reader.cancel().catch(() => undefined);
+      return text.slice(0, maxChars);
+    }
+  }
+  text += decoder.decode();
+  return text.slice(0, maxChars);
+}
+
 function redirectLocation(response: Response, currentUrl: string): string {
   const location = response.headers.get("location");
   if (!location) return "";
@@ -141,7 +169,7 @@ export async function fetchSurfaceProbe(url: string, fetchImpl: typeof fetch = f
     if (!response.ok) return unreachableProbe("probe_http_error", response.status);
     let body: string;
     try {
-      body = (await response.text()).slice(0, MAX_PROBE_BODY_CHARS);
+      body = await readProbeBodyBounded(response, MAX_PROBE_BODY_CHARS);
     } catch {
       // A 2xx whose body cannot be read (a broken/aborted stream) is NOT a served surface — the response line
       // alone proves nothing about what the URL serves, so this stays inconclusive rather than an empty pass.

--- a/test/unit/content-lane-orchestrator.test.ts
+++ b/test/unit/content-lane-orchestrator.test.ts
@@ -8,7 +8,7 @@ import {
   assessSubnetDocument,
   type RegistryLaneSpec,
 } from "../../src/review/content-lane/registry-logic";
-import { diffAppendedSurfaceEntries, runSurfaceReview, survivingExistingEntries, type SurfaceReviewInput } from "../../src/review/content-lane/orchestrator";
+import { diffAppendedSurfaceEntries, MAX_VERIFIED_ENTRIES_PER_RUN, runSurfaceReview, survivingExistingEntries, type SurfaceReviewInput } from "../../src/review/content-lane/orchestrator";
 
 const existing = { kind: "website", url: "https://old.example.ai", source_url: "https://github.com/a/b", public_safe: true };
 const newEntry = { kind: "subnet-api", url: "https://api.example.ai", source_url: "https://github.com/x/y", public_safe: true };
@@ -55,9 +55,36 @@ describe("diffAppendedSurfaceEntries", () => {
     expect(diffAppendedSurfaceEntries("{not json", doc([existing]), "surfaces")).toBeNull();
     expect(diffAppendedSurfaceEntries(JSON.stringify({ netuid: 14 }), doc([existing]), "surfaces")).toBeNull();
   });
+
+  // #9490: identity was raw JSON.stringify, which preserves key order -- so reordering an existing entry's
+  // keys read as a FRESH append (a farmable content-free "contribution") while simultaneously removing its
+  // prior self from the duplicate check's scope.
+  it("REGRESSION (#9490): a key-reordered copy of an existing entry is NOT an append — identity is key-order invariant", () => {
+    const reordered = Object.fromEntries(Object.entries(existing).reverse());
+    expect(JSON.stringify(reordered)).not.toBe(JSON.stringify(existing)); // the reorder is real...
+    expect(diffAppendedSurfaceEntries(doc([reordered]), doc([existing]), "surfaces")).toEqual([]); // ...and reads as zero appends
+
+    // Nested objects too — a shallow sort would miss this.
+    const nestedBase = { ...existing, probe: { expect: "ok", timeout: 5 } };
+    const nestedReordered = { ...existing, probe: { timeout: 5, expect: "ok" } };
+    expect(diffAppendedSurfaceEntries(doc([nestedReordered]), doc([nestedBase]), "surfaces")).toEqual([]);
+  });
+
+  it("INVARIANT (#9490): array ORDER still matters — a reordered array is a real content change, not a cosmetic one", () => {
+    const withList = { ...existing, tags: ["a", "b"] };
+    const reorderedList = { ...existing, tags: ["b", "a"] };
+    expect(diffAppendedSurfaceEntries(doc([reorderedList]), doc([withList]), "surfaces")).toEqual([reorderedList]);
+  });
 });
 
 describe("survivingExistingEntries", () => {
+  const doc9490 = (surfaces: unknown[]) => JSON.stringify({ netuid: 14, surfaces });
+
+  it("REGRESSION (#9490): a key-reordered entry still counts as SURVIVING, keeping its identity inside the duplicate check's scope", () => {
+    const reordered = Object.fromEntries(Object.entries(existing).reverse());
+    expect(survivingExistingEntries(doc9490([reordered]), doc9490([existing]), "surfaces")).toEqual([existing]);
+  });
+
   const doc = (surfaces: unknown[]) => JSON.stringify({ netuid: 14, surfaces });
 
   it("returns base entries that are still present, byte-identical, in head", () => {
@@ -608,6 +635,45 @@ describe("runSurfaceReview — verifyEntry hook", () => {
     // pickAggregateAssessment prefixes a multi-entry reason with its position so the offender is identifiable.
     expect(r?.verdict).toBe("close");
     expect(r?.summary).toBe("Surface entry 2 of 2: not served");
+  });
+
+  // #9490: each verification fetches up to 2 URLs x 5 hops x 10s -- uncapped over metagraphed's
+  // maxAppendedEntries:Infinity, a 500-entry PR was a request-amplification primitive and a subrequest-
+  // exhaustion path that converted into bulk probe_fetch_failed holds.
+  it("REGRESSION (#9490): verifies at most MAX_VERIFIED_ENTRIES_PER_RUN entries; the rest HOLD rather than merging unverified", async () => {
+    const entries = Array.from({ length: MAX_VERIFIED_ENTRIES_PER_RUN + 3 }, (_, i) => ({ ...newEntry, url: `https://api-${i}.example.ai` }));
+    let verified = 0;
+    const r = await withVerifier([existing, ...entries], () => {
+      verified += 1;
+      return Promise.resolve(null);
+    });
+    expect(verified).toBe(MAX_VERIFIED_ENTRIES_PER_RUN);
+    // The capped entries hold the PR: past-budget entries must never sneak through unprobed.
+    expect(r?.verdict).toBe("manual");
+    expect(r?.reason).toContain("verification-capacity");
+  });
+
+  it("INVARIANT (#9490): a run at exactly the cap verifies everything and merges — the cap is a ceiling, not a haircut", async () => {
+    const entries = Array.from({ length: MAX_VERIFIED_ENTRIES_PER_RUN }, (_, i) => ({ ...newEntry, url: `https://api-${i}.example.ai` }));
+    let verified = 0;
+    const r = await withVerifier([existing, ...entries], () => {
+      verified += 1;
+      return Promise.resolve(null);
+    });
+    expect(verified).toBe(MAX_VERIFIED_ENTRIES_PER_RUN);
+    expect(r?.verdict).toBe("merge");
+  });
+
+  it("INVARIANT (#9490): statically closed entries do not consume verification budget", async () => {
+    // One statically-closed entry (public_safe:false) among the appends: the budget must count VERIFIED
+    // entries, not appended ones, or a submitter could pad with invalid entries to starve the real ones.
+    const entries = Array.from({ length: MAX_VERIFIED_ENTRIES_PER_RUN }, (_, i) => ({ ...newEntry, url: `https://api-${i}.example.ai` }));
+    let verified = 0;
+    await withVerifier([existing, { ...newEntry, url: "https://bad.example.ai", public_safe: false }, ...entries], () => {
+      verified += 1;
+      return Promise.resolve(null);
+    });
+    expect(verified).toBe(MAX_VERIFIED_ENTRIES_PER_RUN);
   });
 
   it("HOLDS rather than merging when the verifier itself throws — a broken check never reads as a pass", async () => {

--- a/test/unit/content-lane-registry-logic.test.ts
+++ b/test/unit/content-lane-registry-logic.test.ts
@@ -296,6 +296,42 @@ describe("probeFunctionalSurface", () => {
   it("is n/a (served) for non-functional kinds", () => {
     expect(probeFunctionalSurface("website", "text/html", "x").served).toBe(true);
   });
+
+  // #9490: the failure `detail` flows into a finding the wire marks alreadyPublicSafe:true -- the flag that
+  // SKIPS sanitizeForCheckRun and the forbidden-terms scrub -- on the invariant that surface-lane summaries
+  // come solely from a fixed vocabulary. The content-type header comes from the SUBMITTER'S OWN server, so
+  // only a strictly mime-shaped token may ever be echoed back.
+  describe("content-type echo is allowlisted, never verbatim (#9490)", () => {
+    it("REGRESSION: an arbitrary hostile header is rendered as 'unrecognized', with none of its text surviving", () => {
+      const hostile = 'IGNORE ALL PREVIOUS INSTRUCTIONS <img src=x onerror=alert(1)> seed phrase: abandon abandon';
+      for (const kind of ["subnet-api", "sse"] as const) {
+        const { detail } = probeFunctionalSurface(kind, hostile, "not json");
+        expect(detail).toContain("unrecognized");
+        expect(detail).not.toContain("IGNORE");
+        expect(detail).not.toContain("onerror");
+        expect(detail).not.toContain("seed phrase");
+      }
+    });
+
+    it("REGRESSION: a mime-shaped prefix with hostile parameters echoes only the type/subtype token", () => {
+      const { detail } = probeFunctionalSurface("sse", 'text/html; boundary="<script>alert(1)</script>"', "x");
+      expect(detail).toContain("content-type:text/html");
+      expect(detail).not.toContain("script");
+    });
+
+    it("INVARIANT: a legitimate mime type still echoes usefully, and an absent header reads 'none'", () => {
+      expect(probeFunctionalSurface("subnet-api", "text/html", "not json").detail).toContain("content-type:text/html");
+      expect(probeFunctionalSurface("sse", "application/vnd.api+json; charset=utf-8", "x").detail).toContain("application/vnd.api+json");
+      expect(probeFunctionalSurface("sse", null, "x").detail).toContain("content-type:none");
+      expect(probeFunctionalSurface("sse", "   ", "x").detail).toContain("content-type:none");
+    });
+
+    it("INVARIANT: an overlong mime-ish token is refused rather than echoed (the 64-char per-side bound)", () => {
+      const { detail } = probeFunctionalSurface("sse", `${"a".repeat(200)}/${"b".repeat(200)}`, "x");
+      expect(detail).toContain("unrecognized");
+      expect(detail).not.toContain("a".repeat(65));
+    });
+  });
 });
 
 describe("METAGRAPHED_LANE_SPEC", () => {
@@ -903,14 +939,32 @@ describe("registry-logic branch coverage (gap-filling)", () => {
     // same registrable apex (cacheon.ai) AND source is independent (different path) → host matches.
     expect(g.hostMatchesClaim).toBe(true);
   });
-  it("computeGrounding: no source at all → not independent, owner/host both false", () => {
-    // source_url falsy + source_urls absent → sourceUrl === "" → independentSource false.
+  it("computeGrounding: no source at all → not independent, ALL THREE signals false (#9490)", () => {
+    // source_url falsy + source_urls absent → sourceUrl === "" → independentSource false. #9490 closed the
+    // exception netuid used to enjoy here: it was matched against allText with no independence requirement,
+    // so with MIN_STRONG=1 a submitter's own page asserting its netuid passed grounding self-corroborated.
     const candidate = { netuid: 3, url: "https://github.com/cacheonlabs/repo" };
     const ev = { title: "x", snippet: "cacheonlabs subnet 3 cacheonlabs" };
     const g = computeGrounding(candidate, ev, ev);
     expect(g.ownerMentioned).toBe(false);
     expect(g.hostMatchesClaim).toBe(false);
-    expect(g.netuidMentioned).toBe(true); // netuid path is source-independent
+    expect(g.netuidMentioned).toBe(false);
+    expect(g.strong).toBe(0);
+  });
+
+  it("REGRESSION (#9490): a netuid named ONLY on the target's own page does not ground, even with an independent source present", () => {
+    // The strictest of the three standards: the mention must come from the independent SOURCE's text. The
+    // netuid IS the subnet identity -- the one claim whose self-corroboration was worth farming.
+    const candidate = { netuid: 3, url: "https://docs.example.ai", source_url: "https://github.com/cacheonlabs/repo" };
+    const target = { title: "docs", snippet: "welcome to subnet 3" };
+    const source = { title: "readme", snippet: "a repo about something else" };
+    const g = computeGrounding(candidate, target, source);
+    expect(g.netuidMentioned).toBe(false);
+
+    // And the INVARIANT: the same claim in the independent source's own text still grounds.
+    const g2 = computeGrounding(candidate, target, { title: "readme", snippet: "the official repo for subnet 3" });
+    expect(g2.netuidMentioned).toBe(true);
+    expect(g2.strong).toBeGreaterThanOrEqual(1);
   });
   it("computeGrounding: an unnormalizable target url makes targetKey null → still independent", () => {
     // candidate.url is not a normalizable URL → stripScheme(targetKey) == null → independentSource true.

--- a/test/unit/content-lane-surface-verification.test.ts
+++ b/test/unit/content-lane-surface-verification.test.ts
@@ -123,6 +123,62 @@ describe("fetchSurfaceProbe", () => {
     expect(probe.ok).toBe(false);
   });
 
+  // #9490: the old read was `(await response.text()).slice(...)` -- the FULL hostile body buffered before the
+  // slice, so a streamed multi-hundred-MB response OOMed the isolate before any fail-closed path could run.
+  it("REGRESSION (#9490): a streamed over-limit body is CANCELLED at the cap, never buffered whole", async () => {
+    let chunksServed = 0;
+    let cancelled = false;
+    const chunk = new TextEncoder().encode("x".repeat(16_000));
+    const endless = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        chunksServed += 1;
+        controller.enqueue(chunk);
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    const fetchImpl = (async () => new Response(endless, { status: 200, headers: { "content-type": "text/html" } })) as unknown as typeof fetch;
+
+    const probe = await fetchSurfaceProbe(TARGET, fetchImpl);
+
+    expect(probe.ok).toBe(true);
+    expect(probe.body.length).toBeLessThanOrEqual(64_000);
+    expect(cancelled).toBe(true);
+    // The stream is infinite; reaching here at all proves the read stopped at the cap. The chunk count pins
+    // it quantitatively: ~4 chunks reach the cap, so anything this side of a dozen means bounded reading.
+    expect(chunksServed).toBeLessThan(12);
+  });
+
+  it("INVARIANT (#9490): a cancel() that itself rejects is swallowed — the bounded read still returns the capped body", async () => {
+    const chunk = new TextEncoder().encode("x".repeat(70_000));
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.enqueue(chunk);
+      },
+      cancel() {
+        throw new Error("cancel exploded");
+      },
+    });
+    const fetchImpl = (async () => new Response(stream, { status: 200, headers: { "content-type": "text/html" } })) as unknown as typeof fetch;
+    const probe = await fetchSurfaceProbe(TARGET, fetchImpl);
+    expect(probe.ok).toBe(true);
+    expect(probe.body.length).toBe(64_000);
+  });
+
+  it("INVARIANT (#9490): a small streamed body is read whole through the bounded reader", async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('{"openapi":"3.0.0"}'));
+        controller.close();
+      },
+    });
+    const fetchImpl = (async () => new Response(stream, { status: 200, headers: { "content-type": "application/json" } })) as unknown as typeof fetch;
+    const probe = await fetchSurfaceProbe(TARGET, fetchImpl);
+    expect(probe.ok).toBe(true);
+    expect(probe.body).toBe('{"openapi":"3.0.0"}');
+  });
+
   it("truncates an oversized body to the probe cap", async () => {
     const probe = await fetchSurfaceProbe(TARGET, routes({ [TARGET]: json("x".repeat(MAX_PROBE_BODY_CHARS + 500)) }));
     expect(probe.body).toHaveLength(MAX_PROBE_BODY_CHARS);
@@ -241,12 +297,15 @@ describe("verifySurfaceEntry — grounding (#8908)", () => {
     expect(v.reason).toBe(GROUNDING_INCONCLUSIVE_REASON);
   });
 
-  it("grounds from the TARGET page too, not only the source", async () => {
-    // The source body names neither netuid nor host; the target page names the netuid.
+  it("REGRESSION (#9490): a netuid claimed only by the TARGET's own page no longer grounds — that was the self-corroboration loop", async () => {
+    // Pre-#9490 this exact shape PASSED ("grounds from the TARGET page too"): the submitter's own page
+    // asserting its netuid satisfied MIN_STRONG=1 with the independent source contributing nothing. That is
+    // an unbacked claim wearing a grounding pass. It now fails (holds for a human), and the sibling test
+    // below pins that a source-corroborated netuid still passes.
     const v = await verifySurfaceEntry(groundedEntry, {
       fetchImpl: routes({ [TARGET]: html("<p>Docs for subnet 14</p>"), [SOURCE]: html("<p>readme</p>") }),
     });
-    expect(v.grounding.outcome).toBe("pass");
+    expect(v.grounding.outcome).toBe("fail");
   });
 
   it("still grounds a base-layer wss entry from its source alone (the target is not http-fetchable)", async () => {

--- a/test/unit/federated-import.test.ts
+++ b/test/unit/federated-import.test.ts
@@ -9,6 +9,7 @@ import {
   matchingFederatedKey,
   verifyFederatedBundle,
   type FederatedRejection,
+  MAX_INSTANCE_ID_CHARS,
 } from "../../src/orb/federated-import";
 import { createTestEnv, type TestD1Database } from "../helpers/d1";
 import type { FocusManifest } from "../../src/signals/focus-manifest";
@@ -163,6 +164,23 @@ describe("importPeerBundles (#6480)", () => {
   it("rejects an unknown schema version rather than guessing at it", () => {
     const result = importPeerBundles(manifest(), [signedWith(PEER_KEY_A, { schemaVersion: 999 })], { log: () => undefined });
     expect(result.rejected).toEqual([{ instanceId: "abc123def4567890", reason: "unsupported_schema_version" }]);
+  });
+
+  // #9490: instanceIds are persisted into the single system_flags peer-state blob, and nothing bounded their
+  // length -- 3-4 bundles carrying ~600 KB ids pushed that blob past D1's ~2 MB value limit, the state write
+  // failed silently, and replay/rollback watermarks stopped persisting for EVERY peer.
+  it("REGRESSION (#9490): rejects an oversized instanceId as malformed — it would poison the shared peer-state blob", () => {
+    const oversized = signedWith(PEER_KEY_A, { instanceId: "x".repeat(MAX_INSTANCE_ID_CHARS + 1) });
+    const result = importPeerBundles(manifest(), [oversized], { log: () => undefined });
+    expect(result.accepted).toEqual([]);
+    expect(result.rejected).toEqual([{ instanceId: "x".repeat(MAX_INSTANCE_ID_CHARS + 1), reason: "malformed" }]);
+  });
+
+  it("INVARIANT (#9490): an instanceId at exactly the cap still verifies, and an empty one is malformed", () => {
+    const atCap = signedWith(PEER_KEY_A, { instanceId: "x".repeat(MAX_INSTANCE_ID_CHARS) });
+    expect(importPeerBundles(manifest(), [atCap], { log: () => undefined }).accepted).toEqual([atCap]);
+    const empty = signedWith(PEER_KEY_A, { instanceId: "" });
+    expect(importPeerBundles(manifest(), [empty], { log: () => undefined }).rejected).toEqual([{ instanceId: "", reason: "malformed" }]);
   });
 
   it("rejects a malformed bundle whose signed field is the wrong type", () => {
@@ -395,6 +413,82 @@ describe("applyFederatedPeerWatermarks (#9148, the persisted gates)", () => {
     const bundle = signedWith(PEER_KEY_A);
     const result = await applyFederatedPeerWatermarks(e.DB, okResult([bundle]), [PEER_KEY_A], { now: Date.parse(bundle.generatedAt) });
     expect(result.accepted).toEqual([bundle]); // fail-safe: corrupt cache never blocks a legitimate peer
+  });
+
+  // #9490: an instanceId is BOUND to the first key that verified it. Without this, hostile-but-allowlisted
+  // peer B could claim honest peer A's id -- shadow A's bundle in-batch, overwrite the watermark entry's
+  // keyFingerprint, then ratchet lastGeneratedAtMs so A's genuine bundles reject as replayed_or_rollback
+  // forever: targeted suppression plus stat replacement, and a bypass of B's own Sybil cap (only NEW ids
+  // count against it). Squarely inside #9148's declared threat model.
+  it("REGRESSION (#9490): a second allowlisted key cannot take over an instanceId bound to the first key", async () => {
+    const e = env();
+    const honest = signedWith(PEER_KEY_A, { instanceId: "shared-target-id", generatedAt: "2026-03-01T00:00:00.000Z" });
+    await applyFederatedPeerWatermarks(e.DB, okResult([honest]), [PEER_KEY_A, PEER_KEY_B], { now: Date.parse(honest.generatedAt) });
+
+    // B verifies under its OWN (allowlisted) key but claims A's id, with a newer generatedAt -- the ratchet.
+    const takeover = signedWith(PEER_KEY_B, { instanceId: "shared-target-id", generatedAt: "2026-03-09T00:00:00.000Z" });
+    const result = await applyFederatedPeerWatermarks(e.DB, okResult([takeover]), [PEER_KEY_A, PEER_KEY_B], { now: Date.parse(takeover.generatedAt) });
+
+    expect(result.accepted).toEqual([]);
+    expect(result.rejected).toEqual([{ instanceId: "shared-target-id", reason: "instance_key_conflict" }]);
+
+    // The decisive invariant: A's NEXT genuine bundle still lands -- neither its watermark nor its key
+    // binding was moved by the attempt.
+    const next = signedWith(PEER_KEY_A, { instanceId: "shared-target-id", generatedAt: "2026-03-02T00:00:00.000Z" });
+    const after = await applyFederatedPeerWatermarks(e.DB, okResult([next]), [PEER_KEY_A, PEER_KEY_B], { now: Date.parse(next.generatedAt) });
+    expect(after.accepted).toEqual([next]);
+  });
+
+  it("INVARIANT (#9490): the takeover rejection does not free the id — repeated attempts keep failing without perturbing state", async () => {
+    const e = env();
+    const honest = signedWith(PEER_KEY_A, { instanceId: "sticky-id", generatedAt: "2026-03-01T00:00:00.000Z" });
+    await applyFederatedPeerWatermarks(e.DB, okResult([honest]), [PEER_KEY_A, PEER_KEY_B], { now: Date.parse(honest.generatedAt) });
+    for (const attemptAt of ["2026-03-03T00:00:00.000Z", "2026-03-04T00:00:00.000Z"]) {
+      const attempt = signedWith(PEER_KEY_B, { instanceId: "sticky-id", generatedAt: attemptAt });
+      const result = await applyFederatedPeerWatermarks(e.DB, okResult([attempt]), [PEER_KEY_A, PEER_KEY_B], { now: Date.parse(attemptAt) });
+      expect(result.rejected[0]?.reason).toBe("instance_key_conflict");
+    }
+  });
+
+  it("REGRESSION (#9490): a failing peer-state write is LOUD (error-level structured log) while still failing open", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    try {
+      const e = env();
+      // Make ONLY the system_flags write fail; the read path (SELECT) must still work.
+      const realDb = e.DB;
+      const failingDb = {
+        prepare: (sql: string) => {
+          const statement = realDb.prepare(sql);
+          if (/^INSERT OR REPLACE INTO system_flags/i.test(sql)) {
+            return { bind: () => ({ run: () => Promise.reject(new Error("value exceeds maximum size")) }) };
+          }
+          return statement;
+        },
+      } as unknown as D1Database;
+      const bundle = signedWith(PEER_KEY_A);
+
+      const result = await applyFederatedPeerWatermarks(failingDb, okResult([bundle]), [PEER_KEY_A], { now: Date.parse(bundle.generatedAt) });
+
+      expect(result.accepted).toEqual([bundle]); // fail-open: the sync tick is never failed by the write
+      expect(
+        errorSpy.mock.calls.some((call) => {
+          const line = String(call[0]);
+          return line.includes("federated_peer_state_write_failed") && line.includes("value exceeds maximum size");
+        }),
+      ).toBe(true);
+      // A non-Error rejection takes the String() arm rather than crashing the logger.
+      const failingDb2 = {
+        prepare: (sql: string) =>
+          /^INSERT OR REPLACE INTO system_flags/i.test(sql)
+            ? { bind: () => ({ run: () => Promise.reject("plain string failure") }) }
+            : realDb.prepare(sql),
+      } as unknown as D1Database;
+      const bundle2 = signedWith(PEER_KEY_A, { instanceId: "second-instance" });
+      await applyFederatedPeerWatermarks(failingDb2, okResult([bundle2]), [PEER_KEY_A], { now: Date.parse(bundle2.generatedAt) });
+      expect(errorSpy.mock.calls.some((call) => String(call[0]).includes("plain string failure"))).toBe(true);
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   it("passes through prior rejections untouched alongside its own", async () => {

--- a/test/unit/orb-apr-repo-transfer.test.ts
+++ b/test/unit/orb-apr-repo-transfer.test.ts
@@ -9,6 +9,7 @@ import {
   initiateAprRepoTransfer,
   isAprRepoTransferPollEnabled,
   loadAprIdeaCompletion,
+  loadAprRepoBinding,
   loadPendingAprRepoTransfers,
   pollPendingAprRepoTransfers,
   probeAprRepoTransfer,
@@ -118,6 +119,12 @@ describe("evaluateAprRepoTransferRequestEligibility (#7742)", () => {
   });
 });
 
+describe("loadAprRepoBinding (#9490)", () => {
+  it("fail-closes: returns null until #7664 persists a binding record, so no transfer can authorize", async () => {
+    await expect(loadAprRepoBinding(createTestEnv(), { repoFullName: "loopover-repos/widgets" })).resolves.toBeNull();
+  });
+});
+
 describe("loadAprIdeaCompletion (#7742)", () => {
   it("fail-closes to incomplete until a persisted #7591/#7664 record exists", async () => {
     await expect(loadAprIdeaCompletion(createTestEnv(), { repoFullName: "loopover-repos/widgets" })).resolves.toEqual({
@@ -166,7 +173,8 @@ describe("requestAprRepoTransfer (#7742)", () => {
     const result = await requestAprRepoTransfer(
       env,
       { installationId: 7, repoFullName: "loopover-repos/widgets", newOwner: "customer-acct" },
-      { initiate, loadCompletion },
+      // #9490: completion alone no longer authorizes; the tenant binding must match too.
+      { initiate, loadCompletion, loadBinding: async () => ({ customerLogin: "customer-acct", installationId: 7 }) },
     );
     expect(initiate).toHaveBeenCalledWith(env, 7, "loopover-repos/widgets", "customer-acct");
     expect(result).toEqual({
@@ -180,7 +188,7 @@ describe("requestAprRepoTransfer (#7742)", () => {
     const result = await requestAprRepoTransfer(
       createTestEnv(),
       { installationId: 1, repoFullName: "loopover-repos/widgets", newOwner: "customer-acct" },
-      { initiate, loadCompletion: async () => ({ ideaComplete: true }) },
+      { initiate, loadCompletion: async () => ({ ideaComplete: true }), loadBinding: async () => ({ customerLogin: "customer-acct", installationId: 1 }) },
     );
     expect(result).toEqual({
       status: "failed",
@@ -194,7 +202,7 @@ describe("requestAprRepoTransfer (#7742)", () => {
     const result = await requestAprRepoTransfer(
       createTestEnv(),
       { installationId: 1, repoFullName: "loopover-repos/widgets", newOwner: "customer-acct" },
-      { loadCompletion: async () => ({ ideaComplete: true }) },
+      { loadCompletion: async () => ({ ideaComplete: true }), loadBinding: async () => ({ customerLogin: "customer-acct", installationId: 1 }) },
     );
     expect(result).toEqual({
       status: "initiated",
@@ -209,7 +217,7 @@ describe("requestAprRepoTransfer (#7742)", () => {
     const result = await requestAprRepoTransfer(
       env,
       { installationId: 3, repoFullName: "loopover-repos/widgets", newOwner: "customer-acct" },
-      { initiate, loadCompletion: async () => ({ ideaComplete: true }), pauseDispatch },
+      { initiate, loadCompletion: async () => ({ ideaComplete: true }), loadBinding: async () => ({ customerLogin: "customer-acct", installationId: 3 }), pauseDispatch },
     );
     expect(result.status).toBe("initiated");
     expect(pauseDispatch).toHaveBeenCalledWith(env, "loopover-repos/widgets");
@@ -229,6 +237,7 @@ describe("requestAprRepoTransfer (#7742)", () => {
       {
         initiate: vi.fn().mockResolvedValue({ initiated: false, status: 403, error: "no admin" }),
         loadCompletion: async () => ({ ideaComplete: true }),
+        loadBinding: async () => ({ customerLogin: "customer-acct", installationId: 1 }),
         pauseDispatch,
       },
     );
@@ -312,9 +321,51 @@ describe("probeAprRepoTransfer (#7741)", () => {
     expect(probe).toEqual({ state: "resolved_under_target" });
   });
 
-  it("treats a 404 (App access gone) as accepted-and-departed", async () => {
-    stubFetch(() => new Response("", { status: 404 }));
+  // #9490: a bare 404 at the original path is AMBIGUOUS -- ownership moved away, or the repo was deleted /
+  // the App uninstalled. Departure (a terminal SUCCESS outcome in the ledger) is only declared once the repo
+  // demonstrably resolves under the TARGET owner; otherwise the transfer stays pending and the expiry clock
+  // gives the bounded, truthful answer.
+  it("REGRESSION (#9490): 404 at the original path + repo confirmed under the target owner ⇒ accepted-and-departed", async () => {
+    stubFetch((url) =>
+      url.includes("/repos/customer-acct/widgets")
+        ? new Response(JSON.stringify({ owner: { login: "Customer-Acct" } }), { status: 200 })
+        : new Response("", { status: 404 }),
+    );
     expect(await probeAprRepoTransfer(createTestEnv(), transfer)).toEqual({ state: "access_departed" });
+  });
+
+  it("INVARIANT (#9490): 404 everywhere (repo deleted, or private under its new owner) stays pending — never a fabricated success", async () => {
+    stubFetch(() => new Response("", { status: 404 }));
+    expect(await probeAprRepoTransfer(createTestEnv(), transfer)).toEqual({ state: "pending" });
+  });
+
+  it("INVARIANT (#9490): 404 + a repo under the target PATH but owned by someone else stays pending", async () => {
+    stubFetch((url) =>
+      url.includes("/repos/customer-acct/widgets")
+        ? new Response(JSON.stringify({ owner: { login: "squatter" } }), { status: 200 })
+        : new Response("", { status: 404 }),
+    );
+    expect(await probeAprRepoTransfer(createTestEnv(), transfer)).toEqual({ state: "pending" });
+  });
+
+  it("INVARIANT (#9490): a malformed original path (no repo half) skips corroboration and stays pending", async () => {
+    stubFetch(() => new Response("", { status: 404 }));
+    expect(await probeAprRepoTransfer(createTestEnv(), { ...transfer, repoFullName: "just-an-owner" })).toEqual({ state: "pending" });
+  });
+
+  it("INVARIANT (#9490): a non-2xx or owner-less corroborating response stays pending", async () => {
+    stubFetch((url) => (url.includes("/repos/customer-acct/widgets") ? new Response("", { status: 500 }) : new Response("", { status: 404 })));
+    expect(await probeAprRepoTransfer(createTestEnv(), transfer)).toEqual({ state: "pending" });
+    stubFetch((url) => (url.includes("/repos/customer-acct/widgets") ? new Response(JSON.stringify({}), { status: 200 }) : new Response("", { status: 404 })));
+    expect(await probeAprRepoTransfer(createTestEnv(), transfer)).toEqual({ state: "pending" });
+  });
+
+  it("INVARIANT (#9490): the corroborating fetch itself throwing degrades to pending, honoring the never-throws contract", async () => {
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      if (String(input).includes("/repos/customer-acct/widgets")) throw new Error("network down");
+      return new Response("", { status: 404 });
+    });
+    expect(await probeAprRepoTransfer(createTestEnv(), transfer)).toEqual({ state: "pending" });
   });
 
   it("stays pending while the repo is still under the original owner", async () => {

--- a/test/unit/routes-request-apr-transfer.test.ts
+++ b/test/unit/routes-request-apr-transfer.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createApp } from "../../src/api/routes";
 import { createInstallationToken } from "../../src/github/app";
 import { loadAprIdeaCompletion } from "../../src/orb/apr-idea-completion";
+import { loadAprRepoBinding } from "../../src/orb/apr-repo-binding";
 import { createTestEnv } from "../helpers/d1";
 
 // #7742: POST /v1/loop/request-apr-transfer — customer-facing request-only APR transfer. Completion is
@@ -17,8 +18,18 @@ vi.mock("../../src/orb/apr-idea-completion", async (importOriginal) => {
     loadAprIdeaCompletion: vi.fn(actual.loadAprIdeaCompletion),
   };
 });
+// #9490: the tenant binding is the second server-resolved gate on this route, mocked at the same import seam
+// as completion (its module deliberately mirrors apr-idea-completion.ts for exactly this reason).
+vi.mock("../../src/orb/apr-repo-binding", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/orb/apr-repo-binding")>();
+  return {
+    ...actual,
+    loadAprRepoBinding: vi.fn(actual.loadAprRepoBinding),
+  };
+});
 const mockedToken = vi.mocked(createInstallationToken);
 const mockedLoadCompletion = vi.mocked(loadAprIdeaCompletion);
+const mockedLoadBinding = vi.mocked(loadAprRepoBinding);
 
 function stubFetch(handler: (url: string, init: RequestInit) => Response): void {
   vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => handler(String(input), init ?? {}));
@@ -42,6 +53,8 @@ describe("POST /v1/loop/request-apr-transfer (#7742)", () => {
     mockedToken.mockResolvedValue("ghs_installation_token");
     mockedLoadCompletion.mockReset();
     mockedLoadCompletion.mockResolvedValue({ ideaComplete: false });
+    mockedLoadBinding.mockReset();
+    mockedLoadBinding.mockResolvedValue({ customerLogin: "customer-acct", installationId: 42 });
   });
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -95,6 +108,43 @@ describe("POST /v1/loop/request-apr-transfer (#7742)", () => {
       status: "failed",
       transfer: { initiated: false, status: 403, error: "transfer request failed (403)" },
     });
+  });
+
+  it("REGRESSION (#9490): returns 409 when completion passes but no server-side binding exists — the default fail-closed lookup", async () => {
+    mockedLoadCompletion.mockResolvedValue({ ideaComplete: true });
+    mockedLoadBinding.mockResolvedValue(null); // what loadAprRepoBinding really returns until #7664
+    let fetchCalls = 0;
+    stubFetch(() => {
+      fetchCalls += 1;
+      return new Response("{}", { status: 202 });
+    });
+    const response = await post(createTestEnv(), validBody);
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({ status: "rejected", reason: "repo_not_apr_bound" });
+    expect(fetchCalls).toBe(0);
+    expect(mockedToken).not.toHaveBeenCalled();
+  });
+
+  it("REGRESSION (#9490): returns 409 when newOwner is not the bound customer — a transfer can only move a repo to its OWN tenant", async () => {
+    mockedLoadCompletion.mockResolvedValue({ ideaComplete: true });
+    mockedLoadBinding.mockResolvedValue({ customerLogin: "someone-else", installationId: 42 });
+    let fetchCalls = 0;
+    stubFetch(() => {
+      fetchCalls += 1;
+      return new Response("{}", { status: 202 });
+    });
+    const response = await post(createTestEnv(), validBody);
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({ status: "rejected", reason: "new_owner_not_bound_customer" });
+    expect(fetchCalls).toBe(0);
+  });
+
+  it("REGRESSION (#9490): returns 409 when the installation does not match the binding", async () => {
+    mockedLoadCompletion.mockResolvedValue({ ideaComplete: true });
+    mockedLoadBinding.mockResolvedValue({ customerLogin: "customer-acct", installationId: 7 });
+    const response = await post(createTestEnv(), validBody);
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({ status: "rejected", reason: "installation_not_bound" });
   });
 
   it("rejects an invalid or unparseable body with 400 before any GitHub call", async () => {


### PR DESCRIPTION
## Summary

Seven defects across the content-lane surface-verification feature, the federated peer-intelligence import, and the APR transfer path. Every one is latent behind a flag that currently ships disabled — which is exactly why they are fixed now, before a flag flip converts them into incidents.

Closes #9490

## Content lane (`LOOPOVER_REVIEW_SURFACE_VERIFICATION`, ships `"false"`)

**1. Remote-server text reached the public comment pre-marked as safe.** `probeFunctionalSurface` interpolated the raw `content-type` header — from the *submitter's own server* — into a detail string that flows into a finding the wire marks `alreadyPublicSafe: true`, the flag that **skips** `sanitizeForCheckRun` and the forbidden-terms scrub. The wire's invariant ("summary comes solely from a fixed assessment vocabulary") was simply false after #9255. Only a strictly mime-shaped token (`type/subtype`, ≤64 chars/side) is now ever echoed; anything else renders as `unrecognized`. Allowlist-from-the-start, not a scrub — nothing hostile survives beyond word chars, dots, pluses, dashes.

**2. `MAX_PROBE_BODY_CHARS` did not bound memory.** `(await response.text()).slice(0, 64000)` buffered the *full* hostile body before slicing — a streamed multi-hundred-MB response OOMs the isolate before the fail-closed path can run. Now a streaming bounded reader (grounding-wire's house pattern) that cancels at the cap; the regression test serves an **infinite** stream and pins both the cancel and the chunk count.

**3. Unbounded probe fan-out.** Each verification fetches up to 2 URLs × 5 hops × 10s, and metagraphed's spec sets `maxAppendedEntries: Infinity` — a 500-entry PR was a request-amplification primitive and a subrequest-exhaustion path converting into bulk `probe_fetch_failed` holds for everyone in the isolate. `MAX_VERIFIED_ENTRIES_PER_RUN = 10` (matching source-evidence's own cap); entries past it **hold** for a human, never merge unprobed — the cap bounds spend, it must not become a way to sneak entry #11 through. Counted synchronously before any await, so the concurrent map cannot race the budget; statically-closed entries don't consume it, so padding with invalid entries can't starve real ones.

**4. Netuid grounding was self-corroborating.** With `MIN_STRONG = 1`, a submitter's own page asserting "netuid 64" passed grounding — owner and host require an independent source, netuid didn't. It now holds to the *strictest* standard of the three: the mention must come from the independent **source's** text. It is the one claim whose self-corroboration was worth farming — the netuid *is* the subnet identity. Two pre-existing tests pinned the old semantics ("netuid path is source-independent", "grounds from the TARGET page too"); both are rewritten as regressions of the exploit shape, with invariants that source-corroborated netuids still pass and the wss-entry flow is unchanged.

**5. Key-order-sensitive entry identity.** Both structural diffs keyed entries on raw `JSON.stringify`, so reordering an existing entry's keys read as a *fresh append* while removing its prior self from the duplicate check's scope — a farmable path to content-free auto-merged registry PRs. Identity is now canonical (recursive key sort; arrays keep order — order is meaning there, same rule as `canonicalJson`).

## Federated peer intelligence

**6. `instanceId` takeover across allowlisted keys.** In-batch dedup and the watermark entry's `keyFingerprint` both resolved last-wins by `instanceId` regardless of signing key — so a hostile-but-allowlisted peer B could claim honest peer A's id, ratchet its watermark so A's genuine bundles reject as `replayed_or_rollback` forever (targeted suppression + stat replacement), and bypass B's own Sybil cap, since only *new* ids count against it. Squarely inside #9148's declared threat model. An id is now **bound to the first key that verified it**; a bundle for that id under any other key rejects with a new `instance_key_conflict` reason. The decisive invariant test: after a takeover attempt, the honest peer's next genuine bundle still lands — neither its watermark nor its binding moved.

**7. Unbounded `instanceId` length silently killed watermark persistence.** Nothing bounded the id, and ~3–4 bundles of ~600 KB ids push the single `system_flags` peer-state blob past D1's ~2 MB value limit — after which `writeFederatedPeerState` swallowed the failure *forever*, silently regressing every #9148 protection for every peer. Ids are now capped at 128 chars (empty rejected too) in the shape check, and the write failure logs at error level (structured, forwarder-visible) while still failing open — the sync tick is never failed by it.

## APR transfer

**Tenant binding, installed now while the route is inert.** `installationId`, `repoFullName` and `newOwner` are all caller-supplied, and the only gate was `ideaComplete` — hard-false today, but the module instructs implementers to "replace the body (keep the signature)". The moment a completion record lands, any authorized caller could transfer any completed APR repo — including another customer's — to themselves. `requestAprRepoTransfer` now requires a server-side `AprRepoBinding` (own module, `apr-repo-binding.ts`, mirroring `apr-idea-completion.ts` down to the mockable import seam and the fail-closed replace-the-body contract): no binding ⇒ reject; `newOwner` ≠ bound customer ⇒ reject; installation mismatch ⇒ reject — all **before** GitHub is ever contacted.

**The 404 probe no longer fabricates success.** `probeAprRepoTransfer` treated a bare 404 (repo deleted, App uninstalled) as `accepted_departed` — a terminal *success* in the transfer ledger. Departure is now declared only once the repo demonstrably resolves under the target owner; otherwise the transfer stays pending and the existing expiry clock gives the bounded, truthful answer.

## Validation

- `npx tsc --noEmit`, `db:migrations:check`, `selfhost:env-reference:check`, `git diff --check` — all clean; no schema, env, or OpenAPI changes
- **522 passed** across the eight directly-affected suites, plus **331** across the blast-radius suites (netuid-verification, deliverable-run, flag, scope, source-evidence, spec-resolver, security-scan, safe-url, federated collector/bundle/benchmark, APR creation)
- Patch coverage against this diff: **0 uncovered changed lines**
- **17 of the new tests verified to fail against the unfixed code** (all four touched source files reverted to their pre-fix state and re-run)

**Verified solid and deliberately untouched** (from the issue's own audit): redirect-hop SSRF re-checks, the three-state fail-closed verdict ordering, `safe-url` IP-literal coverage, allowlist fail-closed, timing-safe key matching, the collector's bounded reader, `MAX_PULLED_BUNDLES`, and median-not-mean.
