### PR TITLE
fix(cors): set Vary: Origin on the public no-credential branch

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -572,6 +572,10 @@ export function createApp() {
       c.header("Access-Control-Allow-Headers", "authorization, content-type");
       c.header("Access-Control-Allow-Methods", "GET, OPTIONS");
       c.header("Access-Control-Max-Age", "600");
+      // The response varies by Origin (this branch fires only when the request carried one), so a shared cache
+      // must not serve this Origin-specific response to a no-Origin request or vice versa — append Vary the same
+      // way the credentialed branch does at the else-arm below (#9712).
+      c.header("Vary", "Origin", { append: true });
     } else {
       const allowedOrigin = allowedCorsOrigin(c.env, origin);
       if (allowedOrigin) {

--- a/test/unit/routes-cors.test.ts
+++ b/test/unit/routes-cors.test.ts
@@ -70,3 +70,43 @@ describe("CORS: everything else stays on the strict, credentialed allowlist (#op
     expect(res.headers.get("access-control-allow-origin")).toBeNull();
   });
 });
+
+describe("CORS: the public no-credential branch varies by Origin (#9712)", () => {
+  it("GET /health with an Origin returns Access-Control-Allow-Origin: * AND Vary: Origin", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const res = await app.request("/health", { headers: { origin: PREVIEW_ORIGIN } }, env);
+    expect(res.headers.get("access-control-allow-origin")).toBe("*");
+    expect(res.headers.get("vary")).toContain("Origin");
+  });
+
+  it("GET /v1/public/stats and the per-repo badge route also carry Vary: Origin on the open branch", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    env.LOOPOVER_PUBLIC_STATS = "true";
+    const stats = await app.request("/v1/public/stats", { headers: { origin: "https://random-preview.pages.dev" } }, env);
+    expect(stats.headers.get("access-control-allow-origin")).toBe("*");
+    expect(stats.headers.get("vary")).toContain("Origin");
+
+    const badge = await app.request("/v1/public/github/repos/acme/widgets/stats", { headers: { origin: PREVIEW_ORIGIN } }, env);
+    expect(badge.headers.get("access-control-allow-origin")).toBe("*");
+    expect(badge.headers.get("vary")).toContain("Origin");
+  });
+
+  it("GET /health with NO Origin sets no Access-Control-Allow-Origin — proving the response genuinely varies", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const res = await app.request("/health", {}, env);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("access-control-allow-origin")).toBeNull();
+  });
+
+  it("REGRESSION: the credentialed branch still returns exactly one Vary: Origin plus credentials", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const res = await app.request("/v1/app/kill-switch", { headers: { origin: "https://loopover.ai", authorization: `Bearer ${env.LOOPOVER_API_TOKEN}` } }, env);
+    expect(res.headers.get("access-control-allow-credentials")).toBe("true");
+    // Exactly one Origin token — appended, not duplicated or overwritten.
+    expect((res.headers.get("vary") ?? "").split(",").map((v) => v.trim()).filter((v) => v === "Origin")).toEqual(["Origin"]);
+  });
+});


### PR DESCRIPTION
## What & why

The CORS middleware in `createApp()` has two branches. The public no-credential branch fires when `origin && isPublicNoCredentialRoute(path)` and sets `Access-Control-Allow-Origin: *`, `Access-Control-Allow-Headers/Methods/Max-Age` — but no `Vary`. Because the branch is guarded by `origin &&`, the response headers **differ depending on whether the request carried an `Origin`** (with one → the ACAO/allow headers; without → none). Nothing tells a shared cache that, so a cache keyed only on URL could serve the Origin-bearing response to a later no-Origin request, or vice versa. The credentialed `else` branch already appends `Vary: Origin`; the public branch simply omitted it.

## The fix

Append `Vary: Origin` on the public branch with `{ append: true }` — the identical call the credentialed branch uses — so any `Vary` set elsewhere is preserved rather than overwritten. No change to which origins are allowed, to `Access-Control-Allow-Credentials` (which stays absent on this branch), or to any `Cache-Control` value.

## Tests (`test/unit/routes-cors.test.ts`)

- `GET /health` with an `Origin` returns `Access-Control-Allow-Origin: *` **and** a `Vary` containing `Origin` (**fails on `main`**).
- Same for `GET /v1/public/stats` and the `GET /v1/public/github/repos/:owner/:repo/stats` badge route (**fails on `main`**).
- `GET /health` with **no** `Origin` sets no `Access-Control-Allow-Origin` — pinning that the response genuinely varies, which is what makes the `Vary` load-bearing.
- Regression: the credentialed branch still returns exactly one `Vary: Origin` (appended, not duplicated) plus `Access-Control-Allow-Credentials: true`.

## Validation

- `npm run typecheck` green; `npm run ui:openapi:check` clean (a response header is not part of the schema); the CORS suite (11 tests) green.
- Diff coverage on `src/api/routes.ts` is 100% (the single added header call).
- `git diff --check <base> HEAD` clean; diff is two files, no schema/migration change.

Closes #9712
