### PR TITLE
fix(engine): accept the canonical { kind: 'existing', repo } IdeaTarget in validateIdeaSubmission

### DIFF
--- a/packages/loopover-engine/src/idea-intake.ts
+++ b/packages/loopover-engine/src/idea-intake.ts
@@ -85,6 +85,10 @@ function isNonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
 }
 
+// The "owner/name" slug check shared by both existing-repo input shapes (bare string and
+// `{ kind: "existing", repo }`): each segment must be a GitHub-legal slug.
+const TARGET_REPO_SLUG_PATTERN = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+
 /** Validate + normalize a raw renter submission (spec §1). Returns every failure at once (never folds with
  *  `??`/`||`) so a caller can surface all problems in one pass rather than one-at-a-time. */
 export function validateIdeaSubmission(raw: unknown): IdeaValidationResult {
@@ -98,10 +102,17 @@ export function validateIdeaSubmission(raw: unknown): IdeaValidationResult {
   else if (input.body.length > IDEA_BODY_MAX_CHARS) errors.push("body_too_long");
   // Back-compat wire form: a bare "owner/name" string means an existing repo (each segment a GitHub-legal
   // slug -- an uninstallable/malformed repo is rejected at intake, never scored, since it can never produce a
-  // `go`). A `{ kind: "provision" }` object requests a not-yet-created repo (#7589). Anything else is missing.
+  // `go`). A canonical `{ kind: "existing", repo }` object — the exact shape this validator itself returns,
+  // and what a TypeScript caller building against the exported `IdeaTarget` union constructs — resolves the
+  // same way, with the same slug check, so `validateIdeaSubmission` round-trips its own output (#9609). A
+  // `{ kind: "provision" }` object requests a not-yet-created repo (#7589). Anything else is missing.
   let resolvedTarget: IdeaTarget | undefined;
   if (isNonEmptyString(input.targetRepo)) {
-    if (/^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/.test(input.targetRepo)) resolvedTarget = { kind: "existing", repo: input.targetRepo };
+    if (TARGET_REPO_SLUG_PATTERN.test(input.targetRepo)) resolvedTarget = { kind: "existing", repo: input.targetRepo };
+    else errors.push("target_repo_malformed");
+  } else if (typeof input.targetRepo === "object" && input.targetRepo !== null && (input.targetRepo as Record<string, unknown>).kind === "existing") {
+    const repo = (input.targetRepo as Record<string, unknown>).repo;
+    if (typeof repo === "string" && TARGET_REPO_SLUG_PATTERN.test(repo)) resolvedTarget = { kind: "existing", repo };
     else errors.push("target_repo_malformed");
   } else if (typeof input.targetRepo === "object" && input.targetRepo !== null && (input.targetRepo as Record<string, unknown>).kind === "provision") {
     resolvedTarget = { kind: "provision" };

--- a/test/unit/idea-intake-bridge.test.ts
+++ b/test/unit/idea-intake-bridge.test.ts
@@ -74,11 +74,42 @@ describe("validateIdeaSubmission", () => {
     if (provision.ok) expect(provision.idea.targetRepo).toEqual({ kind: "provision" });
   });
 
-  it("rejects an object targetRepo that is not a provision request", () => {
-    for (const targetRepo of [{}, { kind: "existing" }]) {
+  it("rejects an object targetRepo whose kind is neither existing nor provision", () => {
+    for (const targetRepo of [{}, { kind: "bogus" }]) {
       const r = validateIdeaSubmission(rawIdea({ targetRepo }));
       expect(r.ok).toBe(false);
-      if (!r.ok) expect(r.errors).toContain("target_repo_required");
+      if (!r.ok) expect(r.errors).toEqual(["target_repo_required"]);
+    }
+  });
+
+  it("accepts the canonical { kind: 'existing', repo } object the validator itself returns (#9609)", () => {
+    const r = validateIdeaSubmission(rawIdea({ targetRepo: { kind: "existing", repo: "acme/widgets" } }));
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.idea.targetRepo).toEqual({ kind: "existing", repo: "acme/widgets" });
+  });
+
+  it("round-trips its own output: re-validating a validated idea succeeds with targetRepo unchanged (#9609)", () => {
+    for (const targetRepo of ["acme/widgets", { kind: "provision" }]) {
+      const first = validateIdeaSubmission(rawIdea({ targetRepo }));
+      expect(first.ok).toBe(true);
+      if (!first.ok) continue;
+      const second = validateIdeaSubmission(first.idea);
+      expect(second.ok).toBe(true);
+      if (second.ok) expect(second.idea.targetRepo).toEqual(first.idea.targetRepo);
+    }
+  });
+
+  it("flags a recognised-but-malformed { kind: 'existing' } repo as target_repo_malformed (#9609)", () => {
+    const r = validateIdeaSubmission(rawIdea({ targetRepo: { kind: "existing", repo: "not-a-slug" } }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.errors).toEqual(["target_repo_malformed"]);
+  });
+
+  it("flags an { kind: 'existing' } target whose repo is missing, empty, or not a string as target_repo_malformed (#9609)", () => {
+    for (const targetRepo of [{ kind: "existing" }, { kind: "existing", repo: "" }, { kind: "existing", repo: "   " }, { kind: "existing", repo: 42 }]) {
+      const r = validateIdeaSubmission(rawIdea({ targetRepo }));
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.errors).toEqual(["target_repo_malformed"]);
     }
   });
 


### PR DESCRIPTION
Closes #9609

## Bug

`validateIdeaSubmission` (`packages/loopover-engine/src/idea-intake.ts`) rejects the canonical `{ kind: "existing", repo }` object — the exact `IdeaTarget` shape the function itself returns and the shape any TypeScript caller building against the exported `IdeaSubmission` type constructs. Its `targetRepo` branch only recognised the back-compat bare `"owner/name"` string and `{ kind: "provision" }`; everything else fell through to `target_repo_required`. As a result the validator was not idempotent over its own output: `validateIdeaSubmission(validateIdeaSubmission(raw).idea)` returned `{ ok: false, errors: ["target_repo_required"] }` for every valid existing-repo submission, while the `provision` variant round-tripped fine. Reachable from real callers: `src/mcp/server.ts` (`loopover_intake_idea` / `loopover_plan_idea_claims`) and `src/api/routes.ts` thread `validated.idea.targetRepo` into `buildClaimPlan`, which already accepts both variants — only the validator lagged.

## Root cause

When #7635 introduced the `IdeaTarget` discriminated union, the validator's input handling was only half-updated: the `provision` object arm was added, but the `existing` object arm was not — the bare-string wire form remained the only accepted spelling of an existing-repo target.

## Fix (one added `else if` arm, per the required pattern)

- Added a single `else if` arm on the existing `if / else if / else` chain: an object whose `kind` is `"existing"` resolves to `{ kind: "existing", repo }` when `repo` is a string matching the same `owner/name` slug pattern the bare-string branch uses, and pushes the existing `target_repo_malformed` code when `repo` is missing, not a string, empty/whitespace-only, or not a valid slug (a recognised-but-invalid target, matching how the bare-string branch reports a malformed slug).
- The inline regex was hoisted to a module-local constant so both existing-repo arms test the identical pattern — no new exported symbol, no new error code.
- An object whose `kind` is neither `"existing"` nor `"provision"` still pushes `target_repo_required`, unchanged. Bare-string and `{ kind: "provision" }` behaviour is unchanged.

## RED → GREEN

With the fix stashed (current `main` behavior), the 4 new tests in `test/unit/idea-intake-bridge.test.ts` fail; all pre-existing tests pass:

```
Tests  4 failed | 31 passed (35)
  × accepts the canonical { kind: 'existing', repo } object the validator itself returns (#9609)
  × round-trips its own output: re-validating a validated idea succeeds with targetRepo unchanged (#9609)
  × flags a recognised-but-malformed { kind: 'existing' } repo as target_repo_malformed (#9609)
  × flags an { kind: 'existing' } target whose repo is missing, empty, or not a string as target_repo_malformed (#9609)
```

With the fix applied:

```
Test Files  1 passed (1)
     Tests  35 passed (35)
```

Deliverables asserted by name: the canonical-object accept case (`idea.targetRepo` deep-equal to `{ kind: "existing", repo: "acme/widgets" }`); the round-trip regression test (feeds a validated result's own `idea` back in for both union variants and asserts `ok === true` with `targetRepo` unchanged); `{ kind: "existing", repo: "not-a-slug" }` → `["target_repo_malformed"]`; `{ kind: "existing" }`, `repo: ""`, whitespace-only, and non-string `repo` → `["target_repo_malformed"]`; `{ kind: "bogus" }` and `{}` → `["target_repo_required"]`; existing bare-string and provision cases pass unmodified.

## Gates

- `npx vitest run test/unit/idea-intake-bridge.test.ts` — 35/35 passed.
- `npx vitest run --coverage test/unit/idea-intake-bridge.test.ts` — `packages/loopover-engine/src/idea-intake.ts`: **100% lines (73/73), 100% branches (107/107), 100% functions (18/18)** (lcov `LF:73 LH:73 BRF:107 BRH:107 FNF:18 FNH:18`), so every changed line and both arms of every new conditional in the patch are covered (valid, malformed, missing, empty, and non-string `repo`, plus the unrecognised-`kind` fall-through).
- `npm run build --workspace @loopover/engine` — clean.
- `npm run typecheck:root` (`tsc --noEmit`) — clean.
- `git diff --check` — clean.
