### PR TITLE
fix(engine): share governor-ledger's repo-segment guard with the three normalizers that skipped it

### DIFF
--- a/packages/loopover-engine/src/discovery-index-contract.ts
+++ b/packages/loopover-engine/src/discovery-index-contract.ts
@@ -11,6 +11,8 @@
 // miner-goal-spec.ts / fleet-run-manifest.ts: every field optional, malformed input degrades to a documented
 // default with a warning rather than throwing.
 
+import { isValidRepoSegment } from "./repo-segment.js";
+
 export const DISCOVERY_INDEX_CONTRACT_VERSION = 1;
 
 const MAX_QUERY_ITEMS = 200;
@@ -124,10 +126,12 @@ function normalizeStringList(value: unknown, transform: (entry: string) => strin
   return result;
 }
 
-/** `owner/repo` with exactly one slash and non-empty halves; anything else → null (mirrors normalizeCandidate). */
+/** `owner/repo` with exactly one slash and non-empty, path-safe halves — a "." / ".." traversal segment
+ *  fails the shared isValidRepoSegment guard; anything else → null (mirrors normalizeCandidate). */
 function normalizeRepoFullName(value: string): string | null {
   const [owner, repo, extra] = value.trim().split("/");
   if (!owner || !repo || extra !== undefined) return null;
+  if (!isValidRepoSegment(owner) || !isValidRepoSegment(repo)) return null;
   return `${owner}/${repo}`;
 }
 

--- a/packages/loopover-engine/src/discovery-soft-claim.ts
+++ b/packages/loopover-engine/src/discovery-soft-claim.ts
@@ -1,4 +1,5 @@
 import { DISCOVERY_INDEX_CONTRACT_VERSION } from "./discovery-index-contract.js";
+import { isValidRepoSegment } from "./repo-segment.js";
 
 // Soft-claim coordination request builder (#4302). The local soft-claim ledger (claim-ledger.js) is 100%
 // client-side — "never uploads, syncs, or phones home" — and duplicate-cluster adjudication
@@ -53,12 +54,14 @@ export function softClaimActionForStatus(status: SoftClaimStatus): SoftClaimActi
   return status === "active" ? "claim" : "release";
 }
 
-/** `owner/repo` with exactly one slash and non-empty halves; anything else → null (mirrors the discovery-index
- *  contract / claim-ledger repo validation). */
+/** `owner/repo` with exactly one slash and non-empty, path-safe halves; anything else → null (mirrors the
+ *  discovery-index contract / claim-ledger repo validation, including their shared "." / ".." traversal-
+ *  segment rejection). */
 function normalizeRepoFullName(value: unknown): string | null {
   if (typeof value !== "string") return null;
   const [owner, repo, extra] = value.trim().split("/");
   if (!owner || !repo || extra !== undefined) return null;
+  if (!isValidRepoSegment(owner) || !isValidRepoSegment(repo)) return null;
   return `${owner}/${repo}`;
 }
 

