### PR TITLE
fix(build): build @loopover/contract in both deploy paths so a clean checkout can deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
-    "deploy:api": "npm --workspace @loopover/engine run build && wrangler d1 migrations apply loopover --remote && wrangler deploy",
+    "deploy:api": "turbo run build --filter=@loopover/engine --filter=@loopover/contract && wrangler d1 migrations apply loopover --remote && wrangler deploy",
     "selfhost:postgres:migrate": "tsx scripts/migrate-selfhost-sqlite-to-postgres.ts",
     "selfhost:env-reference": "node --experimental-strip-types scripts/gen-selfhost-env-reference.ts",
     "selfhost:env-reference:check": "node --experimental-strip-types scripts/gen-selfhost-env-reference.ts --check",
@@ -59,7 +59,7 @@
     "lint:composite-actions": "node --experimental-strip-types scripts/lint-composite-actions.ts",
     "ui:dev": "npm run ui:preview",
     "ui:kit:build": "npm run build --workspace @loopover/ui-kit",
-    "ui:build": "npm run ui:kit:build && turbo run build --filter=@loopover/engine && npm run ui:openapi && npm --workspace @loopover/ui run build && npm --workspace @loopover/ui-miner run build",
+    "ui:build": "npm run ui:kit:build && turbo run build --filter=@loopover/engine --filter=@loopover/contract && npm run ui:openapi && npm --workspace @loopover/ui run build && npm --workspace @loopover/ui-miner run build",
     "ui:preview": "npm run ui:build && wrangler dev --config apps/loopover-ui/dist/server/wrangler.json --ip 127.0.0.1 --port 4173 --local",
     "ui:lint": "npm run ui:kit:build && npm --workspace @loopover/ui-kit run format:check && npm --workspace @loopover/ui run format:check && npm --workspace @loopover/ui run lint && npm --workspace @loopover/ui-miner run format:check && npm --workspace @loopover/ui-miner run lint",
     "ui:typecheck": "npm run ui:kit:build && npm --workspace @loopover/ui run typecheck && npm --workspace @loopover/ui-miner run typecheck",


### PR DESCRIPTION
## Summary

`Workers Builds: loopover-ui` has failed on **every one of the last 25+ commits on `main`**, and it is the deploy path — no GitHub Actions workflow runs `wrangler deploy` (`ui-deploy.yml` only validates). Production has been serving stale code as a result: `#9574`'s `fleetAccuracy.basis` and `#9594`'s anchor-payload auth exemption both landed on `main` on 2026-07-28, and neither is live (`/v1/public/stats` has no `basis` key; `/anchor-payload` still 401s).

The Cloudflare build command is `npm run build:cloudflare` → `npm ci && npm run ui:build`. `ui:build` runs `turbo run build --filter=@loopover/engine`, then `ui:openapi`, whose `scripts/write-ui-openapi.ts` reaches `src/openapi/schemas.ts` and imports `@loopover/contract/dist/public-api.js`. Nothing in that chain builds `@loopover/contract` — `@loopover/engine` does not depend on it — so on a clean checkout:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
  '/opt/buildhome/repo/node_modules/@loopover/contract/dist/public-api.js'
  imported from /opt/buildhome/repo/src/openapi/schemas.ts
```

It passes in `test:ci` only by accident of ordering: `npm run typecheck` runs earlier, and the `//#typecheck` turbo task already carries an explicit `@loopover/contract#build` edge — added for exactly this failure mode, and documented in `turbo.json` as *"the root package.json dependency does NOT create a build edge for a root (`//#`) task"*. Cloudflare runs `ui:build` on its own, so that ordering never applies.

This adds the same edge to `ui:build`'s own turbo invocation, which is the level that actually owns the dependency. One line.

Closes #9731

## Validation

Verified against a genuinely clean tree — package `dist/` directories and `.tsbuildinfo` files removed, `TURBO_FORCE=1` to defeat the shared worktree cache:

| | `ui:build` exit | `@loopover/contract/dist/public-api.js` | `@loopover/engine/dist/parse-pull-request-target-key.js` |
|---|---|---|---|
| `origin/main` | **1** (`ERR_MODULE_NOT_FOUND`) | absent | absent |
| this branch | **0** | emitted | emitted |

Worth recording, because it masked the reproduction twice: `packages/loopover-engine`'s build does not clear its own `.tsbuildinfo` the way `@loopover/contract`'s does, so deleting `dist/` alone leaves `tsc` a silent no-op; and turbo's shared worktree cache replays a stale `dist` unless forced. Neither applies to a fresh Cloudflare clone, but both produce a convincing false result locally. Flagged on #9731 rather than fixed here.

- [x] `git diff --check`
- [x] `npm run ui:build` from a clean tree (the actual regression)
- [x] `npm run ui:openapi:check` — no OpenAPI drift
- [ ] `npm run test:coverage` / `test:workers` / `build:mcp` / `test:mcp-pack` — not run; this changes one npm script and no `src/**` line, so there is nothing for `codecov/patch` to measure. Left to CI.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

No runtime code changes — one npm script gains a build dependency it already had implicitly. No rendered output changes, hence no UI Evidence table. No secrets involved; this touches no credential path.

## Notes

**Merge this one first.** The other four open PRs (#9675, #9718, #9720, #9721) all carry the same red `Workers Builds` check for this reason, and none of them will reach production until deploys work again. `Workers Builds: loopover-api` also fails on these commits; whether it shares this root cause is unconfirmed — its log has not been read.