### PR TITLE
fix(selfhost): fail preflight on half-configured ledger anchoring instead of silently skipping it

### DIFF
--- a/apps/loopover-ui/src/lib/selfhost-env-reference.ts
+++ b/apps/loopover-ui/src/lib/selfhost-env-reference.ts
@@ -282,6 +282,26 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
     firstReference: "src/selfhost/ai.ts",
   },
   {
+    name: "LOOPOVER_LEDGER_ANCHOR_GIT_INSTALLATION_ID",
+    firstReference: "src/selfhost/preflight.ts",
+  },
+  {
+    name: "LOOPOVER_LEDGER_ANCHOR_GIT_OWNER",
+    firstReference: "src/selfhost/preflight.ts",
+  },
+  {
+    name: "LOOPOVER_LEDGER_ANCHOR_GIT_REPO",
+    firstReference: "src/selfhost/preflight.ts",
+  },
+  {
+    name: "LOOPOVER_LEDGER_ANCHOR_KEYS",
+    firstReference: "src/selfhost/preflight.ts",
+  },
+  {
+    name: "LOOPOVER_LEDGER_ANCHOR_PRIVATE_KEY",
+    firstReference: "src/selfhost/preflight.ts",
+  },
+  {
     name: "LOOPOVER_MCP_TOKEN",
     firstReference: "src/selfhost/preflight.ts",
   },
@@ -759,6 +779,11 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| `LOOPOVER_CENTRAL_POSTHOG_KEY` | `src/selfhost/posthog.ts` |",
   "| `LOOPOVER_ENABLE_PAGERDUTY` | `src/services/notify-pagerduty.ts` |",
   "| `LOOPOVER_ENABLE_UNSAFE_CODEX_REVIEWER` | `src/selfhost/ai.ts` |",
+  "| `LOOPOVER_LEDGER_ANCHOR_GIT_INSTALLATION_ID` | `src/selfhost/preflight.ts` |",
+  "| `LOOPOVER_LEDGER_ANCHOR_GIT_OWNER` | `src/selfhost/preflight.ts` |",
+  "| `LOOPOVER_LEDGER_ANCHOR_GIT_REPO` | `src/selfhost/preflight.ts` |",
+  "| `LOOPOVER_LEDGER_ANCHOR_KEYS` | `src/selfhost/preflight.ts` |",
+  "| `LOOPOVER_LEDGER_ANCHOR_PRIVATE_KEY` | `src/selfhost/preflight.ts` |",
   "| `LOOPOVER_MCP_TOKEN` | `src/selfhost/preflight.ts` |",
   "| `LOOPOVER_METRICS_REPO_LABELS` | `src/server.ts` |",
   "| `LOOPOVER_PUBLIC_SCORE_TERMS_ALLOWED_REPOS` | `src/selfhost/inert-config.ts` |",

--- a/src/selfhost/preflight.ts
+++ b/src/selfhost/preflight.ts
@@ -1,5 +1,6 @@
 import { createPrivateKey } from "node:crypto";
 import { CRON_INTERVAL_MIN_MS } from "./cron-alignment";
