### PR TITLE
fix(content-lane): reject a non-integer subnet netuid instead of coercing it to subnet 0

### DIFF
--- a/src/review/content-lane/registry-logic.ts
+++ b/src/review/content-lane/registry-logic.ts
@@ -552,10 +552,14 @@ export function assessSubnetDocument(
     return fail("malformed-json", "Subnet document must be a JSON object.");
   }
   const doc = document as { netuid?: unknown; surfaces?: unknown };
-  if (!Number.isInteger(Number(doc.netuid))) {
+  // Type-first, like the `!Array.isArray(doc.surfaces)` sibling below: validate the RAW value, never Number(raw)
+  // (#9665). Number() coerces null/""/[]/booleans/hex/whitespace strings into "valid" integers, so a document
+  // with `netuid: null` was silently accepted as subnet 0 and threaded into assessSurfaceEntry's consistency
+  // check as if validated. A netuid is a non-negative index, so a negative integer is rejected too.
+  if (typeof doc.netuid !== "number" || !Number.isInteger(doc.netuid) || doc.netuid < 0) {
     return fail("unsupported-shape", "Subnet document netuid must be an integer.");
   }
-  const netuid = Number(doc.netuid); // normalize once; thread the canonical integer to entry + (future) grounding
+  const netuid = doc.netuid; // already validated as a non-negative integer above; no coercion on this path
   if (!Array.isArray(doc.surfaces)) {
     return fail("unsupported-shape", "Subnet document must carry a surfaces[] array.");
   }

--- a/test/unit/content-lane-registry-logic.test.ts
+++ b/test/unit/content-lane-registry-logic.test.ts
@@ -231,9 +231,41 @@ describe("assessSubnetDocument (whole-file gate: root netuid + exactly-one appen
     expect(assessSubnetDocument(dirty, { appendedEntry: entry, secretsScan: false }).verdict).toBe("merged");
   });
 
-  it("threads the normalized root netuid to the entry (string root coerces; conflicting entry netuid rejected)", () => {
-    expect(assessSubnetDocument({ netuid: "14", surfaces: [entry] }, { appendedEntry: entry }).verdict).toBe("merged");
+  it("threads the validated integer root netuid to the entry; a conflicting entry netuid is rejected", () => {
+    // A string root netuid is no longer coerced/accepted (#9665) — that is covered by the reject table below.
+    // Here the root is a real integer that matches the entry, and a conflicting entry netuid still fails.
+    expect(assessSubnetDocument(doc, { appendedEntry: { ...entry, netuid: 14 } }).verdict).toBe("merged");
     expect(assessSubnetDocument(doc, { appendedEntry: { ...entry, netuid: 99 } }).reason).toBe("unsupported-shape");
+  });
+
+  describe("root netuid must be a real non-negative integer, not a coercible value (#9665)", () => {
+    // Before #9665 the check was `!Number.isInteger(Number(doc.netuid))`, so Number() smuggled these through:
+    // Number(null)===0, Number("")===0, Number([])===0, Number(true)===1, Number("0x10")===16, Number("  7  ")===7.
+    for (const bad of [null, "", true, [], [5], "7", "0x10", 1.5, -1, undefined] as unknown[]) {
+      it(`rejects netuid ${JSON.stringify(bad)} with unsupported-shape`, () => {
+        const r = assessSubnetDocument({ netuid: bad, surfaces: [entry] }, { appendedEntry: entry });
+        expect(r.reason).toBe("unsupported-shape");
+        expect(r.summary).toBe("Subnet document netuid must be an integer.");
+      });
+    }
+
+    for (const good of [0, 64]) {
+      it(`keeps a valid integer netuid ${good} (not over-tightened)`, () => {
+        const r = assessSubnetDocument({ netuid: good, surfaces: [{ ...entry, netuid: good }] }, { appendedEntry: { ...entry, netuid: good } });
+        expect(r.reason).not.toBe("unsupported-shape");
+      });
+    }
+
+    it("no longer merges a document with netuid null and a surface declaring netuid 0 (end-to-end regression)", () => {
+      // The exact exploit: a null root coerced to subnet 0, and a surface netuid of 0 matched it, reaching a
+      // decisive merge on the surface lane. It must now fail on the root shape check instead.
+      const r = assessSubnetDocument(
+        { netuid: null, surfaces: [{ ...entry, netuid: 0 }] },
+        { appendedEntry: { ...entry, netuid: 0 } },
+      );
+      expect(r.verdict).not.toBe("merged");
+      expect(r.reason).toBe("unsupported-shape");
+    });
   });
 });
 


### PR DESCRIPTION
## What & why

`assessSubnetDocument` (`src/review/content-lane/registry-logic.ts`) is the content lane's shape validator for a registry subnet file. Its root-netuid check was:

```ts
if (!Number.isInteger(Number(doc.netuid))) { … }
```

`Number()` coerces *before* the integer test, so values the message promises it rejects slipped through: `Number(null) === 0`, `Number("") === 0`, `Number([]) === 0`, `Number(true) === 1`, `Number("0x10") === 16`, `Number("  7  ") === 7`. A document with `"netuid": null` was therefore accepted as **subnet 0** and threaded into `assessSurfaceEntry`'s consistency check as if it had been validated — its comment even relies on "the document validator already proved the root netuid is an integer". A surface declaring `netuid: 0` then matched the fabricated root and could reach a decisive `merge` on the surface lane.

## The fix

Validate the **raw** value type-first, mirroring the `!Array.isArray(doc.surfaces)` sibling three lines below (which never coerces):

```ts
if (typeof doc.netuid !== "number" || !Number.isInteger(doc.netuid) || doc.netuid < 0) {
  return fail("unsupported-shape", "Subnet document netuid must be an integer.");
}
const netuid = doc.netuid; // already validated; no coercion on this path
```

A netuid is a non-negative index, so a negative integer is rejected too; `0` stays valid. The failure summary and `unsupported-shape` reason code are unchanged (they're asserted by existing tests and rendered into the public close comment). No change to `assessSurfaceEntry` or any other branch.

## Tests (`test/unit/content-lane-registry-logic.test.ts`)

- Table-driven `#9665` case: each of `null`, `""`, `true`, `[]`, `[5]`, `"7"`, `"0x10"`, `1.5`, `-1`, `undefined` → `unsupported-shape` with the exact summary text. **9 of these fail against `main`.**
- `netuid: 0` and `netuid: 64` still produce a non-`unsupported-shape` outcome (not over-tightened).
- End-to-end regression (Deliverable 3): a document with `netuid: null` and a surface declaring `netuid: 0` no longer reaches `merged` — it fails on `unsupported-shape`.
- Updated the existing "string root coerces → merged" case, which encoded the removed behaviour, to assert an integer root threads through and a conflicting entry netuid is rejected.

## Validation

- `npm run typecheck` green; the suite (171 tests) green.
- Diff coverage on the changed file is 100% line and branch (all three arms of the new guard); whole-file branch 100%.
- `git diff --check <base> HEAD` clean; diff is two files, no route/schema/migration change.

Closes #9665
