### PR TITLE
fix(ops): scope the PagerDuty cooldown to rows that actually paged

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -3161,6 +3161,39 @@ export async function countRecentAuditEventsForActorAndTarget(env: Env, actor: s
   return row.count;
 }
 
+/** Same as {@link countRecentAuditEventsForActorAndTarget} but additionally scoped to a specific `outcome` +
+ *  `detail`. Backs the PagerDuty cooldown (#9695): a repeat page is suppressed only by rows that ACTUALLY paged
+ *  (outcome "completed", detail "triggered"), never by the suppression rows or the auto-resolve rows that share
+ *  the same eventType/targetKey — otherwise a single page (or even a `denied` non-page) self-renewed the window
+ *  every cron tick and the repo never paged again. */
+export async function countRecentAuditEventsForActorTargetAndOutcome(
+  env: Env,
+  actor: string,
+  eventType: string,
+  targetKey: string,
+  outcome: string,
+  detail: string,
+  sinceIso: string,
+): Promise<number> {
+  const db = getDb(env.DB);
+  const [row] = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(auditEvents)
+    .where(
+      and(
+        eq(auditEvents.actor, actor),
+        eq(auditEvents.eventType, eventType),
+        eq(auditEvents.targetKey, targetKey),
+        eq(auditEvents.outcome, outcome),
+        eq(auditEvents.detail, detail),
+        gte(auditEvents.createdAt, sinceIso),
+      ),
+    );
+  /* v8 ignore next -- count(*) always returns exactly one row; the empty-array guard only satisfies the destructure type. */
+  if (!row) return 0;
+  return row.count;
+}
+
 /** Shared by every `targetKey` literal-prefix `LIKE` scan below ({@link countRecentAuditEventsForActorInRepo},
  *  {@link findHottestReviewTargetForRepo}) so a repo name containing a SQL `LIKE` wildcard (`%`/`_`) is always
  *  matched literally, never as a pattern -- e.g. `owner/foo_bar` must never spuriously match `owner/fooXbar#...`'s

--- a/src/services/notify-pagerduty.ts
+++ b/src/services/notify-pagerduty.ts
@@ -1,4 +1,4 @@
-import { countRecentAuditEventsForActorAndTarget, recordAuditEvent } from "../db/repositories";
+import { countRecentAuditEventsForActorTargetAndOutcome, recordAuditEvent } from "../db/repositories";
 import { errorMessage } from "../utils/json";
 import { meetsSeverityThreshold, resolveSeverityThreshold, type LoopoverSeverity } from "./severity-threshold";
 
@@ -21,6 +21,12 @@ import { meetsSeverityThreshold, resolveSeverityThreshold, type LoopoverSeverity
 //     every cron tick doesn't re-page every tick.
 
 const PAGERDUTY_EVENTS_URL = "https://events.pagerduty.com/v2/enqueue";
+
+// The audit `detail` written for a real page vs an auto-resolve. Both share outcome "completed", so the cooldown
+// must key off `detail` to count only rows that ACTUALLY paged (#9695). Exported + used at both the write and
+// the read site so the two spellings can never drift.
+export const PAGERDUTY_AUDIT_DETAIL_TRIGGERED = "triggered";
+export const PAGERDUTY_AUDIT_DETAIL_RESOLVED = "resolved";
 // PagerDuty routing/integration keys are 32 lowercase hex characters.
 const ROUTING_KEY_RE = /^[a-f0-9]{32}$/i;
 const DEFAULT_MIN_SEVERITY: PagerDutySeverity = "error";
@@ -182,8 +188,8 @@ export async function triggerPagerDutyIncident(
   // window can reach back across the deploy boundary. Querying both actors costs one extra indexed count and
   // removes the whole risk category rather than requiring a precisely-timed follow-up cleanup.
   const [recentPagesNewActor, recentPagesLegacyActor] = await Promise.all([
-    countRecentAuditEventsForActorAndTarget(env, "loopover", "external_notification.pagerduty", params.dedupKey, cooldownSinceIso),
-    countRecentAuditEventsForActorAndTarget(env, "gittensory", "external_notification.pagerduty", params.dedupKey, cooldownSinceIso),
+    countRecentAuditEventsForActorTargetAndOutcome(env, "loopover", "external_notification.pagerduty", params.dedupKey, "completed", PAGERDUTY_AUDIT_DETAIL_TRIGGERED, cooldownSinceIso),
+    countRecentAuditEventsForActorTargetAndOutcome(env, "gittensory", "external_notification.pagerduty", params.dedupKey, "completed", PAGERDUTY_AUDIT_DETAIL_TRIGGERED, cooldownSinceIso),
   ]);
   const recentPages = recentPagesNewActor + recentPagesLegacyActor;
   if (recentPages > 0) {
@@ -211,7 +217,7 @@ export async function triggerPagerDutyIncident(
       signal: AbortSignal.timeout(5000),
     });
     if (!response.ok) throw new Error(`pagerduty_events_http_${response.status}`);
-    await auditPagerDutyNotification(env, { repoFullName: params.repoFullName, dedupKey: params.dedupKey }, "completed", "triggered", { source: resolution.source });
+    await auditPagerDutyNotification(env, { repoFullName: params.repoFullName, dedupKey: params.dedupKey }, "completed", PAGERDUTY_AUDIT_DETAIL_TRIGGERED, { source: resolution.source });
   } catch (error) {
     const message = errorMessage(error);
     console.warn(JSON.stringify({ event: "pagerduty_trigger_failed", repo: params.repoFullName, message: message.slice(0, 200) }));
@@ -251,7 +257,7 @@ export async function resolvePagerDutyIncident(
       signal: AbortSignal.timeout(5000),
     });
     if (!response.ok) throw new Error(`pagerduty_events_http_${response.status}`);
-    await auditPagerDutyNotification(env, { repoFullName: params.repoFullName, dedupKey: params.dedupKey }, "completed", "resolved", { source: resolution.source });
+    await auditPagerDutyNotification(env, { repoFullName: params.repoFullName, dedupKey: params.dedupKey }, "completed", PAGERDUTY_AUDIT_DETAIL_RESOLVED, { source: resolution.source });
   } catch (error) {
     const message = errorMessage(error);
     console.warn(JSON.stringify({ event: "pagerduty_resolve_failed", repo: params.repoFullName, message: message.slice(0, 200) }));

--- a/test/unit/notify-pagerduty.test.ts
+++ b/test/unit/notify-pagerduty.test.ts
@@ -230,6 +230,60 @@ describe("triggerPagerDutyIncident — cooldown gate (alert fatigue control #2)"
     expect(calls).toHaveLength(1);
   });
 
+  it("REGRESSION: a recent suppression (denied/cooldown_active) row does NOT itself suppress the next page (#9695)", async () => {
+    const calls = stubFetch();
+    const env = enabledEnv();
+    const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    // Before #9695 this `denied` row was counted (the counter did not filter outcome/detail), so a single
+    // suppression self-renewed the window and the repo could never page again.
+    await recordAuditEvent(env, {
+      eventType: "external_notification.pagerduty",
+      actor: "loopover",
+      targetKey: "ops_anomaly:acme/widgets",
+      outcome: "denied",
+      detail: "cooldown_active",
+      metadata: {},
+      createdAt: fiveMinutesAgo,
+    });
+    await trigger(env);
+    expect(calls).toHaveLength(1); // it pages, because no ACTUAL page happened in the window
+  });
+
+  it("REGRESSION: a recent auto-resolve (completed/resolved) row does NOT suppress the next page (#9695)", async () => {
+    const calls = stubFetch();
+    const env = enabledEnv();
+    const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    // resolved shares outcome "completed" with a real page, so an outcome-only filter would wrongly count it.
+    await recordAuditEvent(env, {
+      eventType: "external_notification.pagerduty",
+      actor: "loopover",
+      targetKey: "ops_anomaly:acme/widgets",
+      outcome: "completed",
+      detail: "resolved",
+      metadata: {},
+      createdAt: fiveMinutesAgo,
+    });
+    await trigger(env);
+    expect(calls).toHaveLength(1); // a re-page for a flapping condition is not blocked by its own resolve
+  });
+
+  it("REGRESSION: a recent failed page (error) does NOT suppress its own retry (#9695)", async () => {
+    const calls = stubFetch();
+    const env = enabledEnv();
+    const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    await recordAuditEvent(env, {
+      eventType: "external_notification.pagerduty",
+      actor: "loopover",
+      targetKey: "ops_anomaly:acme/widgets",
+      outcome: "error",
+      detail: "The page failed",
+      metadata: {},
+      createdAt: fiveMinutesAgo,
+    });
+    await trigger(env);
+    expect(calls).toHaveLength(1); // nobody was paged, so the retry must go through
+  });
+
   it("REGRESSION: a recent page recorded under the pre-rebrand 'loopover' actor still suppresses a duplicate within the cooldown window", async () => {
     const calls = stubFetch();
     const env = enabledEnv();


### PR DESCRIPTION
## What & why

The PagerDuty cooldown suppresses a repeat page for the same `dedupKey` within the window. It counted recent rows via `countRecentAuditEventsForActorAndTarget`, which filters neither `outcome` nor `detail`. But `auditPagerDutyNotification` writes the same `external_notification.pagerduty` eventType + `targetKey` for **every** path:

- a real page — `completed` / `triggered`
- a suppression — `denied` / `cooldown_active`
- a failed page — `error`
- an auto-resolve — `completed` / `resolved`

So the count was `> 0` for causes that never paged anyone. Concretely, at the default 60-minute cooldown with a sub-hourly cron:

1. **Self-renewing cooldown** — a page writes a row; the next tick suppresses *and writes another row*; the window slides forward forever and the repo never pages again.
2. A **non-page silences a real page** — a `denied` row suppresses a later genuine anomaly.
3. A **failed page blocks its own retry**.
4. An **auto-resolve suppresses the re-page** for a flapping condition.

## The fix

- Add `countRecentAuditEventsForActorTargetAndOutcome` to `src/db/repositories.ts`, shaped exactly like `countRecentAuditEventsForActorAndTarget` with additional `eq(outcome)` + `eq(detail)` terms.
- `triggerPagerDutyIncident` counts only `outcome: "completed"`, `detail: "triggered"` rows, for both the `loopover` and legacy `gittensory` actors (the two-actor union is preserved).
- Export `PAGERDUTY_AUDIT_DETAIL_TRIGGERED` / `PAGERDUTY_AUDIT_DETAIL_RESOLVED` and use them at both the write (`auditPagerDutyNotification` calls) and the read (cooldown count) sites, so the two spellings can never drift.
- The `denied` / `error` / `resolved` rows are still written — they are the operator's evidence that suppression/failure/resolution happened; they are simply no longer counted. No change to the cooldown-minutes or min-severity resolution.

## Tests (`test/unit/notify-pagerduty.test.ts`)

Three new regression cases, each **failing on `main`**: a recent `denied`/`cooldown_active` row, a `completed`/`resolved` row, and an `error` row each do **not** suppress the next page (`calls` length 1). The existing "a real triggered page suppresses" and two-actor cases still pass.

## Validation

- `npm run typecheck` green; the pagerduty suite (38 tests) green.
- Diff coverage on both changed src files is 100% line and branch.
- `git diff --check <base> HEAD` clean; no route/schema/migration change (a DB counter + service logic).

Closes #9695