--- a/packages/loopover-engine/src/governor-ledger.ts
+++ b/packages/loopover-engine/src/governor-ledger.ts
@@ -1,3 +1,5 @@
+import { isValidRepoSegment } from "./repo-segment.js";
+
 /** Immutable governor decision vocabulary — unknown values fail closed before insert. */
 export const GOVERNOR_LEDGER_EVENT_TYPES = Object.freeze([
   "allowed",
@@ -34,16 +36,6 @@ function normalizeRequiredString(value: unknown, code: string): string {
   const trimmed = value.trim();
   if (!trimmed) throw new Error(code);
   return trimmed;
-}
-
-// #5831/#7525's path-safety guard, restated locally. The miner package's parsers share
-// repo-clone.ts's isValidRepoSegment, but this engine package must not import from the miner package
-// (miner depends on engine, not the reverse), so the semantics are duplicated here deliberately:
-// a segment must be entirely [A-Za-z0-9._-] and must not be a bare "." or ".." traversal segment.
-const REPO_SEGMENT_PATTERN = /^[A-Za-z0-9._-]+$/;
-
-function isValidRepoSegment(segment: string): boolean {
-  return REPO_SEGMENT_PATTERN.test(segment) && segment !== "." && segment !== "..";
 }
 
 function normalizeOptionalRepoFullName(repoFullName: unknown): string | null {

--- a/packages/loopover-engine/src/idea-intake.ts
+++ b/packages/loopover-engine/src/idea-intake.ts
@@ -10,6 +10,7 @@ import {
   type FeasibilityGateInput,
   type FeasibilityVerdict,
 } from "./feasibility.js";
+import { isValidRepoSegment } from "./repo-segment.js";
 
 // Intake bounds — mirror the manifest text-slot handling (focus-manifest.ts): a renter's freeform text is
 // length-capped so one submission can never dominate a public surface.
@@ -101,8 +102,14 @@ export function validateIdeaSubmission(raw: unknown): IdeaValidationResult {
   // `go`). A `{ kind: "provision" }` object requests a not-yet-created repo (#7589). Anything else is missing.
   let resolvedTarget: IdeaTarget | undefined;
   if (isNonEmptyString(input.targetRepo)) {
-    if (/^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/.test(input.targetRepo)) resolvedTarget = { kind: "existing", repo: input.targetRepo };
-    else errors.push("target_repo_malformed");
+    // Same split-and-guard shape as repo-clone.ts's normalizeRepoFullName: exactly two segments, each a
+    // valid repo segment, so a bare "." / ".." traversal segment is rejected at intake too.
+    const [owner, repo, extra] = input.targetRepo.split("/");
+    if (!owner || !repo || extra !== undefined || !isValidRepoSegment(owner) || !isValidRepoSegment(repo)) {
+      errors.push("target_repo_malformed");
+    } else {
+      resolvedTarget = { kind: "existing", repo: input.targetRepo };
+    }
   } else if (typeof input.targetRepo === "object" && input.targetRepo !== null && (input.targetRepo as Record<string, unknown>).kind === "provision") {
     resolvedTarget = { kind: "provision" };
   } else errors.push("target_repo_required");

--- a/packages/loopover-engine/src/index.ts
+++ b/packages/loopover-engine/src/index.ts
@@ -193,6 +193,7 @@ export {
   type GovernorLedgerEventType,
   type NormalizedGovernorLedgerEvent,
 } from "./governor-ledger.js";
+export { REPO_SEGMENT_PATTERN, isValidRepoSegment } from "./repo-segment.js";
 export {
   MINER_TELEMETRY_EVENT_TYPES,
   MINER_TELEMETRY_OUTCOME_BUCKETS,

--- a/packages/loopover-engine/src/repo-segment.ts
+++ b/packages/loopover-engine/src/repo-segment.ts
@@ -1,0 +1,11 @@
+// Shared repo-segment path-safety guard (the #5831 -> #7525 -> #8350 fix family). The miner package's
+// parsers share packages/loopover-miner/lib/repo-clone.ts's isValidRepoSegment, but this engine package
+// must not import from the miner package (miner depends on engine, not the reverse), so the engine keeps
+// its own single copy here: a segment must be entirely [A-Za-z0-9._-] and must not be a bare "." or ".."
+// traversal segment.
+
+export const REPO_SEGMENT_PATTERN = /^[A-Za-z0-9._-]+$/;
+
+export function isValidRepoSegment(segment: string): boolean {
+  return REPO_SEGMENT_PATTERN.test(segment) && segment !== "." && segment !== "..";
+}

--- a/packages/loopover-engine/test/repo-segment.test.ts
+++ b/packages/loopover-engine/test/repo-segment.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  REPO_SEGMENT_PATTERN,
+  buildSoftClaimRequest,
+  isValidRepoSegment,
+  normalizeDiscoveryIndexCandidate,
+  normalizeDiscoveryIndexResponse,
+  validateIdeaSubmission,
+} from "../dist/index.js";
+
+// #9610: the "."/".." path-safety segment guard from the #5831 -> #7525 -> #8350 family now lives in one
+// shared module (repo-segment.ts) and is applied by every engine-package owner/repo normalizer, not just
+// governor-ledger's write path (whose own traversal tests live in governor-ledger.test.ts).
+
+test("repo-segment: isValidRepoSegment accepts GitHub-legal slugs and rejects traversal/non-slug segments (#9610)", () => {
+  for (const segment of ["acme", "a.b_c-d9", "...three-dots-are-a-slug..."]) {
+    assert.equal(isValidRepoSegment(segment), true, segment);
+    assert.equal(REPO_SEGMENT_PATTERN.test(segment), true, segment);
+  }
+  for (const segment of ["evil repo", "", "a/b", ".", ".."]) {
+    assert.equal(isValidRepoSegment(segment), false, segment);
+  }
+});
+
+test("idea-intake: a '.'/'..' traversal segment in a bare-string targetRepo is rejected at intake (#9610)", () => {
+  const idea = { id: "idea-1", title: "t", body: "b" };
+  for (const targetRepo of ["../evilrepo", "./x", "a/..", "../..", "/x", "x/", "a/b/c", "no-slash", "evil repo/x"]) {
+    assert.deepEqual(
+      validateIdeaSubmission({ ...idea, targetRepo }),
+      { ok: false, errors: ["target_repo_malformed"] },
+      targetRepo,
+    );
+  }
+  const accepted = validateIdeaSubmission({ ...idea, targetRepo: "acme/widgets" });
+  assert.equal(accepted.ok, true);
+  if (accepted.ok) assert.deepEqual(accepted.idea.targetRepo, { kind: "existing", repo: "acme/widgets" });
+});
+
+test("discovery-index contract: a traversal-segment repoFullName fails candidate normalization (#9610)", () => {
+  for (const repoFullName of ["../evil", "evil/..", "./evil"]) {
+    assert.equal(normalizeDiscoveryIndexCandidate({ repoFullName, issueNumber: 1, title: "x" }), null, repoFullName);
+  }
+  const valid = normalizeDiscoveryIndexCandidate({ repoFullName: "owner/repo", issueNumber: 1, title: "x" });
+  assert.equal(valid?.repoFullName, "owner/repo");
+
+  const parsed = normalizeDiscoveryIndexResponse({
+    candidates: [
+      { repoFullName: "../evil", issueNumber: 1, title: "x" },
+      { repoFullName: "owner/repo", issueNumber: 2, title: "y" },
+    ],
+  });
+  assert.deepEqual(parsed.response.candidates.map((candidate) => candidate.repoFullName), ["owner/repo"]);
+  assert.ok(parsed.warnings.includes("DiscoveryIndexResponse dropped an invalid or boundary-violating candidate."));
+});
+
+test("discovery soft-claim: a traversal-segment repoFullName never becomes a soft-claim request (#9610)", () => {
+  const claim = { id: 7, repoFullName: "owner/repo", issueNumber: 42, claimedAt: "2026-01-01T00:00:00Z", status: "active" as const };
+  for (const repoFullName of ["../evil", "evil/..", "./evil"]) {
+    assert.equal(buildSoftClaimRequest({ ...claim, repoFullName }), null, repoFullName);
+  }
+  assert.equal(buildSoftClaimRequest(claim)?.repoFullName, "owner/repo");
+});

--- a/test/unit/discovery-index-contract.test.ts
+++ b/test/unit/discovery-index-contract.test.ts
@@ -196,3 +196,26 @@ describe("discovery-index API contract (#4300)", () => {
     });
   });
 });
