### PR TITLE
fix(control-plane): give the fake tenant registry KV's last-writer-wins installation index

### DIFF
--- a/control-plane/src/tenant-registry.ts
+++ b/control-plane/src/tenant-registry.ts
@@ -78,14 +78,30 @@ function sortRecords(records: TenantRegistryRecord[]): TenantRegistryRecord[] {
 }
 
 /** In-memory fake for tests -- mirrors `createFakeTenantProvisioningDriver`'s own minimal-fake convention.
- *  `getByOrbInstallationId` is a plain linear scan -- fine for a fake with, at most, a handful of test
- *  records; the real KV-backed registry below needs an actual secondary index instead, since KV has no query
- *  capability at all. */
+ *  `getByOrbInstallationId` resolves through the same write-time installation -> primary-key secondary
+ *  index the real KV-backed registry below keeps (last writer wins, with #9143's compare-and-delete rule
+ *  on a cleared/changed claim), held as an in-memory Map -- NOT a scan of `records`, whose insertion order
+ *  would answer duplicated-installation scenarios first-inserted-wins, the opposite of KV. */
 export function createFakeTenantRegistry(): TenantRegistry {
   const records = new Map<string, TenantRegistryRecord>();
+  const installationIndex = new Map<number, string>();
   return {
     async upsert(record) {
-      records.set(instanceKeyFor(record.tenant.name, record.product), record);
+      const primaryKey = instanceKeyFor(record.tenant.name, record.product);
+      // Mirror createKvTenantRegistry's write-time index maintenance: when this update changes (or clears)
+      // the tenant's installation claim, drop the stale pointer -- but only if it still points at THIS
+      // tenant's own primary key (#9143's compare-and-delete: the ID may since have been legitimately
+      // taken over by another tenant, whose live pointer must survive this record's late upsert).
+      const previous = records.get(primaryKey);
+      if (previous?.orbInstallationId !== undefined && previous.orbInstallationId !== record.orbInstallationId) {
+        if (installationIndex.get(previous.orbInstallationId) === primaryKey) {
+          installationIndex.delete(previous.orbInstallationId);
+        }
+      }
+      records.set(primaryKey, record);
+      if (record.orbInstallationId !== undefined) {
+        installationIndex.set(record.orbInstallationId, primaryKey);
+      }
     },
     async get(name, product) {
       return records.get(instanceKeyFor(name, product));
@@ -94,7 +110,8 @@ export function createFakeTenantRegistry(): TenantRegistry {
       return sortRecords([...records.values()]);
     },
     async getByOrbInstallationId(installationId) {
-      return [...records.values()].find((record) => record.orbInstallationId === installationId);
+      const primaryKey = installationIndex.get(installationId);
+      return primaryKey === undefined ? undefined : records.get(primaryKey);
     },
   };
 }

--- a/control-plane/test/tenant-registry.test.ts
+++ b/control-plane/test/tenant-registry.test.ts
@@ -255,3 +255,45 @@ test("createKvTenantRegistry: an unrelated tenant's installation-index entry SUR
   assert.equal(kv.store.get("installation:555"), "tenant:orb:newcomer");
   assert.equal((await registry.getByOrbInstallationId(555))?.tenant.name, "newcomer");
 });
+
+// #9613: the fake used to answer getByOrbInstallationId with a linear scan of `records` in Map insertion
+// order (first-inserted-wins) while the KV registry resolves through its last-writer-wins installation
+// index -- so for #9143's duplicated-installation scenario the two implementations returned OPPOSITE
+// tenants, and http-app.test.ts (which injects the fake) asserted inverted routing/409 semantics.
+test("createFakeTenantRegistry: an unrelated tenant's installation-index entry SURVIVES a stale record's later re-creation/teardown upsert (#9143)", async () => {
+  const registry = createFakeTenantRegistry();
+
+  // Tenant "old" claimed installation 555 at creation, then failed -- its record still carries the ID.
+  await registry.upsert({ ...recordFor("old", "orb", "failed"), orbInstallationId: 555 });
+  // A brand-new tenant legitimately re-claims installation 555: last writer wins, exactly like KV.
+  await registry.upsert({ ...recordFor("newcomer", "orb", "active"), orbInstallationId: 555 });
+  assert.equal((await registry.getByOrbInstallationId(555))?.tenant.name, "newcomer");
+
+  // "old" is later torn down with no orbInstallationId: the compare-and-delete rule sees the index no
+  // longer points at "old" and leaves newcomer's live pointer alone.
+  await registry.upsert(recordFor("old", "orb", "torn down"));
+  assert.equal((await registry.getByOrbInstallationId(555))?.tenant.name, "newcomer");
+});
+
+test("createFakeTenantRegistry: re-linking a tenant to a different installation ID clears the stale index entry", async () => {
+  const registry = createFakeTenantRegistry();
+  await registry.upsert({ ...recordFor("acme"), orbInstallationId: 555 });
+
+  await registry.upsert({ ...recordFor("acme"), orbInstallationId: 777 });
+
+  assert.equal(await registry.getByOrbInstallationId(555), undefined);
+  assert.equal((await registry.getByOrbInstallationId(777))?.tenant.name, "acme");
+
+  // Re-upserting with the SAME installation ID (state-only change) leaves the pointer in place.
+  await registry.upsert({ ...recordFor("acme", "orb", "torn down"), orbInstallationId: 777 });
+  assert.equal((await registry.getByOrbInstallationId(777))?.state, "torn down");
+});
+
+test("createFakeTenantRegistry: unlinking a tenant's installation ID (upsert without it) clears the stale index entry", async () => {
+  const registry = createFakeTenantRegistry();
+  await registry.upsert({ ...recordFor("acme"), orbInstallationId: 555 });
+
+  await registry.upsert(recordFor("acme"));
+
+  assert.equal(await registry.getByOrbInstallationId(555), undefined);
+});


