### PR TITLE
fix(engine): return a fresh copy from getTenantConfig + normalize maxConcurrentLoops (#9614)

### DIFF
--- a/packages/loopover-engine/src/tenant-config.ts
+++ b/packages/loopover-engine/src/tenant-config.ts
@@ -36,6 +36,13 @@ export const DEFAULT_TENANT_CONFIG: TenantConfig = {
   preferences: { maxConcurrentLoops: 1, pauseOnFailure: true, allowedActionClasses: ["open_pr", "comment"] },
 };
 
+// Mirrors the finiteNonNegativeInt discipline already applied in tenant-quota.ts / loop-consumption.ts /
+// worktree-pool.ts of this same #4778 family: a non-finite, negative, or fractional maxConcurrentLoops can
+// never reach a loop-scheduling decision as NaN/negative/fractional (`??` does not catch NaN) (#9614).
+function finiteNonNegativeInt(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
 /**
  * Resolve a tenant's effective config from the defaults plus their overrides. Pure and fully isolated: the
  * returned config shares no mutable reference with the defaults or any other resolution — the action-class list
@@ -52,9 +59,23 @@ export function resolveTenantConfig(overrides: TenantConfigOverrides = {}): Tena
   return {
     autonomyLevel,
     preferences: {
-      maxConcurrentLoops: prefs.maxConcurrentLoops ?? base.preferences.maxConcurrentLoops,
+      maxConcurrentLoops: finiteNonNegativeInt(prefs.maxConcurrentLoops ?? base.preferences.maxConcurrentLoops),
       pauseOnFailure: prefs.pauseOnFailure ?? base.preferences.pauseOnFailure,
       allowedActionClasses: [...(prefs.allowedActionClasses ?? base.preferences.allowedActionClasses)],
+    },
+  };
+}
+
+/** Deep-copy a resolved config so a returned value never shares a mutable reference (the `preferences` object
+ *  or its action-class list) with the immutable store — the same freshly-copied-collections guarantee
+ *  `resolveTenantConfig` gives, applied to an already-stored config (#9614). */
+function copyTenantConfig(config: TenantConfig): TenantConfig {
+  return {
+    autonomyLevel: config.autonomyLevel,
+    preferences: {
+      maxConcurrentLoops: config.preferences.maxConcurrentLoops,
+      pauseOnFailure: config.preferences.pauseOnFailure,
+      allowedActionClasses: [...config.preferences.allowedActionClasses],
     },
   };
 }
@@ -77,7 +98,11 @@ export function setTenantConfig(
   return Object.freeze({ ...store, [tenantId]: resolveTenantConfig(overrides) });
 }
 
-/** Read a tenant's effective config, falling back to a fresh copy of the defaults when they've set none. */
+/** Read a tenant's effective config, falling back to a fresh copy of the defaults when they've set none.
+ *  Always returns a FRESH copy: the store holds an immutable config, and a caller mutating the returned
+ *  value (e.g. pushing to `preferences.allowedActionClasses`) must never rewrite the stored tenant config
+ *  — the leak `Object.freeze`'s shallow freeze left open on the hit path (#9614). */
 export function getTenantConfig(store: TenantConfigStore, tenantId: string): TenantConfig {
-  return store[tenantId] ?? resolveTenantConfig();
+  const stored = store[tenantId];
+  return stored ? copyTenantConfig(stored) : resolveTenantConfig();
 }

--- a/test/unit/tenant-config.test.ts
+++ b/test/unit/tenant-config.test.ts
@@ -68,3 +68,43 @@ describe("tenant config store (#4787)", () => {
     expect(DEFAULT_TENANT_CONFIG.preferences.allowedActionClasses).not.toContain("delete_repo");
   });
 });
+
+describe("getTenantConfig same-tenant isolation + maxConcurrentLoops normalization (#9614)", () => {
+  it("returns a fresh copy on a HIT — a caller mutating it never rewrites that tenant's stored config", () => {
+    const store = setTenantConfig(EMPTY_TENANT_CONFIG_STORE, "acme");
+    const first = getTenantConfig(store, "acme");
+    // The read-path leak (#9614): before the fix, this pushed straight into the stored object.
+    (first.preferences.allowedActionClasses as string[]).push("merge_pr");
+    first.preferences.maxConcurrentLoops = 99;
+
+    const second = getTenantConfig(store, "acme");
+    expect(second.preferences.allowedActionClasses).toEqual(["open_pr", "comment"]);
+    expect(second.preferences.maxConcurrentLoops).toBe(1);
+    // No shared mutable reference between reads.
+    expect(second.preferences).not.toBe(first.preferences);
+    expect(second.preferences.allowedActionClasses).not.toBe(first.preferences.allowedActionClasses);
+  });
+
+  it("falls back to a fresh copy of the defaults on a MISS, and mutating it never touches the shared default", () => {
+    const a = getTenantConfig(EMPTY_TENANT_CONFIG_STORE, "unknown");
+    expect(a).toEqual(DEFAULT_TENANT_CONFIG);
+    (a.preferences.allowedActionClasses as string[]).push("x");
+    expect(getTenantConfig(EMPTY_TENANT_CONFIG_STORE, "unknown").preferences.allowedActionClasses).toEqual(["open_pr", "comment"]);
+    expect(DEFAULT_TENANT_CONFIG.preferences.allowedActionClasses).not.toContain("x");
+  });
+
+  it("normalizes a non-finite / negative / fractional maxConcurrentLoops to a non-negative integer", () => {
+    for (const [input, expected] of [
+      [-5, 0],
+      [0.5, 0],
+      [3.9, 3],
+      [Number.NaN, 0],
+      [Number.POSITIVE_INFINITY, 0],
+      [2, 2],
+    ] as const) {
+      expect(resolveTenantConfig({ preferences: { maxConcurrentLoops: input } }).preferences.maxConcurrentLoops).toBe(expected);
+    }
+    // An absent override inherits the already-valid default (the `??` fallback side).
+    expect(resolveTenantConfig().preferences.maxConcurrentLoops).toBe(1);
+  });
+});


### PR DESCRIPTION
## Problem

Closes #9614.

`packages/loopover-engine/src/tenant-config.ts` promises an IMMUTABLE store where every resolve returns a fresh, isolated config. Two gaps:

1. **`getTenantConfig` leaked the stored object on a hit** (`return store[tenantId] ?? resolveTenantConfig()`). `setTenantConfig`'s `Object.freeze` is shallow, so a caller mutating `preferences.allowedActionClasses` (or `autonomyLevel`) silently rewrote that tenant's stored config — the two fields that decide what the tenant's loop may do. The miss path already returned a fresh copy; the hit path did not.
2. **`maxConcurrentLoops` was never normalized** — `prefs.maxConcurrentLoops ?? base` passes `-5`, `0.5`, `NaN`, `Infinity` through verbatim (`??` doesn't catch `NaN`), unlike every sibling in the #4778 family (tenant-quota / loop-consumption / worktree-pool).

## Fix

- Add `copyTenantConfig` and return a fresh copy from `getTenantConfig` on the hit path too (freshly-copied `preferences` + action-class list), matching the miss path and the module's stated guarantee.
- Add the local `finiteNonNegativeInt` helper (mirroring the three siblings) and normalize `maxConcurrentLoops` through it.

## Tests

`test/unit/tenant-config.test.ts`: a hit-path read whose mutation no longer rewrites the stored config (and shares no reference across reads); a miss-path copy that never mutates the shared default; and normalization of `-5`/`0.5`/`3.9`/`NaN`/`Infinity` → non-negative integers with the default preserved. 100% branch coverage on the changed file.