+
+describe("repo-segment path safety in candidate normalization (#9610)", () => {
+  it("returns null for a candidate whose repoFullName carries a '.'/'..' traversal segment", () => {
+    expect(normalizeDiscoveryIndexCandidate({ repoFullName: "../evil", issueNumber: 1, title: "x" })).toBeNull();
+    expect(normalizeDiscoveryIndexCandidate({ repoFullName: "evil/..", issueNumber: 1, title: "x" })).toBeNull();
+    expect(normalizeDiscoveryIndexCandidate({ repoFullName: "./evil", issueNumber: 1, title: "x" })).toBeNull();
+  });
+
+  it("drops a traversal-segment candidate from a response with the existing invalid-candidate warning", () => {
+    const parsed = normalizeDiscoveryIndexResponse({
+      candidates: [{ repoFullName: "../evil", issueNumber: 1, title: "x" }, VALID_CANDIDATE],
+    });
+    expect(parsed.response.candidates.map((candidate) => candidate.repoFullName)).toEqual(["owner/repo"]);
+    expect(parsed.warnings).toContain("DiscoveryIndexResponse dropped an invalid or boundary-violating candidate.");
+  });
+
+  it("still round-trips a valid owner/repo unchanged through candidate normalization", () => {
+    const normalized = normalizeDiscoveryIndexCandidate(VALID_CANDIDATE);
+    expect(normalized?.repoFullName).toBe("owner/repo");
+    expect(normalized?.owner).toBe("owner");
+    expect(normalized?.repo).toBe("repo");
+  });
+});

