### PR TITLE
fix(visual): stop silently dropping mobile screenshots of long pages

### DIFF
--- a/src/review/visual/shot.ts
+++ b/src/review/visual/shot.ts
@@ -68,8 +68,23 @@ type ScreenshotPage = {
 export const DESKTOP_VIEWPORT: Viewport = { width: 1440, height: 900 };
 export const MOBILE_VIEWPORT: Viewport = { width: 390, height: 844 }; // iPhone-class portrait
 const VIEWPORT = DESKTOP_VIEWPORT;
-export const MAX_SCREENSHOT_HEIGHT = 10000;
-export const MAX_SCREENSHOT_PIXELS = 14_400_000; // 1440 × 10000, matching the full-page cap.
+// A sanity bound against a pathological infinite-scroll page, NOT a cost proxy -- cost is bounded by
+// MAX_SCREENSHOT_PIXELS below, and separately by MAX_SCREENSHOT_BYTES.
+//
+// It used to be 10000, which was derived for the 1440-wide DESKTOP viewport (see the pixel cap's own
+// comment: 1440 × 10000). Applied unchanged to the 390-wide MOBILE viewport it rejected captures costing a
+// third as much: an ordinary long docs page renders ~10850px tall at 390 wide, which is 4.2M pixels against
+// a 14.4M budget -- comfortably affordable, silently dropped. On the ORB that was 64 mobile screenshots
+// discarded in a single hour, weakening the visual gate precisely on the viewport most likely to reveal a
+// responsive regression.
+//
+// 20000 is empirically verified against this deployment's own renderer (browserless v2 / Chrome 149):
+// a 390 × 20000 full-page capture returns 200 in ~157KB. The renderer was never the binding constraint.
+// Desktop is unaffected -- 1440 × 20000 is 28.8M pixels and still fails the pixel cap.
+export const MAX_SCREENSHOT_HEIGHT = 20000;
+// The real cost ceiling: width × height, so a narrow-tall page is judged by what it actually costs to
+// render rather than by height alone.
+export const MAX_SCREENSHOT_PIXELS = 14_400_000; // 1440 × 10000 — one full desktop-width page.
 export const MAX_SCREENSHOT_BYTES = 5 * 1024 * 1024;
 const SCREENSHOT_TIMEOUT_MS = 10000;
 const SCREENSHOT_HEIGHT_PROBE_TIMEOUT_MS = 2_000;

--- a/test/unit/visual-shot.test.ts
+++ b/test/unit/visual-shot.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { captureInteractionFrames, captureScrollFrames, captureShot, handleShot } from "../../src/review/visual/shot";
+import { captureInteractionFrames, captureScrollFrames, captureShot, handleShot, MAX_SCREENSHOT_HEIGHT, MAX_SCREENSHOT_PIXELS, MOBILE_VIEWPORT, DESKTOP_VIEWPORT } from "../../src/review/visual/shot";
 import { counterValue, resetMetrics } from "../../src/selfhost/metrics";
 
 const mocks = vi.hoisted(() => ({
@@ -1112,4 +1112,33 @@ describe("visual capture result metric (#9487)", () => {
     expect(counterValue("loopover_visual_capture_total", { result: "error" })).toBe(1);
   });
 
+});
+
+describe("a narrow-tall mobile page is judged by cost, not height alone", () => {
+  // Observed on the ORB: 64 mobile captures discarded in one hour, every one at width 390. An ordinary long
+  // docs page is ~10850px tall at that width -- 4.2M pixels against a 14.4M budget. The old 10000 height cap
+  // was derived for the 1440-wide DESKTOP viewport (MAX_SCREENSHOT_PIXELS is literally 1440 × 10000), so
+  // reusing it for mobile rejected captures costing a third as much, weakening the visual gate on exactly
+  // the viewport most likely to reveal a responsive regression.
+  it("REGRESSION: the real observed mobile page (390 × 10847) is now within both caps", () => {
+    const width = MOBILE_VIEWPORT.width;
+    const height = 10847;
+    expect(width).toBe(390);
+    expect(height).toBeLessThanOrEqual(MAX_SCREENSHOT_HEIGHT);
+    expect(width * height).toBeLessThanOrEqual(MAX_SCREENSHOT_PIXELS);
+  });
+
+  it("INVARIANT: desktop is unaffected — the pixel cap still rejects a wide page of the same height", () => {
+    // The cost ceiling must not have been widened by raising the height bound.
+    const area = DESKTOP_VIEWPORT.width * 10847;
+    expect(area).toBeGreaterThan(MAX_SCREENSHOT_PIXELS);
+  });
+
+  it("INVARIANT: the height cap is a sanity bound the renderer can actually satisfy", () => {
+    // 20000 is verified against this deployment's renderer (browserless v2 / Chrome 149): a 390 × 20000
+    // full-page capture returns 200 in ~157KB. If this is ever raised past what the renderer can produce,
+    // captures fail at request time instead of being cheaply rejected here.
+    expect(MAX_SCREENSHOT_HEIGHT).toBe(20000);
+    expect(MOBILE_VIEWPORT.width * MAX_SCREENSHOT_HEIGHT).toBeLessThanOrEqual(MAX_SCREENSHOT_PIXELS);
+  });
 });


### PR DESCRIPTION
## The bug

`MAX_SCREENSHOT_HEIGHT` was `10000` — a bound derived for the **desktop** viewport. Its sibling constant says so outright:

```ts
export const MAX_SCREENSHOT_PIXELS = 14_400_000; // 1440 × 10000, matching the full-page cap.
```

Applied unchanged to the 390-wide **mobile** viewport, it rejected captures costing a third as much. An ordinary long docs page renders ~10,850px tall at 390 wide — **4.2M pixels against a 14.4M budget**, comfortably affordable — and was thrown away, with `renderShot` returning `null`.

Found on the live ORB, which logged it 64 times in a single hour, every one at width 390:

```
{"event":"render_screenshot_too_large","width":390,"height":10847,"maxHeight":10000,"maxPixels":14400000}
```

So the visual gate was quietly running desktop-only on long pages — losing coverage on exactly the viewport most likely to expose a responsive regression.

## The renderer was never the constraint

I checked rather than assumed, against this deployment's own browserless (v2 / Chrome 149), full-page PNG at 390 wide:

| height | result |
|---|---|
| 10,847 | 200, 90 KB |
| 12,000 | 200, 100 KB |
| 16,000 | 200, 129 KB |
| 16,500 | 200, 132 KB |
| 20,000 | 200, 157 KB |

The 10,000 cap was a second, cruder cost proxy sitting next to the accurate one.

## The fix

Raise the height bound to `20000` as a sanity limit against pathological infinite-scroll pages, and let `MAX_SCREENSHOT_PIXELS` remain the real cost ceiling — it judges a narrow-tall page by what it actually costs to render. `MAX_SCREENSHOT_BYTES` (5 MB) is untouched as the third bound.

**Desktop is unaffected and the cost ceiling is not widened**: 1440 × 10,847 is 15.6M pixels and still fails the pixel cap. An invariant test pins that, so this can't be misread as "we raised the limits."

## Tests

3 new cases: a regression using the exact observed dimensions, an invariant proving desktop still fails the pixel cap at that height, and one asserting the height bound stays something the renderer can actually satisfy. 98 pass.