### PR DESCRIPTION
Closes #9613

## Summary

`fix(control-plane): give the fake tenant registry KV's last-writer-wins installation index`

`createFakeTenantRegistry.getByOrbInstallationId` was `[...records.values()].find(...)` — a linear scan in `Map` insertion order, i.e. **first-inserted-wins** — while `createKvTenantRegistry` resolves through its `installation:${id}` secondary index, which `upsert` repoints on every write: **last-writer-wins**, with #9143's compare-and-delete rule. The two implementations agree only while at most one record carries a given installation ID, and the #9143 comment block in this same file documents that assumption as false by design (`isRecreatableState` lets a failed/torn-down tenant's claim be taken over by a new tenant). For that exact scenario the fake resolved `555` to the stale `"old"` tenant while KV resolves it to `"newcomer"` — and the fake is what `http-app.test.ts` injects, so the `installation_already_claimed` 409 and webhook-routing assertions ran against inverted semantics.

## Root cause

The fake derived the answer by scanning `records` at read time instead of maintaining the write-time installation index the real implementation's semantics come from.

## Fix

- The fake now keeps its own `installationIndex: Map<number, string>` (installation → primary key) inside the closure, maintained on every `upsert` exactly like `createKvTenantRegistry`'s index maintenance: the new claim always repoints the index (last writer wins), and a cleared/changed claim removes the stale entry **only** if it still points at the upserting record's own key (#9143's compare-and-delete — a late upsert of a stale record can never rip out another tenant's live pointer).
- `getByOrbInstallationId` resolves through the index; no scan.
- `upsert`, `get`, and `list` otherwise unchanged, including `list()`'s existing sort. `TenantRegistry` interface, `createKvTenantRegistry`, and `http-app.ts` untouched.
- The fake's header comment now describes the index (no longer "a plain linear scan").

Diff: `control-plane/src/tenant-registry.ts` (+27/−5) and `control-plane/test/tenant-registry.test.ts` (+42) only.

## Tests (RED → GREEN)

Against the unfixed source, the required named regression test fails (the fake resolves the duplicated ID to the stale `"old"` tenant):

```
not ok 232 - createFakeTenantRegistry: an unrelated tenant's installation-index entry SURVIVES a stale record's later re-creation/teardown upsert (#9143)
# tests 234
# pass 233
# fail 1
```

After the fix:

```
# tests 234
# pass 234
# fail 0
```

- The #9143 fake-side scenario: upsert `("old","orb","failed")` with `orbInstallationId: 555`, then `("newcomer","orb","active")` with `555` → `getByOrbInstallationId(555)` resolves to `"newcomer"`; then upsert `("old","orb","torn down")` with no `orbInstallationId` → still `"newcomer"` (compare-and-delete keeps the pointer).
- Re-linking `555 → 777` returns `undefined` for `555` and the tenant for `777` (mirrors the existing KV test), plus a same-ID re-upsert leaves the pointer in place (the unchanged-claim arm).
- Unlinking (upsert without an ID) clears the tenant's own stale entry.
- The existing fake test (`"getByOrbInstallationId finds a tenant by installation ID, undefined for an unclaimed one"`) passes unmodified, as does the whole pre-existing suite.

## Coverage

Control-plane files are graded by the `control-plane` Codecov flag; I ran CI's exact recipe (`node --experimental-strip-types scripts/control-plane-coverage.ts`, c8 over the built dist remapped to `control-plane/src/**`):

```
Statements   : 100% ( 2295/2295 )
Branches     : 100% ( 476/476 )
Functions    : 100% ( 109/109 )
Lines        : 100% ( 2295/2295 )
```

Cross-referencing the lcov against this PR's diff hunks: `control-plane/src/tenant-registry.ts` — changed lines 22, uncovered changed lines none, partial branches on changed lines none; whole file has zero uncovered lines or branches. Both arms of every new conditional are exercised: upsert with an ID / without / changed / unchanged, and the compare-and-delete branch in both the "index still points at me" (delete) and "index points at someone else" (keep) cases.

## Validation commands (repo root)

```sh
git diff --check                                                    # clean
npm run control-plane:test                                          # 234 tests, 234 pass, 0 fail
node --experimental-strip-types scripts/control-plane-coverage.ts   # 100% statements/branches/functions/lines
npm --prefix control-plane run cf:typecheck                         # clean
```
