### PR TITLE
fix(openapi): declare the real statuses for POST /v1/loop/request-apr-transfer

### DIFF
--- a/apps/loopover-ui/public/openapi.json
+++ b/apps/loopover-ui/public/openapi.json
@@ -26291,14 +26291,20 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "Transfer requested"
+          "202": {
+            "description": "Transfer initiation accepted (pending acceptance)"
           },
           "400": {
             "description": "Malformed request"
           },
           "401": {
             "description": "Missing or invalid token"
+          },
+          "409": {
+            "description": "Transfer gate rejected the request; GitHub was not touched"
+          },
+          "502": {
+            "description": "Transfer attempt failed downstream"
           }
         }
       }

--- a/src/openapi/internal-and-public-route-specs.ts
+++ b/src/openapi/internal-and-public-route-specs.ts
@@ -403,7 +403,13 @@ const MISC_ROUTES: SpecEntry[] = [
     tags: ["Loop"],
     summary: "Request an APR transfer for a rented loop",
     auth: "token",
-    responses: { 200: { description: "Transfer requested" }, 400: { description: "Malformed request" }, 401: { description: "Missing or invalid token" } },
+    responses: {
+      202: { description: "Transfer initiation accepted (pending acceptance)" },
+      400: { description: "Malformed request" },
+      401: { description: "Missing or invalid token" },
+      409: { description: "Transfer gate rejected the request; GitHub was not touched" },
+      502: { description: "Transfer attempt failed downstream" },
+    },
   },
   {
     method: "post",

--- a/test/unit/openapi.test.ts
+++ b/test/unit/openapi.test.ts
@@ -353,6 +353,10 @@ describe("OpenAPI contract", () => {
     const aprTransfer = spec.paths["/v1/loop/request-apr-transfer"]?.post;
     expect(aprTransfer?.operationId).toBe("requestAprTransfer");
     expect(aprTransfer?.requestBody).toBeUndefined();
+    // #9711: the declared statuses must match the handler's real exits (400/409/502/202) — never the 200 it
+    // could never return. A spec claiming 200 for a route that only ever answers 202 misleads every generated
+    // client.
+    expect(Object.keys(aprTransfer?.responses ?? {}).sort()).toEqual(["202", "400", "401", "409", "502"]);
   });
 
   // #9308: the eight /v1/lint/* + /v1/validate/focus-manifest advisory-check routes are each backed by an MCP


### PR DESCRIPTION
## What & why

`POST /v1/loop/request-apr-transfer`'s spec entry (`requestAprTransfer`) declared `200: "Transfer requested"`. The handler has exactly four exits and **none of them is 200**:

- `400` — failed parse
- `409` — the transfer gate rejected the request (GitHub was not touched)
- `502` — the transfer attempt failed downstream
- `202` — initiation accepted, pending acceptance (the success path)

So every generated client documented a status the route cannot return and omitted the three it actually produces.

## The fix

Replace `200` with `202` and add `409` + `502` (keeping `400`/`401`), mirroring the concrete-per-status description style of the neighbouring `MISC_ROUTES` entries. The handler's statuses are unchanged — this only makes the published contract match what it already returns. `apps/loopover-ui/public/openapi.json` regenerated.

## Tests

- `test/unit/openapi.test.ts`: `buildOpenApiSpec()`'s declared statuses for `POST /v1/loop/request-apr-transfer` are exactly `{202, 400, 401, 409, 502}` — **fails on `main`**, which returns `200`.
- The route's real exits are already pinned by `test/unit/routes-request-apr-transfer.test.ts` (existing `202`/`409`/`502`/`400` cases), which the spec now matches.

## Validation

- `npm run typecheck` green; `npm run ui:openapi:check` clean (regenerated spec matches source); both suites green.
- Diff coverage on the changed spec file is 100%.
- `git diff --check <base> HEAD` clean; diff is the spec source + its test + the regenerated `openapi.json`; no handler or lockfile change.

Closes #9711
