### PR TITLE
fix(test): repair main — #9813 changed three contracts and updated only some callers

### DIFF
--- a/config/examples/loopover.full.yml
+++ b/config/examples/loopover.full.yml
@@ -290,6 +290,25 @@ gate:
     - name: Contributor trust
       appSlug: example-security-app
 
+  # Check-runs to IGNORE ENTIRELY (#9810) — the stronger sibling of advisoryCheckRuns above. Same
+  # spoof-resistant { name, appSlug } matching, but a matched run is treated as if it did not exist: it never
+  # gates CI, never counts as "still running", and — unlike advisory — never routes the PR to a manual-review
+  # hold either. Its conclusion is surfaced informationally only.
+  #
+  # Use this when a check's verdict carries no signal for YOUR repo while OTHER checks from the same app stay
+  # meaningful. The motivating case: a vendor app publishes both a real security scan AND a heuristic
+  # contributor-trust score. The scan is worth gating on; the trust score fails for perfectly good
+  # contributors, and listing it under advisoryCheckRuns still converts every one of their otherwise-clean PRs
+  # into a manual review — automation replaced by a queue of human decisions, and contributors left wondering
+  # whether they are being judged fairly. Ignoring the trust check keeps the scan's protection and drops the
+  # noise. If BOTH lists name the same check, ignore wins (it is the stronger, more explicit intent).
+  #
+  # List of { name, appSlug }, or omit. Default: not configured (byte-identical behavior for every repo that
+  # doesn't opt in). Config-as-code only — no DB column or dashboard toggle.
+  ignoredCheckRuns:
+    - name: Contributor trust
+      appSlug: example-security-app
+
   # Promote a confident AI-judgment-only finding (one the reviewer itself placed under "Blockers", never
   # a "Nit") into a real, deterministic gate blocker instead of leaving it advisory (#3907). Only matters
   # for repos already running the registry content lane (see contentLane below) — content/registry repos