+import { currentAnchorKey, parseAnchorPublicKeys } from "../review/ledger-anchor";
 
 export type SelfHostPreflightProblem = {
   var: string;
@@ -67,6 +68,83 @@ function isGitHubAppPrivateKey(value: string): boolean {
     return createPrivateKey(value.replace(/\\n/g, "\n")).asymmetricKeyType === "rsa";
   } catch {
     return false;
+  }
+}
+
+/**
+ * Ledger anchoring (#9769) is OPT-IN, so "nothing configured" is deliberately not a problem. What IS a
+ * problem is PARTIAL configuration, because it fails completely silently: runScheduledLedgerAnchor logs
+ * `ledger_anchor_skipped_unconfigured` and returns (ledger-anchor-scheduler.ts), while the job keeps firing
+ * every couple of minutes. An operator who set half the vars has no signal at all that anchoring never runs
+ * -- and a self-host container DOES run the scheduler and DOES have a populated decision_ledger, so it is
+ * genuinely one keypair away from working.
+ *
+ * The published-key checks call the real `parseAnchorPublicKeys`/`currentAnchorKey` rather than
+ * re-validating the shape here, so preflight can never disagree with what the scheduler will actually do.
+ */
+function checkLedgerAnchorConfig(problems: SelfHostPreflightProblem[], env: SelfHostPreflightEnv): void {
+  const rawKeys = nonBlank(env["LOOPOVER_LEDGER_ANCHOR_KEYS"]);
+  const privateKey = nonBlank(env["LOOPOVER_LEDGER_ANCHOR_PRIVATE_KEY"]);
+
+  if (rawKeys && !privateKey) {
+    addProblem(
+      problems,
+      "LOOPOVER_LEDGER_ANCHOR_PRIVATE_KEY",
+      "LOOPOVER_LEDGER_ANCHOR_KEYS is set but the private half is not, so anchoring silently never runs. Set the P-256 PKCS8 private key, or unset LOOPOVER_LEDGER_ANCHOR_KEYS to disable anchoring.",
+    );
+  }
+  if (privateKey && !rawKeys) {
+    addProblem(
+      problems,
+      "LOOPOVER_LEDGER_ANCHOR_KEYS",
+      "LOOPOVER_LEDGER_ANCHOR_PRIVATE_KEY is set but no public key list is published, so anchors would be unverifiable and anchoring silently never runs. Publish the matching key, or unset the private key to disable anchoring.",
+    );
+  }
+  if (rawKeys) {
+    const keys = parseAnchorPublicKeys(rawKeys);
+    if (keys.length === 0) {
+      addProblem(
+        problems,
+        "LOOPOVER_LEDGER_ANCHOR_KEYS",
+        "No usable entries parsed. Expected a JSON array of { keyId, publicKeySpki, notBefore, notAfter }; malformed JSON and entries missing any required field are dropped silently at runtime.",
+      );
+    } else if (currentAnchorKey(keys) === null) {
+      const current = keys.filter((key) => key.notAfter === null).length;
+      addProblem(
+        problems,
+        "LOOPOVER_LEDGER_ANCHOR_KEYS",
+        current === 0
+          ? "No entry has notAfter: null, so there is no current signing key and anchoring silently never runs. Exactly one entry must be open-ended."
+          : `${current} entries have notAfter: null. An ambiguous rotation fails closed rather than guessing which key signs, so anchoring silently never runs. Exactly one entry must be open-ended.`,
+      );
+    }
+  }
+
+  // The git backend is independently optional, but owner+repo without an installation id means job-dispatch
+  // resolves `submitGit` to null and the backend is skipped without comment.
+  const gitOwner = nonBlank(env["LOOPOVER_LEDGER_ANCHOR_GIT_OWNER"]);
+  const gitRepo = nonBlank(env["LOOPOVER_LEDGER_ANCHOR_GIT_REPO"]);
+  const installationId = nonBlank(env["LOOPOVER_LEDGER_ANCHOR_GIT_INSTALLATION_ID"]);
+  if (gitOwner && gitRepo && !installationId) {
+    addProblem(
+      problems,
+      "LOOPOVER_LEDGER_ANCHOR_GIT_INSTALLATION_ID",
+      "A git anchor target is configured but no installation id is set, so no write token can be minted and the git backend is skipped silently. Set the installation id, or unset the git owner/repo.",
+    );
+  }
+  if (installationId && !/^[1-9][0-9]*$/.test(installationId)) {
+    addProblem(
+      problems,
+      "LOOPOVER_LEDGER_ANCHOR_GIT_INSTALLATION_ID",
+      "Must be a positive integer; any other value resolves to no git submitter and the backend is skipped silently.",
+    );
+  }
+  if ((gitOwner && !gitRepo) || (gitRepo && !gitOwner)) {
+    addProblem(
+      problems,
+      gitOwner ? "LOOPOVER_LEDGER_ANCHOR_GIT_REPO" : "LOOPOVER_LEDGER_ANCHOR_GIT_OWNER",
+      "A git anchor target needs BOTH owner and repo; with only one set the backend is skipped silently.",
+    );
   }
 }
 
