### PR TITLE
fix(ci): cache every workspace's node_modules, not just the root and one app

### DIFF
--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -51,12 +51,23 @@ runs:
       with:
         path: |
           node_modules
-          apps/loopover-ui/node_modules
+          apps/*/node_modules
+          packages/*/node_modules
         # hashFiles('.nvmrc') matters as much as the package manifests and lockfile: a Node bump
         # with no lockfile change would otherwise still hit and silently reuse node_modules whose
         # native addons (sharp, workerd, fsevents) were compiled against the OLD Node's ABI. The
         # manifests matter too because npm ci validates package.json/package-lock.json consistency
         # and runs lifecycle scripts from package.json; a package.json-only change must not skip it.
+        #
+        # The path list must cover EVERY workspace's own node_modules, not just the root and one app.
+        # npm decides per dependency whether it hoists to the root or nests under a workspace, and that
+        # decision moves whenever a version range changes: the #8608 eslint-10 bump nested `@eslint/js`
+        # under both UI apps, so on a cache HIT `apps/loopover-miner-ui/node_modules` did not exist at all
+        # and `eslint .` died with "Cannot find module '@eslint/js'" -- a failure that reproduces on no
+        # developer machine, because a real `npm ci`/`npm install` always creates those directories.
+        # Globbing `apps/*` + `packages/*` (the workspace globs from package.json) makes the cache follow
+        # npm's layout automatically instead of re-breaking on the next hoist change. review-enrichment
+        # and control-plane are NOT workspaces -- they have their own installs and their own cache steps.
         key: npm-${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'fork' || 'trusted' }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('package.json', 'apps/*/package.json', 'packages/*/package.json', 'package-lock.json') }}
 
     - name: Install dependencies (retry on transient failures)
@@ -82,5 +93,6 @@ runs:
       with:
         path: |
           node_modules
-          apps/loopover-ui/node_modules
+          apps/*/node_modules
+          packages/*/node_modules
         key: ${{ steps.node-modules-cache.outputs.cache-primary-key }}


### PR DESCRIPTION
## The failure

Every PR's **UI lint** step is failing on `main` right now:

```
> @loopover/ui-miner@0.0.0 lint
> eslint .
Error: Cannot find module '@eslint/js'
Require stack:
- /home/runner/work/loopover/loopover/apps/loopover-miner-ui/eslint.config.ts
```

## Why

`setup-workspace`'s node_modules cache listed only `node_modules` and `apps/loopover-ui/node_modules`. npm decides **per dependency** whether it hoists to the root or nests under a workspace, and that decision moves whenever a version range changes. #8608's eslint-10 bump made npm nest `@eslint/js` under *both* UI apps — so on a cache **hit**, `apps/loopover-miner-ui/node_modules` was never restored (it isn't in the path list) and the config's very first import failed.

It reproduces on no developer machine: a real `npm ci` / `npm install` always creates those directories, so only the cache-hit path is broken. That's also why it slipped through #9589's own green run — that run was a cache *miss* (the lockfile had just changed), which installed everything for real.

## The fix

Glob `apps/*/node_modules` + `packages/*/node_modules` — the same workspace globs `package.json` declares — in both the restore and the save step, so the cache follows npm's layout automatically instead of re-breaking on the next hoist change. `review-enrichment` and `control-plane` are deliberately untouched: they are not workspaces, and they already have their own installs and their own cache steps.

Verified: `actionlint` and `lint:composite-actions` both clean. The real proof is this PR's own CI — a first run installs fresh and saves the widened cache; every subsequent PR then restores a complete tree.