### PR TITLE
chore(release): move the ORB target to 3.6.0 so the beta channel resumes

### DIFF
--- a/orb-manifest.json
+++ b/orb-manifest.json
@@ -1,4 +1,4 @@
 {
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "Source of truth for the self-hostable loopover-orb container image's target release version (ghcr.io/jsonbored/loopover-selfhost). Bumped by a maintainer when a feat/fix/breaking change since the last stable orb-v tag warrants moving to a new target version -- scripts/orb-release-core.ts and .github/workflows/orb-beta-release.yml read this file to decide what version the next automated beta snapshot targets. Promoting a beta to a stable orb-vX.Y.Z release is still a manual `git tag` -- this manifest only drives the automated beta channel."
 }


### PR DESCRIPTION
## What

One line: `orb-manifest.json` `3.5.0` → `3.6.0`.

## Why

`orb-v3.5.0` shipped as stable on 2026-07-27, but the manifest still declares `3.5.0` as the target. `orb-release-core.ts` deliberately refuses to cut a beta for a version that already has a stable tag:

> A STABLE tag already exists for targetVersion (the manifest's own declared intent has already fully shipped) — cutting a beta for that exact version now would either collide with a pre-promotion beta tag or silently mean "another beta of an already-released version". Nothing is due until a human moves the manifest's target forward.

So every nightly `orb-beta-release` run since the stable release has reported `due: false` and done nothing. **The beta channel has been dormant, with 73 image-relevant commits accumulated behind it** — which is why the ORB server is still on `beta.10`.

This is the automation working as designed and waiting on the one step it never takes itself. The report already named the answer:

| before | after |
|---|---|
| `due: false` | `due: true` |
| `nextTag: orb-v3.5.0-beta.1` (already exists) | `nextTag: orb-v3.6.0-beta.1` |
| `manifestStale: true` | `manifestStale: false` |
| `inferredVersion: 3.6.0` | matches the target |

`3.6.0` is the tool's own `inferredVersion`, derived from the `feat:` commits since the last stable — not a number I picked.

## Note

Nothing here surfaced that the channel had stalled; it just quietly reported `due: false` nightly. Worth a follow-up so a stale manifest is visible rather than silent, but that's a separate change from unblocking the release.

**Merge order:** #9776 (the migration boot-crash fix) must land before an image is actually cut.