### PR TITLE
fix(stats): drop counterfactual-replay rows from the public per-rule precision

### DIFF
--- a/src/review/public-rule-precision.ts
+++ b/src/review/public-rule-precision.ts
@@ -45,6 +45,23 @@ export type PublicRulePrecision = {
 };
 
 /**
+ * Provenance tags whose override rows carry a verdict that was NOT a human decision about the rule the row is
+ * filed under, and so cannot support a per-rule "measured accuracy" claim.
+ *
+ * `slop_replay_backfill_v1` (#8277) is the counterfactual replay: it re-scores the deterministic slop signals
+ * over archived diffs, but takes each label verbatim from the `ai_consensus_defect` corpus's human verdict on
+ * the same target (`scripts/backfill-slop-corpus.ts`'s `manifestToSourceCases`). That is exactly the evidence
+ * it was built to be -- internal input to a flip-to-live decision, and by its own module header a LOWER BOUND
+ * on live scoring -- but published under "precision of each automated rule over its human-decided cases" it
+ * asserts something untrue: those were another rule's human-decided cases. It also made the public table print
+ * one number twice, since both rules then shared a label set and a target set.
+ *
+ * NOT excluded: `review_targets_decision_level` (#8083's own backfill), whose labels come from what actually
+ * happened to the PRs THAT rule fired on -- synthesized rows, but genuinely about that rule.
+ */
+const NON_ATTRIBUTABLE_OVERRIDE_PROVENANCES = ["slop_replay_backfill_v1"] as const;
+
+/**
  * Load the public per-rule precision block. Fail-safe per section (the same degradation contract as
  * loadCalibrationTrend): a read error yields an empty/absent section, never a thrown public endpoint.
  */
