### PR TITLE
fix(content-lane): canonicalize the issue-body path token in checkContentLaneDeliverable

### DIFF
--- a/src/review/content-lane/registry-logic.ts
+++ b/src/review/content-lane/registry-logic.ts
@@ -930,7 +930,10 @@ export function checkContentLaneDeliverable(
   issueTitle?: string,
 ): ContentLaneDeliverableCheck {
   const matchesSpec = (candidate: string): boolean => spec.entryFilePattern.test(candidate) || (spec.providerFilePattern?.test(candidate) ?? false);
-  const mentionedPath = extractPathTokens(issueText).find(matchesSpec);
+  // globToRegExp compiles the spec patterns against a CANONICALIZED (lowercased) path, so test canonicalize(token)
+  // — exactly as the changedFiles side below and classifyRegistryPrScope's matchesPattern already do — while
+  // keeping the ORIGINAL token for mentionedPath, which is quoted verbatim into the public PR comment (#9667).
+  const mentionedPath = extractPathTokens(issueText).find((token) => matchesSpec(canonicalize(token)));
   const titleImplies = !mentionedPath && Boolean(issueTitle && spec.issueTitleImpliesEntryPattern?.test(issueTitle));
   if (!mentionedPath && !titleImplies) return { verdict: "not-applicable" };
   const delivered = changedFiles.some((file) => matchesSpec(canonicalize(file)));

--- a/test/unit/content-lane-registry-logic.test.ts
+++ b/test/unit/content-lane-registry-logic.test.ts
@@ -676,6 +676,35 @@ describe("checkContentLaneDeliverable (generic, spec-driven — #content-lane-de
     expect(checkContentLaneDeliverable(entryOnlySpec, issueText, ["tests/foo.test.mjs"]).verdict).toBe("missing");
   });
 
+  describe("canonicalizes the issue-body path token so mixed-case paths still fire the gate (#9667)", () => {
+    it("is 'missing' for a mixed-case issue path against a non-delivering PR, quoting the ORIGINAL token", () => {
+      const issueText = "Add the surfaces to Registry/Subnets/Foo.json.";
+      const result = checkContentLaneDeliverable(spec, issueText, ["tests/foo-verify.test.mjs"]);
+      // The gate fires (was silently not-applicable before #9667), and mentionedPath stays verbatim for the
+      // public comment — NOT lowercased.
+      expect(result).toEqual({ verdict: "missing", mentionedPath: "Registry/Subnets/Foo.json" });
+    });
+
+    it("is 'delivered' for that same mixed-case issue path when the PR changes the canonical file", () => {
+      const issueText = "Add the surfaces to Registry/Subnets/Foo.json.";
+      expect(checkContentLaneDeliverable(spec, issueText, ["registry/subnets/foo.json"]).verdict).toBe("delivered");
+    });
+
+    it("leaves already-lowercase path behaviour byte-identical (delivered and missing)", () => {
+      const issueText = "Add registry/subnets/foo.json.";
+      expect(checkContentLaneDeliverable(spec, issueText, ["registry/subnets/foo.json"]).verdict).toBe("delivered");
+      expect(checkContentLaneDeliverable(spec, issueText, ["tests/foo.test.mjs"])).toEqual({
+        verdict: "missing",
+        mentionedPath: "registry/subnets/foo.json",
+      });
+    });
+
+    it("still returns not-applicable for an issue path that matches no spec pattern (not over-broadened)", () => {
+      const issueText = "Update the docs at Docs/Readme.md — nothing registry-shaped here.";
+      expect(checkContentLaneDeliverable(spec, issueText, ["registry/subnets/foo.json"])).toEqual({ verdict: "not-applicable" });
+    });
+  });
+
   // #content-lane-deliverable follow-up (metagraphed #7060-class gap): the literal-path scan alone is BLIND
   // to metagraphed's own ~120 "MCP execute: verify + wire SN*" issues, whose bodies write the registry path
   // with a generic `<slug>` documentation placeholder rather than the real resolved filename — confirmed


### PR DESCRIPTION
## What & why

`checkContentLaneDeliverable` (`src/review/content-lane/registry-logic.ts`) is the deterministic "did this PR actually deliver the content file its linked issue names?" guard against a test-only PR closing a content issue via a bare `Closes #N`. It compared each issue-body token against `matchesSpec` **raw**:

```ts
const mentionedPath = extractPathTokens(issueText).find(matchesSpec);   // RAW token
…
const delivered = changedFiles.some((file) => matchesSpec(canonicalize(file)));   // canonicalized
```

`entryFilePattern`/`providerFilePattern` are compiled by `globToRegExp`, which canonicalizes (lowercases) the glob and emits `^…$` with **no `i` flag** — so the patterns only ever match lowercase input. An issue body naming its path with any capitalization (`Registry/Subnets/Foo.json`) produced no `mentionedPath`, and with no title fallback the check returned `not-applicable` — the gate silently didn't run, exactly the gap the function exists to close. The `changedFiles` side already canonicalizes; the issue-body side never got that treatment (`classifyRegistryPrScope` in the same file documents why it matters).

## The fix

Canonicalize the token at the point of test, mirroring `classifyRegistryPrScope`'s `matchesPattern`:

```ts
const mentionedPath = extractPathTokens(issueText).find((token) => matchesSpec(canonicalize(token)));
```

`mentionedPath` still holds the **original** token — it is quoted verbatim into the public PR comment, so it must match what the contributor and maintainer see in the issue. Already-lowercase tokens are byte-identical to today. No change to `extractPathTokens`, `globToRegExp`, `canonicalize`, or the `issueTitleImpliesEntryPattern` fallback (no `i` flag added to the compiled globs).

## Tests (`test/unit/content-lane-registry-logic.test.ts`)

New `#9667` suite:
- Mixed-case issue path (`Registry/Subnets/Foo.json`) against a non-delivering PR → `missing` with `mentionedPath` quoting the **original** mixed-case token (**fails on `main`**).
- Same mixed-case issue path, PR changes `registry/subnets/foo.json` → `delivered` (**fails on `main`**).
- Already-lowercase behaviour unchanged (both `delivered` and `missing`).
- An issue path matching no spec pattern still returns `not-applicable` (not over-broadened).

## Validation

- `npm run typecheck` green; the suite (175 tests) green.
- Diff coverage on the changed file is 100% line and branch; whole-file branch 100%.
- `git diff --check <base> HEAD` clean; diff is two files, no route/schema/migration change.

Closes #9667
