### PR TITLE
fix(ci): bump the cache-key salt so #9596's widened path list actually takes effect

### DIFF
--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -68,7 +68,14 @@ runs:
         # Globbing `apps/*` + `packages/*` (the workspace globs from package.json) makes the cache follow
         # npm's layout automatically instead of re-breaking on the next hoist change. review-enrichment
         # and control-plane are NOT workspaces -- they have their own installs and their own cache steps.
-        key: npm-${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'fork' || 'trusted' }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('package.json', 'apps/*/package.json', 'packages/*/package.json', 'package-lock.json') }}
+        # `v2` is a manual cache-generation salt, and bumping it is REQUIRED whenever the `path` list
+        # above changes. Widening `path` alone does not invalidate anything: the key is computed from the
+        # manifests only, so an unchanged lockfile keeps HITTING the pre-existing entry, which was
+        # archived from the narrow path list and therefore still restores no
+        # `apps/loopover-miner-ui/node_modules` -- and a hit skips `npm ci`, so the tree stays incomplete
+        # exactly as before. (#9596 widened the list without this bump and did not take effect.) Bumping
+        # the salt forces one clean miss so a complete tree gets archived under the current list.
+        key: npm-v2-${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'fork' || 'trusted' }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('package.json', 'apps/*/package.json', 'packages/*/package.json', 'package-lock.json') }}
 
     - name: Install dependencies (retry on transient failures)
       if: ${{ steps.node-modules-cache.outputs.cache-hit != 'true' }}


### PR DESCRIPTION
## Why this is needed on top of #9596

#9596 widened the node_modules cache to every workspace, but the salt commit that made it *work* raced the gate's auto-merge and did not land — the merged action has the widened `path` list and the **original** key.

That combination is a no-op. The key is computed from the manifests only, so a branch with an unchanged lockfile keeps **hitting** the entry archived under the narrow list. That entry contains no `apps/loopover-miner-ui/node_modules`, and because it's a *hit*, `npm ci` is skipped — so the tree stays exactly as incomplete and UI lint keeps failing on `Cannot find module '@eslint/js'`.

## The fix

Add an explicit `npm-v2-` generation salt to the key, forcing one clean miss so a complete tree is archived under the current path list. The comment states the rule for next time: **bumping the salt is required whenever the `path` list changes**, since widening a path list never invalidates entries archived under the old one.

Verified `lint:composite-actions` clean; the real proof is the first run here installing fresh and every later PR restoring a complete tree.