--- a/test/unit/agent-approval-queue.test.ts
+++ b/test/unit/agent-approval-queue.test.ts
@@ -583,7 +583,7 @@ describe("agent approval queue (#779)", () => {
 
     expect(result.status).toBe("accepted");
     expect(fetchRequiredStatusContexts).toHaveBeenCalledWith(env, "owner/repo", null, expect.any(String), expect.any(String));
-    expect(fetchLiveCiAggregate).toHaveBeenCalledWith(env, "owner/repo", "h7", expect.any(String), new Set(["build", "test"]), expect.any(String), undefined);
+    expect(fetchLiveCiAggregate).toHaveBeenCalledWith(env, "owner/repo", "h7", expect.any(String), new Set(["build", "test"]), expect.any(String), undefined, undefined);
   });
 
   it("unions branch-protection contexts into the accept-time live CI re-check", async () => {
@@ -599,7 +599,7 @@ describe("agent approval queue (#779)", () => {
 
     expect(result.status).toBe("accepted");
     expect(fetchRequiredStatusContexts).toHaveBeenCalledWith(env, "owner/repo", "main", expect.any(String), expect.any(String));
-    expect(fetchLiveCiAggregate).toHaveBeenCalledWith(env, "owner/repo", "h7", expect.any(String), new Set(["branch-required", "build"]), expect.any(String), undefined);
+    expect(fetchLiveCiAggregate).toHaveBeenCalledWith(env, "owner/repo", "h7", expect.any(String), new Set(["branch-required", "build"]), expect.any(String), undefined, undefined);
   });
 
   it("falls back to expectedCiContexts when the accept-time branch-protection read fails", async () => {
@@ -614,7 +614,7 @@ describe("agent approval queue (#779)", () => {
     const result = await decidePendingAgentAction(env, { id: action.id, decision: "accept", decidedBy: "owner" });
 
     expect(result.status).toBe("accepted");
-    expect(fetchLiveCiAggregate).toHaveBeenCalledWith(env, "owner/repo", "h7", expect.any(String), new Set(["build"]), expect.any(String), null);
+    expect(fetchLiveCiAggregate).toHaveBeenCalledWith(env, "owner/repo", "h7", expect.any(String), new Set(["build"]), expect.any(String), null, null);
   });
 
   it("accept supersedes a staged merge when live CI has since turned pending, not just failed (#2126)", async () => {

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -1877,6 +1877,7 @@ describe("queue processors", () => {
         new Set(["trusted-required-ci"]),
         "installation:9001",
         undefined, // #4372: advisoryCheckRuns (unconfigured here)
+        undefined, // #9810: ignoredCheckRuns (unconfigured here)
       );
       expect(gateChecks).toBeGreaterThan(0);
       const finalized = await env.DB.prepare("select count(*) as n from audit_events where event_type = ?")
@@ -3168,8 +3169,10 @@ describe("queue processors", () => {
         await processJob(env, { type: "agent-regate-pr", deliveryId: "required-contexts-lookup-recovers", repoFullName: "owner/agent-repo", prNumber: 7, installationId: 9001 });
         expect(liveCiSpy.mock.calls.length).toBeGreaterThan(liveReadsAfterFailedLookup);
         expect(await renderMetrics()).toContain('loopover_ci_state_cache_total{field="aggregate",result="miss"} 1');
-        // #4372: the durable cache key now folds in the advisory-check-runs fingerprint (empty "|adv:" when unconfigured).
-        expect(await getPullRequestDetailSyncState(env, "owner/agent-repo", 7)).toMatchObject({ ciState: "passed", ciRequiredContextsKey: `${JSON.stringify(["trusted-required-ci"])}|adv:` });
+        // #4372/#9810: the durable cache key folds in BOTH check-run fingerprints — advisory and ignored —
+        // so a config change to either invalidates the cached aggregate instead of serving a stale verdict.
+        // Both empty here ("|adv:|ign:") because neither list is configured in this fixture.
+        expect(await getPullRequestDetailSyncState(env, "owner/agent-repo", 7)).toMatchObject({ ciState: "passed", ciRequiredContextsKey: `${JSON.stringify(["trusted-required-ci"])}|adv:|ign:` });
       } finally {
         liveCiSpy.mockRestore();
       }


### PR DESCRIPTION
## main is red

#9813 changed three things and updated only some of their callers:

| change | missed caller |
|---|---|
| `ignoredCheckRuns` added as an **8th arg** to `fetchLiveCiAggregate*` | `agent-approval-queue.test.ts` ×3, `queue.test.ts` — `toHaveBeenCalledWith` pinned the 7-arg shape |
| `\|ign:` fragment added to the durable CI-cache key | `queue.test.ts` asserted `\|adv:` only |
| `ignoredCheckRuns` documented in `.loopover.yml.example` | `config/examples/loopover.full.yml` must match it from the `WHERE IT LIVES` marker onward |

Six failures, on `main`, independent of any open PR — confirmed by checking out `origin/main` clean and reproducing.

## My error, and the specific process failure

I verified #9813 by running the **touched test files**, not the full suite. All three broken files assert on contracts that PR changed while living elsewhere in the tree, so none of them ran before merge. Targeted runs cannot catch a contract change's blast radius — that is exactly what the full suite is for.

## The fixes

- Add the 8th argument to the four call-shape assertions, each commented with what it is.
- Update the cache-key assertion to `\|adv:\|ign:`, and rewrite the comment to explain *why* both fingerprints are folded in (a config change to either must invalidate the cached aggregate rather than serve a stale verdict) — the old comment named only the advisory half.
- Port the `ignoredCheckRuns` block into `config/examples/loopover.full.yml` so the two examples are byte-identical from the marker onward, which is what the test actually requires.

No production code changes — these are test/doc contracts catching up with a shipped change.

## Verification

Full unit suite: **1314 files, 25,209 tests passed**, 3 skipped, zero failures. `tsc` clean.

One thing worth recording: `mcp-cli-completion-spec` and `mcp-cli-response-validation` fail on a bare `vitest run` unless `npm run build:mcp` has been run first — they exercise the built CLI. CI builds it as part of `test:ci`; a local full-suite run needs it explicitly, or you get three failures that look real and are not.