### PR TITLE
fix(auth): normalize INTERNAL_JOB_TOKEN whitespace like the three private secrets

### DIFF
--- a/src/auth/security.ts
+++ b/src/auth/security.ts
@@ -119,7 +119,12 @@ export async function authenticatePrivateToken(env: Env, token: string | undefin
 }
 
 export async function authenticateInternalToken(env: Env, token: string | undefined): Promise<AuthIdentity | null> {
-  if (await timingSafeEqual(token, env.INTERNAL_JOB_TOKEN)) return { kind: "static", actor: "internal" };
+  // Mirror authenticatePrivateToken's normalization (#9713): early-exit on a falsy bearer, and compare against the
+  // trimmed secret via nonBlank(). extractBearerToken already trims the incoming token, so an INTERNAL_JOB_TOKEN
+  // secret carrying a trailing newline (the shape a `wrangler secret put` piped from a file produces) would
+  // otherwise never match any caller and 401 every /v1/internal/* route, unlike the three secrets above.
+  if (!token) return null;
+  if (await timingSafeEqual(token, nonBlank(env.INTERNAL_JOB_TOKEN))) return { kind: "static", actor: "internal" };
   return null;
 }
 

--- a/test/unit/auth-security-helpers.test.ts
+++ b/test/unit/auth-security-helpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  authenticateInternalToken,
   buildBrowserSessionCookie,
   buildClearedBrowserSessionCookie,
   buildClearedGitHubOAuthStateCookie,
@@ -134,5 +135,38 @@ describe("session/oauth cookie builders", () => {
     expect(buildClearedGitHubOAuthStateCookie("http://[::1]/cb")).toBe(
       "loopover_oauth_state=; Max-Age=0; Path=/v1/auth/github; SameSite=Lax; HttpOnly",
     );
+  });
+});
+
+describe("authenticateInternalToken (#9713)", () => {
+  // authenticateInternalToken reads only env.INTERNAL_JOB_TOKEN, so a minimal cast keeps this pure-helper
+  // suite dependency-light (no D1) while still exercising both the nonBlank() and the early-exit branches.
+  const envWith = (internalJobToken: string): Env => ({ INTERNAL_JOB_TOKEN: internalJobToken }) as unknown as Env;
+
+  it("trims surrounding whitespace on INTERNAL_JOB_TOKEN, matching the three private secrets (regression for #9713)", async () => {
+    const env = envWith("  secret  ");
+    await expect(authenticateInternalToken(env, "secret")).resolves.toEqual({ kind: "static", actor: "internal" });
+  });
+
+  it("authenticates a correct, untrimmed secret (bearer already trimmed by extractBearerToken)", async () => {
+    const env = envWith("secret");
+    await expect(authenticateInternalToken(env, "secret")).resolves.toEqual({ kind: "static", actor: "internal" });
+  });
+
+  it("authenticates nobody when INTERNAL_JOB_TOKEN is whitespace-only", async () => {
+    const env = envWith("   ");
+    // The blank secret trims to undefined via nonBlank(), so even the same whitespace never matches.
+    await expect(authenticateInternalToken(env, "   ")).resolves.toBeNull();
+    await expect(authenticateInternalToken(env, "")).resolves.toBeNull();
+  });
+
+  it("early-returns null for an absent bearer without consulting the secret", async () => {
+    const env = envWith("secret");
+    await expect(authenticateInternalToken(env, undefined)).resolves.toBeNull();
+  });
+
+  it("rejects a token that does not match the configured secret", async () => {
+    const env = envWith("secret");
+    await expect(authenticateInternalToken(env, "wrong")).resolves.toBeNull();
   });
 });


### PR DESCRIPTION
## What & why

`src/auth/security.ts` has two token authenticators side by side. `authenticatePrivateToken` early-returns `null` for a falsy token, then compares against `nonBlank(env.LOOPOVER_API_TOKEN)`, `nonBlank(env.LOOPOVER_MCP_ADMIN_TOKEN)`, and `nonBlank(env.LOOPOVER_MCP_TOKEN)`. `authenticateInternalToken` was the only one of the four comparing against the **raw** `env.INTERNAL_JOB_TOKEN`, with no `nonBlank()` and no early exit.

`extractBearerToken` already trims the incoming bearer, so a configured `INTERNAL_JOB_TOKEN` carrying leading/trailing whitespace — the exact shape a secret file or a `wrangler secret put` piped from a file produces when it ends in a newline — could **never** be matched by any caller, while the same whitespace on `LOOPOVER_API_TOKEN` is tolerated. The failure mode is a blanket `401 unauthorized` from the `/v1/internal/*` middleware for every internal job route and read endpoint, with nothing pointing at whitespace as the cause.

## The fix

`authenticateInternalToken` now applies `nonBlank()` to `env.INTERNAL_JOB_TOKEN` and early-returns `null` for an absent/empty `token`, mirroring `authenticatePrivateToken` exactly (the existing module-local `nonBlank` helper and the existing `timingSafeEqual` call shape — no new helper, no change to `timingSafeEqual` semantics, no change at the middleware call site or to the incoming bearer).

This is a normalization gap, not a fail-open one: `timingSafeEqual` already returns `false` for an empty/undefined expected value, and `nonBlank("   ")` is `undefined`, so a whitespace-only secret still authenticates nobody.

## Tests (`test/unit/auth-security-helpers.test.ts`)

New `#9713` suite covering every DoD case:

- `INTERNAL_JOB_TOKEN = "  secret  "`, bearer `"secret"` → `{ kind: "static", actor: "internal" }` (named regression; **fails on current `main`**).
- Untrimmed correct secret (`"secret"` / `"secret"`) → internal identity (unchanged behavior).
- `INTERNAL_JOB_TOKEN = "   "` (whitespace-only) → `authenticateInternalToken(env, "   ")` and `(env, "")` both `null`.
- `authenticateInternalToken(env, undefined)` → `null` without consulting the secret.
- A non-matching token → `null`.

Both arms of the new `if (!token)` guard and both arms of the `nonBlank` result are covered.

## Validation

- `npm run typecheck` green; full auth suite green.
- Diff branch coverage on `src/auth/security.ts` is 100% (every added line and branch); the file's whole-file branch coverage is well above the gate floor.
- `git diff --check` clean; no route/schema/wrangler/migration change, so nothing to regenerate.
- Diff is two files: `src/auth/security.ts` + its unit test.

Closes #9713