--- a/test/unit/discovery-soft-claim.test.ts
+++ b/test/unit/discovery-soft-claim.test.ts
@@ -85,3 +85,15 @@ describe("soft-claim coordination request builder (#4302)", () => {
     }
   });
 });
+
+describe("repo-segment path safety in soft-claim requests (#9610)", () => {
+  it("returns null for a claim whose repoFullName carries a '.'/'..' traversal segment", () => {
+    expect(buildSoftClaimRequest({ ...ACTIVE_CLAIM, repoFullName: "../evil" })).toBeNull();
+    expect(buildSoftClaimRequest({ ...ACTIVE_CLAIM, repoFullName: "evil/.." })).toBeNull();
+    expect(buildSoftClaimRequest({ ...ACTIVE_CLAIM, repoFullName: "./evil" })).toBeNull();
+  });
+
+  it("still round-trips a valid owner/repo unchanged", () => {
+    expect(buildSoftClaimRequest(ACTIVE_CLAIM)?.repoFullName).toBe("owner/repo");
+  });
+});

--- a/test/unit/idea-intake-bridge.test.ts
+++ b/test/unit/idea-intake-bridge.test.ts
@@ -320,3 +320,23 @@ describe("buildClaimPlan — routes a scored task-graph into a loop claim plan (
     expect(plan.graphVerdict).toBe("avoid"); // least-favorable across the graph
   });
 });
+
+describe("validateIdeaSubmission targetRepo path safety (#9610)", () => {
+  it("rejects a '.'/'..' traversal segment in the bare-string targetRepo with target_repo_malformed", () => {
+    for (const targetRepo of ["../evilrepo", "./x", "a/..", "../.."]) {
+      expect(validateIdeaSubmission(rawIdea({ targetRepo }))).toEqual({ ok: false, errors: ["target_repo_malformed"] });
+    }
+  });
+
+  it("still rejects empty halves, extra segments, and non-slug characters", () => {
+    for (const targetRepo of ["/x", "x/", "a/b/c", "no-slash", "evil repo/x", "acme/widg!ts"]) {
+      expect(validateIdeaSubmission(rawIdea({ targetRepo }))).toEqual({ ok: false, errors: ["target_repo_malformed"] });
+    }
+  });
+
+  it("still accepts a well-formed owner/name and resolves it as an existing-repo target", () => {
+    const r = validateIdeaSubmission(rawIdea({ targetRepo: "acme/widgets" }));
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.idea.targetRepo).toEqual({ kind: "existing", repo: "acme/widgets" });
+  });
+});