@@ -265,6 +343,8 @@ export function preflightEnv(env: SelfHostPreflightEnv): SelfHostPreflightResult
   positiveInteger(problems, env, "CRON_INTERVAL_MS", CRON_INTERVAL_MIN_MS, 24 * 60 * 60_000);
   positiveInteger(problems, env, "PORT", 1, 65_535);
   positiveInteger(problems, env, "GITHUB_CACHE_TTL_SECONDS", 0, 86_400);
+
+  checkLedgerAnchorConfig(problems, env);
 
   return problems.length === 0 ? { ok: true, problems: [] } : { ok: false, problems };
 }

--- a/test/unit/selfhost-preflight.test.ts
+++ b/test/unit/selfhost-preflight.test.ts
@@ -440,3 +440,101 @@ describe("self-host environment preflight (#2080)", () => {
     );
   });
 });
+
+describe("ledger-anchor configuration preflight (#9769)", () => {
+  const privateKey = generateKeyPairSync("rsa", { modulusLength: 2048 }).privateKey.export({ format: "pem", type: "pkcs8" }).toString();
+  const base = { REDIS_URL: "redis://redis:6379", GITHUB_APP_ID: "123", GITHUB_APP_PRIVATE_KEY: privateKey };
+  const key = (over: Record<string, unknown> = {}) => JSON.stringify([{ keyId: "k1", publicKeySpki: "c3BraQ==", notBefore: "2026-01-01T00:00:00.000Z", notAfter: null, ...over }]);
+  const anchorProblems = (env: Record<string, string | undefined>) => {
+    const result = preflightEnv({ ...base, ...env });
+    return result.problems.filter((p: SelfHostPreflightProblem) => p.var.startsWith("LOOPOVER_LEDGER_ANCHOR"));
+  };
+
+  it("INVARIANT: anchoring is opt-in — configuring none of it is never a problem", () => {
+    expect(preflightEnv(base)).toEqual({ ok: true, problems: [] });
+  });
+
+  it("accepts a fully configured Rekor-only setup", () => {
+    expect(anchorProblems({ LOOPOVER_LEDGER_ANCHOR_KEYS: key(), LOOPOVER_LEDGER_ANCHOR_PRIVATE_KEY: "pem" })).toEqual([]);
+  });
+
+  it("REGRESSION: catches a published key with no private half — silently disables anchoring today", () => {
+    expect(anchorProblems({ LOOPOVER_LEDGER_ANCHOR_KEYS: key() })).toEqual([
+      expect.objectContaining({ var: "LOOPOVER_LEDGER_ANCHOR_PRIVATE_KEY" }),
+    ]);
+  });
+
+  it("REGRESSION: catches a private key with nothing published — anchors would be unverifiable", () => {
+    expect(anchorProblems({ LOOPOVER_LEDGER_ANCHOR_PRIVATE_KEY: "pem" })).toEqual([
+      expect.objectContaining({ var: "LOOPOVER_LEDGER_ANCHOR_KEYS" }),
+    ]);
+  });
+
+  it("catches a key list that parses to nothing (malformed JSON, or entries missing required fields)", () => {
+    for (const raw of ["not json", "{}", "[]", JSON.stringify([{ keyId: "k1" }])]) {
+      expect(anchorProblems({ LOOPOVER_LEDGER_ANCHOR_KEYS: raw, LOOPOVER_LEDGER_ANCHOR_PRIVATE_KEY: "pem" })).toEqual([
+        expect.objectContaining({ var: "LOOPOVER_LEDGER_ANCHOR_KEYS", message: expect.stringContaining("No usable entries") }),
+      ]);
+    }
+  });
+
+  it("catches a key list with no open-ended entry — no current signing key", () => {
+    const problems = anchorProblems({ LOOPOVER_LEDGER_ANCHOR_KEYS: key({ notAfter: "2026-06-01T00:00:00.000Z" }), LOOPOVER_LEDGER_ANCHOR_PRIVATE_KEY: "pem" });
+    expect(problems[0]?.message).toContain("No entry has notAfter: null");
+  });
+
+  it("catches an AMBIGUOUS rotation — more than one open-ended entry fails closed at runtime", () => {
+    const twoOpen = JSON.stringify([
+      { keyId: "k1", publicKeySpki: "c3BraQ==", notBefore: "2026-01-01T00:00:00.000Z", notAfter: null },
+      { keyId: "k2", publicKeySpki: "c3BraR==", notBefore: "2026-02-01T00:00:00.000Z", notAfter: null },
+    ]);
+    const problems = anchorProblems({ LOOPOVER_LEDGER_ANCHOR_KEYS: twoOpen, LOOPOVER_LEDGER_ANCHOR_PRIVATE_KEY: "pem" });
+    expect(problems[0]?.message).toContain("2 entries have notAfter: null");
+  });
+
+  it("catches a git target with no installation id — the backend is skipped silently", () => {
+    expect(
+      anchorProblems({
+        LOOPOVER_LEDGER_ANCHOR_KEYS: key(),
+        LOOPOVER_LEDGER_ANCHOR_PRIVATE_KEY: "pem",
+        LOOPOVER_LEDGER_ANCHOR_GIT_OWNER: "acme",
+        LOOPOVER_LEDGER_ANCHOR_GIT_REPO: "anchors",
+      }),
+    ).toEqual([expect.objectContaining({ var: "LOOPOVER_LEDGER_ANCHOR_GIT_INSTALLATION_ID" })]);
+  });
+
+  it("catches a non-positive-integer installation id", () => {
+    for (const bad of ["0", "-1", "abc", "1.5"]) {
+      const problems = anchorProblems({
+        LOOPOVER_LEDGER_ANCHOR_KEYS: key(),
+        LOOPOVER_LEDGER_ANCHOR_PRIVATE_KEY: "pem",
+        LOOPOVER_LEDGER_ANCHOR_GIT_OWNER: "acme",
+        LOOPOVER_LEDGER_ANCHOR_GIT_REPO: "anchors",
+        LOOPOVER_LEDGER_ANCHOR_GIT_INSTALLATION_ID: bad,
+      });
+      expect(problems.some((p) => p.message.includes("positive integer"))).toBe(true);
+    }
+  });
+
+  it("catches half a git target in either direction", () => {
+    const shared = { LOOPOVER_LEDGER_ANCHOR_KEYS: key(), LOOPOVER_LEDGER_ANCHOR_PRIVATE_KEY: "pem", LOOPOVER_LEDGER_ANCHOR_GIT_INSTALLATION_ID: "42" };
+    expect(anchorProblems({ ...shared, LOOPOVER_LEDGER_ANCHOR_GIT_OWNER: "acme" })).toEqual([
+      expect.objectContaining({ var: "LOOPOVER_LEDGER_ANCHOR_GIT_REPO" }),
+    ]);
+    expect(anchorProblems({ ...shared, LOOPOVER_LEDGER_ANCHOR_GIT_REPO: "anchors" })).toEqual([
+      expect.objectContaining({ var: "LOOPOVER_LEDGER_ANCHOR_GIT_OWNER" }),
+    ]);
+  });
+
+  it("accepts a fully configured git + Rekor setup", () => {
+    expect(
+      anchorProblems({
+        LOOPOVER_LEDGER_ANCHOR_KEYS: key(),
+        LOOPOVER_LEDGER_ANCHOR_PRIVATE_KEY: "pem",
+        LOOPOVER_LEDGER_ANCHOR_GIT_OWNER: "acme",
+        LOOPOVER_LEDGER_ANCHOR_GIT_REPO: "anchors",
+        LOOPOVER_LEDGER_ANCHOR_GIT_INSTALLATION_ID: "42",
+      }),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Anchoring has nine `LOOPOVER_LEDGER_ANCHOR_*` vars, all documented in `env.d.ts` and all genuinely read — and **not one appeared in any self-host preflight or config-lint**. An operator got zero boot-time guidance.

That matters more than a normal missing-config warning because the failure is *completely silent*: `runScheduledLedgerAnchor` logs `ledger_anchor_skipped_unconfigured` and returns (`ledger-anchor-scheduler.ts:113-121`), while the job keeps firing every ~2 minutes doing two queries and nothing else.

And the stakes are higher than they look: a self-host container **already runs the anchor scheduler** (`src/index.ts:145` → `src/server.ts:1322-1339` → `processJob` directly, bypassing the hosted ack-and-drop) and **already has a populated `decision_ledger`**. It is genuinely one keypair away from real anchoring, and nothing tells the operator that.

Closes #9769

## What changed

**Anchoring stays opt-in.** Configuring none of it is deliberately not a problem — `preflightEnv`'s problems are fatal (`assertSelfHostPreflight` throws), and turning an optional feature into a boot requirement would be a worse bug than the one being fixed. There's an invariant test pinning that so a future edit can't quietly do it.

What now fails preflight is **partial** configuration — every case of which silently disables anchoring while looking configured:

| Case | Why it's silent today |
|---|---|
| published keys, no private half | scheduler skips; nothing surfaces |
| private key, nothing published | anchors would be unverifiable; scheduler skips |
| key list parses to zero usable entries | malformed JSON **and** entries missing a required field are both dropped silently by `parseAnchorPublicKeys` |
| no entry with `notAfter: null`, **or more than one** | `currentAnchorKey` fails closed on an ambiguous rotation rather than guessing which key signs |
| git owner/repo with no installation id | no write token can be minted, so `job-dispatch` resolves `submitGit` to `null` and the backend is skipped |
| non-positive-integer installation id, or half a git target | same silent skip |

**The key checks call the real `parseAnchorPublicKeys`/`currentAnchorKey`** rather than re-validating the shape locally, so preflight can never disagree with what the scheduler will actually do. A second hand-written copy of those rules is precisely how this drifts apart again.

## Validation

| Check | Result |
|---|---|
| Patch coverage | **80 changed lines, 0 uncovered, 0 partial branches** |
| `selfhost-preflight` suite | **39 tests pass** (10 new) |
| `typecheck` · `ui:typecheck` · `selfhost:validate-observability` · `selfhost:env-reference:check` · `git diff --check` | all clean |

The ambiguous-rotation case is worth calling out as a test: two entries with `notAfter: null` is the one an operator is most likely to create *during* a rotation, and it fails closed at runtime with no message.

## Regenerated artifact

`apps/loopover-ui/src/lib/selfhost-env-reference.ts` — required, since preflight now reads these vars under `src/selfhost/**`. Worth naming as a side benefit rather than noise: **all five anchor vars now appear in the generated operator-facing env documentation for the first time**, which is itself part of the problem #9769 describes.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

This reads key **metadata** only — `keyId`, `publicKeySpki`, `notBefore`/`notAfter` — and never the private key's contents, only whether it is set. No key material reaches a preflight message; every message names the variable and the consequence. The only rendered output is the generated env-reference table, which lists variable names and the file that reads them, so there is no UI Evidence table.

## Notes

Decision-independent by design: this is correct under every option on #9719, including the one where anchoring stays a per-deployment capability and the hosted list stays empty on purpose.