@@ -57,6 +74,7 @@ export async function loadPublicRulePrecision(env: Env, nowMs: number = Date.now
             SUM(CASE WHEN json_extract(metadata_json, '$.verdict') = 'reversed' THEN 1 ELSE 0 END) AS reversed
        FROM audit_events
       WHERE event_type LIKE '${HUMAN_OVERRIDE_EVENT_TYPE_PREFIX}%' AND created_at >= ?
+        AND COALESCE(json_extract(metadata_json, '$.provenance'), '') NOT IN (${NON_ATTRIBUTABLE_OVERRIDE_PROVENANCES.map((tag) => `'${tag}'`).join(", ")})
       GROUP BY rule_id`,
     sinceIso,
   );

--- a/test/unit/public-rule-precision.test.ts
+++ b/test/unit/public-rule-precision.test.ts
@@ -55,6 +55,46 @@ describe("loadPublicRulePrecision (#8230)", () => {
     expect(block.rules).toEqual([{ ruleId: "sparse_rule", decided: PUBLIC_PRECISION_MIN_DECIDED - 1, confirmed: PUBLIC_PRECISION_MIN_DECIDED - 1, precision: null }]);
   });
 
+  it("REGRESSION: excludes counterfactual-replay rows whose label came from a DIFFERENT rule's human verdicts", async () => {
+    // #8277's slop replay copies each label verbatim from the ai_consensus_defect corpus's verdict on the same
+    // target, so publishing it under "precision over its human-decided cases" both misattributes the verdict and
+    // made the public table print one number twice (both rules showed decided=460/confirmed=287 in production).
+    const env = createTestEnv();
+    await seedVerdicts(env, "ai_consensus_defect", 15, 5);
+    const store = createSignalStore(env);
+    for (let i = 0; i < 20; i += 1) {
+      await store.recordHumanOverride({
+        ruleId: "slop_gate_score",
+        targetKey: `acme/widgets#${i + 1}`,
+        verdict: i < 15 ? "confirmed" : "reversed",
+        occurredAt: new Date(NOW - 1000 - i).toISOString(),
+        metadata: { backfilled: true, provenance: "slop_replay_backfill_v1" },
+      });
+    }
+
+    const block = await loadPublicRulePrecision(env, NOW);
+    expect(block.rules).toEqual([{ ruleId: "ai_consensus_defect", decided: 20, confirmed: 15, precision: 0.75 }]);
+  });
+
+  it("keeps synthesized rows whose labels ARE about the rule they are filed under", async () => {
+    // review_targets_decision_level is #8083's own backfill: the labels come from what happened to the PRs that
+    // rule fired on, so they support a precision claim for it. Only the cross-rule copy is excluded.
+    const env = createTestEnv();
+    const store = createSignalStore(env);
+    for (let i = 0; i < 12; i += 1) {
+      await store.recordHumanOverride({
+        ruleId: "ai_consensus_defect",
+        targetKey: `acme/widgets#${i + 1}`,
+        verdict: i < 9 ? "confirmed" : "reversed",
+        occurredAt: new Date(NOW - 1000 - i).toISOString(),
+        metadata: { backfilled: true, provenance: "review_targets_decision_level" },
+      });
+    }
+
+    const block = await loadPublicRulePrecision(env, NOW);
+    expect(block.rules).toEqual([{ ruleId: "ai_consensus_defect", decided: 12, confirmed: 9, precision: 0.75 }]);
+  });
+
   it("counts all three reversal shapes over the window and surfaces the latest backtest run's corpus checksum", async () => {
     const env = createTestEnv();
     for (const [eventType, count] of [


### PR DESCRIPTION
## Summary

The public "Measured accuracy per rule" table published `ai_consensus_defect` and `slop_gate_score` with **byte-identical** `decided: 460, confirmed: 287, precision: 62.4%`. Not a coincidence — `slop_gate_score`'s override rows are the same label set, copied.

#8277's slop backfill re-scores the deterministic slop signals over archived diffs, but takes each label **verbatim** from the `ai_consensus_defect` corpus's human verdict on the same target: `manifestToSourceCases` (`scripts/backfill-slop-corpus.ts:51-58`) passes `backtestCase.label` straight through, and `replaySlopCorpus` writes it unchanged into the new rule's `verdict` (`scripts/backfill-slop-corpus-core.ts:133-134,165`). Only the *score* side is recomputed.

That is exactly what it was built to be — internal evidence for a flip-to-live decision, and by its own module header "a LOWER BOUND on what live scoring would have produced". But the public table describes itself as *"Precision of each automated rule over its human-decided cases in the last 90 days"*, and those were **another rule's** human-decided cases. It also made the table print one number twice, since both rules then shared a label set and a target set.

Corroborating that the published rows cannot be live measurements: `slop_gate_score` is in `GATE_SCORE_SIGNAL_CODES` (`src/rules/advisory.ts:207`), which `recordImplicitTerminalConfirmations` explicitly excludes (`src/review/outcomes-wire.ts:654`), and `recordConfiguredGateBlockerOverrides` only ever writes `reversed`. On the live path that rule has **no route to a `confirmed` verdict at all**, so a 62.4% could only ever have come from replayed rows.

Excluded by **provenance**, not by rule id, so the next cross-rule replay inherits the same protection. `review_targets_decision_level` (#8083's own backfill) is deliberately **not** excluded — its labels come from what actually happened to the PRs that rule fired on, so they do support a precision claim for it, and there is a test pinning that distinction.

Refs #9676

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Coverage measured **scoped**: `vitest run --coverage` over `public-rule-precision.test.ts` restricted to the changed module reports **100% statements / branches / functions / lines** (19/19, 10/10, 6/6, 17/17). Both sides of the new exclusion are pinned — a cross-rule replay row is dropped, a same-rule synthesized row is kept.
- Ran the neighbouring suites that consume this block (`public-stats`, `public-stats-route`, `public-eval-scores-route`): 59 tests green.
- No UI files touched, so `ui:lint`/`ui:typecheck`/`ui:build` were not run. `ui:openapi:check` passes — response shape is unchanged, only which rows qualify.
- `test:workers`, `build:mcp`, `test:mcp-pack` untouched by this diff; left to CI.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

No auth/CORS/session change. No UI file is touched — the fairness page already renders whatever rows the block returns, so this removes a row rather than changing a component; that is why there is no UI Evidence table here. The existing `INVARIANT: the public payload never carries target keys, repos, confidences, or private terms` test still passes.

## Notes

On the current production data every `slop_gate_score` row carries this provenance, so that rule drops out of the public table entirely and `ai_consensus_defect` remains at 460 / 287 / 62.4%. That is the honest outcome: one rule with a real (if synthesized-from-its-own-history) measurement, instead of two rules appearing to independently corroborate each other while sharing one label set.