--- a/test/unit/repo-segment.test.ts
+++ b/test/unit/repo-segment.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { REPO_SEGMENT_PATTERN, isValidRepoSegment } from "../../packages/loopover-engine/src/index";
+
+describe("shared repo-segment path-safety guard (#9610)", () => {
+  it("re-exports the guard from the engine barrel", () => {
+    expect(REPO_SEGMENT_PATTERN).toBeInstanceOf(RegExp);
+    expect(typeof isValidRepoSegment).toBe("function");
+  });
+
+  it("accepts GitHub-legal slug segments", () => {
+    expect(isValidRepoSegment("acme")).toBe(true);
+    expect(isValidRepoSegment("a.b_c-d9")).toBe(true);
+    expect(isValidRepoSegment("...three-dots-are-a-slug...")).toBe(true);
+  });
+
+  it("rejects a segment outside [A-Za-z0-9._-]", () => {
+    expect(isValidRepoSegment("evil repo")).toBe(false);
+    expect(isValidRepoSegment("")).toBe(false);
+    expect(isValidRepoSegment("a/b")).toBe(false);
+  });
+
+  it("rejects the bare '.' and '..' traversal segments", () => {
+    expect(isValidRepoSegment(".")).toBe(false);
+    expect(isValidRepoSegment("..")).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #9610

## Summary

`fix(engine): share governor-ledger's repo-segment guard with the three normalizers that skipped it`

Three `owner/repo` normalizers in `packages/loopover-engine` performed the same "exactly one slash, both halves non-empty" check but skipped the `"."`/`".."` path-safety segment guard that closed #5831 → #7525 → #8350:

1. `idea-intake.ts` — `validateIdeaSubmission({ targetRepo: "../evilrepo" })` returned `ok: true` (regex has the right character class but no traversal rejection), and `buildClaimPlan` copied that value verbatim into every `ClaimStep.targetRepo`. This is the renter-supplied freeform intake path reachable over HTTP (`POST /v1/loop/intake-idea`, `POST /v1/loop/plan-idea-claims`), whose zod schema is deliberately loose because the engine validator "owns the real bounds/format checks".
2. `discovery-index-contract.ts:normalizeRepoFullName` — data from the "OPTIONAL, only-partially-trusted hosted index" flowed into `owner`/`repo` slicing with no segment guard.
3. `discovery-soft-claim.ts:normalizeRepoFullName` — an identical unchecked copy whose JSDoc claimed it "mirrors the … claim-ledger repo validation" (which *does* call `isValidRepoSegment`).

## Root cause

The engine-side copy of the guard lived privately inside `governor-ledger.ts` (deliberately not importable from the miner package), so each sibling normalizer hand-rolled its own slash check without the traversal rejection.

## Fix

- New module `packages/loopover-engine/src/repo-segment.ts` exporting exactly two symbols — `REPO_SEGMENT_PATTERN` (`/^[A-Za-z0-9._-]+$/`) and `isValidRepoSegment` — a straight lift of `governor-ledger.ts:43-47`, byte-for-byte semantics. Both re-exported from `packages/loopover-engine/src/index.ts` in the existing explicit named-export barrel style.
- `governor-ledger.ts` deletes its local copy and imports from `./repo-segment.js`; externally observable behaviour unchanged (its suite passes unmodified).
- `idea-intake.ts` `targetRepo` string branch now follows `repo-clone.ts:87-93`'s shape — split on `/`, reject empty/extra segments, then `isValidRepoSegment` on both halves — rejecting with the existing `target_repo_malformed` code. No new error code.
- `discovery-index-contract.ts` `normalizeRepoFullName` returns `null` when either segment fails the guard; a rejected candidate is still dropped with the existing `"DiscoveryIndexResponse dropped an invalid or boundary-violating candidate."` warning. No new warning string.
- `discovery-soft-claim.ts` `normalizeRepoFullName` likewise returns `null`, so `buildSoftClaimRequest` returns `null` for such a claim, exactly as it already does for a slashless value.
- `packages/loopover-miner/lib/repo-clone.ts` untouched (engine must not import from the miner package). No widened character class, no new regex, no new error/warning strings.

## Tests (RED → GREEN)

New named regression tests, run against the unfixed source first:

```
Test Files  4 failed (4)
     Tests  8 failed | 62 passed (70)
```

(the traversal-rejection tests fail pre-fix; the round-trip/still-accepts tests pass, showing no behavior regression). After the fix, including the untouched governor-ledger suite and both intake routes suites:

```
Test Files  7 passed (7)
     Tests  90 passed (90)
```

- `validateIdeaSubmission({ …, targetRepo: "../evilrepo" })` → `{ ok: false, errors: ["target_repo_malformed"] }`; `"./x"`, `"a/.."`, `"../.."` covered in the same block; `"acme/widgets"` still resolves to `{ kind: "existing", repo: "acme/widgets" }`.
- `normalizeDiscoveryIndexCandidate({ repoFullName: "../evil", issueNumber: 1, title: "x" })` → `null`; `normalizeDiscoveryIndexResponse` drops that candidate and emits the existing invalid-candidate warning.
- `buildSoftClaimRequest({ …, repoFullName: "../evil" })` → `null`.
- A valid `"owner/repo"` round-trips unchanged through all three normalizers, asserted in each suite.
- New dedicated `test/unit/repo-segment.test.ts` covers the barrel re-export plus a passing slug, a pattern-failing segment, `"."`, and `".."`.
- New `packages/loopover-engine/test/repo-segment.test.ts` mirrors all four rejection classes and both accept paths inside the engine package's own node:test suite (801 tests, 801 pass), so the change is behavior-tested by the suite that actually grades engine source — not only by a vitest twin.

## Coverage

Engine source is graded under two Codecov flags, and this diff is covered under **both flags' own coverage runs**:

- **`engine` flag** (c8 over the engine package's own node:test suite — `node --experimental-strip-types scripts/engine-coverage.ts`, CI's exact recipe): cross-referencing the produced `packages/loopover-engine/coverage/lcov.info` against this PR's diff hunks — every changed line covered, zero partial branches on changed lines, and the new `repo-segment.ts` at 100% lines/branches:

```
OK: packages/loopover-engine/src/repo-segment.ts             | uncovered - | partial-branch-lines -
OK: packages/loopover-engine/src/governor-ledger.ts          | changed-lines 2 | uncovered - | partial-branch-lines -
OK: packages/loopover-engine/src/idea-intake.ts              | changed-lines 9 | uncovered - | partial-branch-lines -
OK: packages/loopover-engine/src/discovery-index-contract.ts | changed-lines 5 | uncovered - | partial-branch-lines -
OK: packages/loopover-engine/src/discovery-soft-claim.ts     | changed-lines 5 | uncovered - | partial-branch-lines -
OK: packages/loopover-engine/src/index.ts                    | changed-lines 1 | uncovered - | partial-branch-lines -
```

- **`backend` flag** (root vitest v8 coverage, `packages/loopover-engine/src/**/*.ts` is inside `coverage.include`): same cross-reference against the vitest lcov — all changed lines covered, no partial branches on changed lines; `repo-segment.ts` and `idea-intake.ts` at 100% stmts/branch/funcs/lines.

Both arms of every new conditional are exercised: `isValidRepoSegment` pass / pattern-fail / `"."` / `".."`, and each of the three call sites with accepted and rejected values (empty halves, extra segments, non-slug characters, traversal segments).

## Validation commands (repo root)

```sh
git diff --check                                  # clean
npm run build --workspace @loopover/engine        # clean tsc build
npm run test --workspace @loopover/engine         # 801 tests, 801 pass, 0 fail
node --experimental-strip-types scripts/engine-coverage.ts   # engine-flag lcov: every patch line covered, no partial branches
npx vitest run test/unit                          # green (sole exception: miner-attempt-cli #8808 timeout, which reproduces identically on unmodified origin/main in this environment)
npx vitest run --coverage test/unit/idea-intake-bridge.test.ts test/unit/discovery-index-contract.test.ts test/unit/discovery-soft-claim.test.ts test/unit/repo-segment.test.ts test/unit/governor-ledger.test.ts test/unit/routes-intake-idea.test.ts test/unit/routes-plan-idea-claims.test.ts
npm run typecheck                                 # clean
```
