### PR TITLE
fix(db): index decision_ledger_anchors on (row_hash, status)

### DIFF
--- a/migrations/0203_decision_ledger_anchors_row_hash_index.sql
+++ b/migrations/0203_decision_ledger_anchors_row_hash_index.sql
@@ -1,0 +1,6 @@
+-- #9489: anchorBackendsMissingForRowHash queries
+-- `SELECT DISTINCT backend FROM decision_ledger_anchors WHERE row_hash = ? AND status = 'ok' AND backend IN (...)`
+-- once per row being re-anchored; without an index on (row_hash, status) that is a full table scan per call.
+-- Lead with row_hash (the equality predicate) and include status so the `status = 'ok'` filter is served from
+-- the index rather than a row fetch. Sibling precedent: decision_ledger_record_id in migrations/0198.
+CREATE INDEX IF NOT EXISTS decision_ledger_anchors_row_hash_status ON decision_ledger_anchors (row_hash, status);

--- a/test/unit/ledger-anchor-persistence.test.ts
+++ b/test/unit/ledger-anchor-persistence.test.ts
@@ -240,4 +240,22 @@ describe("anchorBackendsMissingForRowHash (#9489)", () => {
     expect(await anchorBackendsMissingForRowHash(env, "hash-a", [])).toEqual([]);
     expect(spy).not.toHaveBeenCalled();
   });
+
+  it("is served by the (row_hash, status) index rather than a full table scan (#9652)", async () => {
+    const env = createTestEnv();
+    const idx = await env.DB.prepare("SELECT name FROM sqlite_master WHERE type='index' AND name = ?")
+      .bind("decision_ledger_anchors_row_hash_status")
+      .first<{ name: string }>();
+    expect(idx?.name).toBe("decision_ledger_anchors_row_hash_status");
+
+    // The exact predicate anchorBackendsMissingForRowHash runs — must SEARCH via the new index, not SCAN.
+    const plan = await env.DB.prepare(
+      "EXPLAIN QUERY PLAN SELECT DISTINCT backend FROM decision_ledger_anchors WHERE row_hash = ? AND status = 'ok' AND backend IN ('rekor', 'git')",
+    )
+      .bind("hash-a")
+      .all<{ detail: string }>();
+    const detail = (plan.results ?? []).map((row) => row.detail).join(" ");
+    expect(detail).toContain("decision_ledger_anchors_row_hash_status");
+    expect(detail).not.toContain("SCAN decision_ledger_anchors ");
+  });
 });


### PR DESCRIPTION
## What & why

`anchorBackendsMissingForRowHash` (#9489, `src/review/ledger-anchor-persistence.ts`) runs

```sql
SELECT DISTINCT backend FROM decision_ledger_anchors WHERE row_hash = ? AND status = 'ok' AND backend IN (...)
```

once per row being re-anchored, but `decision_ledger_anchors` had no index on `row_hash`. So each call was a full table scan whose cost grows with the anchor ledger.

## The fix

Add migration **0203** creating:

```sql
CREATE INDEX IF NOT EXISTS decision_ledger_anchors_row_hash_status ON decision_ledger_anchors (row_hash, status);
```

`row_hash` leads (the equality predicate); `status` is included so the `status = 'ok'` filter is served from the index rather than a row fetch. This mirrors the `decision_ledger_record_id` index added in `migrations/0198`. The migration contains nothing else — no schema or data change.

> Note: the issue names migration `0202`, but that number is now taken (`0202_orb_signal_rollups.sql`), so this uses the next contiguous free number, `0203`.

## Tests (`test/unit/ledger-anchor-persistence.test.ts`)

- After replaying `migrations/**` (via `createTestEnv`), the index `decision_ledger_anchors_row_hash_status` exists, and `EXPLAIN QUERY PLAN` for the exact `anchorBackendsMissingForRowHash` predicate **SEARCHes via it, not SCANs** (**fails without the migration**).
- The existing `anchorBackendsMissingForRowHash` behaviour cases (all-missing / some-present / all-present / different-rowHash) confirm results are unchanged after the migration.

## Validation

- `npm run db:migrations:check` green (contiguous 0001..0203); `npm run db:schema-drift:check` green (index on a raw-SQL table, no Drizzle change); `npm run typecheck` green.
- `migrations/**` is outside Codecov's include, so the migration carries no coverage obligation; the test imports `createTestEnv`, so shards see real `src/**`.
- `git diff --check <base> HEAD` clean; diff is the one migration + its test, no `src/**` source change.

Closes #9652
