### PR TITLE
fix(ci): update the setup-workspace cache assertions to the widened path list

### DIFF
--- a/test/unit/ci-composite-setup-workspace.test.ts
+++ b/test/unit/ci-composite-setup-workspace.test.ts
@@ -53,7 +53,15 @@ describe("setup-workspace composite action", () => {
     expect(restore.uses).toContain("actions/cache/restore@");
     const restoreWith = record(restore.with, "restore.with");
     expect(String(restoreWith.path)).toContain("node_modules");
-    expect(String(restoreWith.path)).toContain("apps/loopover-ui/node_modules");
+    // #9596: the path list must cover EVERY workspace, via the same globs package.json declares -- npm
+    // decides per dependency whether it hoists to the root or nests under a workspace, and pinning one app
+    // by name is what let a cache hit restore a tree with no apps/loopover-miner-ui/node_modules at all.
+    expect(String(restoreWith.path)).toContain("apps/*/node_modules");
+    expect(String(restoreWith.path)).toContain("packages/*/node_modules");
+    // #9597: the path list and the KEY must move together. Widening the paths alone changes nothing --
+    // an unchanged lockfile keeps hitting the entry archived under the old list -- so the generation salt
+    // is asserted here, beside the paths, to keep the two from drifting apart again.
+    expect(String(restoreWith.key)).toContain("npm-v2-");
     expect(String(restoreWith.key)).toContain("hashFiles('package.json', 'apps/*/package.json', 'packages/*/package.json', 'package-lock.json')");
     expect(String(restoreWith.key)).toContain("package.json");
     expect(String(restoreWith.key)).toContain("apps/*/package.json");
@@ -74,6 +82,9 @@ describe("setup-workspace composite action", () => {
     expect(save.uses).toContain("actions/cache/save@");
     const saveWith = record(save.with, "save.with");
     expect(saveWith.key).toBe("${{ steps.node-modules-cache.outputs.cache-primary-key }}");
+    // The SAVE list is the one that decides what a future run can restore, so a narrowing here would be
+    // invisible until some later job failed on a missing workspace -- assert it matches the restore list.
+    expect(String(saveWith.path)).toBe(String(restoreWith.path));
 
     // Save must come after install (a broken/partial node_modules from a failed install step is never reached).
     const stepNames = steps.map((s) => s.name);


### PR DESCRIPTION
## The break

`test/unit/ci-composite-setup-workspace.test.ts` has been failing on `main` and on every open branch since #9596/#9597 merged:

```
AssertionError: expected 'node_modules\napps/*/node_modules\npa…' to contain 'apps/loopover-ui/node_modules'
```

My fault: those PRs changed the cache to glob every workspace and added a key salt, but I didn't update the test that pins the old literal path.

## The fix

Assert the contract that now holds, and close two gaps the old test left open while I'm here:

- **Both workspace globs** (`apps/*/node_modules`, `packages/*/node_modules`), matching what `package.json` declares as workspaces.
- **The `npm-v2-` salt, asserted beside the paths.** Widening the paths without bumping the salt is a no-op — that's exactly the bug #9597 had to fix after #9596 — so the test now fails if a future change moves one without the other.
- **The save step's path list equals the restore step's.** The save list is what decides what a future run can restore, so a narrowing there would stay invisible until some unrelated job failed on a missing workspace.

Verified locally: 5/5 passing.