### PR TITLE
fix(db): stop documenting 0090 as a grandfathered migration duplicate

### DIFF
--- a/scripts/check-migrations.ts
+++ b/scripts/check-migrations.ts
@@ -23,12 +23,12 @@
 //   • 0074 — both 0074_ai_review_cache (#1462) and 0074_orb_self_enrollment_disabled (#1465, a bare ADD COLUMN)
 //     merged + deployed before the collision surfaced; the column already exists in prod, so a rename would
 //     re-run the ALTER and fail. Grandfathered for the same reason as 0015/0017.
-//   • 0090 — both 0090_contributor_cap_label (#2479) and 0090_pull_request_detail_sync_head_sha (#2527)
-//     merged with bare ADD COLUMN statements. Preserve both filenames so already-applied databases never
-//     replay either ALTER under a new migration name.
+//   • 0090 — NOT grandfathered: 0090_pull_request_detail_sync_head_sha (#2527) was renumbered to
+//     migrations/0092_* by #8897, so only 0090_contributor_cap_label (#2479) exists at 0090 today — a single
+//     file, no collision, and correctly absent from KNOWN_MIGRATION_DUPLICATES. Do not re-add it from git history.
 //   • 0156 — both 0156_draft_pr_close_policy and 0156_pull_request_screenshot_table_presence_satisfied
 //     merged independently from the same base and were both applied to production before the collision
-//     surfaced; bare ADD COLUMN statements, same grandfather reasoning as 0074/0090.
+//     surfaced; bare ADD COLUMN statements, same grandfather reasoning as 0074.
 import { readdirSync, readFileSync } from "node:fs";
 import { detectMigrationCollisions, extractMigrationNumber, KNOWN_MIGRATION_DUPLICATES, MIGRATION_FILENAME_PATTERN } from "../src/db/migration-collisions";
 import { detectColumnCollisions } from "../src/db/migration-column-extraction";

--- a/test/unit/migration-collisions.test.ts
+++ b/test/unit/migration-collisions.test.ts
@@ -1,3 +1,4 @@
+import { readdirSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { detectMigrationCollisions, extractMigrationNumber, KNOWN_MIGRATION_DUPLICATES, MIGRATION_FILENAME_PATTERN } from "../../src/db/migration-collisions";
 
@@ -89,5 +90,33 @@ describe("KNOWN_MIGRATION_DUPLICATES (#2550)", () => {
     expect(detectMigrationCollisions(["0090_contributor_cap_label.sql"], KNOWN_MIGRATION_DUPLICATES)).toEqual([]);
     // And the renumbered file at its new number is likewise a lone, non-colliding entry.
     expect(detectMigrationCollisions(["0092_pull_request_detail_sync_head_sha.sql"], KNOWN_MIGRATION_DUPLICATES)).toEqual([]);
+  });
+
+  describe("stays bidirectionally in step with the real migrations/ directory (#9653)", () => {
+    const realMigrationFiles = readdirSync("migrations").filter((f) => MIGRATION_FILENAME_PATTERN.test(f));
+
+    it("every filename in KNOWN_MIGRATION_DUPLICATES exists on disk (no dead grandfather entries)", () => {
+      // A re-added 0090 entry (or any stale filename) fails here — the file no longer exists, so the list would
+      // point at a migration that isn't there.
+      const onDisk = new Set(realMigrationFiles);
+      const missing: string[] = [];
+      for (const files of KNOWN_MIGRATION_DUPLICATES.values()) {
+        for (const file of files) if (!onDisk.has(file)) missing.push(file);
+      }
+      expect(missing).toEqual([]);
+    });
+
+    it("every migration number with more than one file on disk is a KNOWN_MIGRATION_DUPLICATES key", () => {
+      // The reverse direction: a genuine on-disk collision that isn't grandfathered would surface here rather
+      // than only at premerge, keeping the two sources in step in both directions.
+      const filesByNumber = new Map<number, string[]>();
+      for (const file of realMigrationFiles) {
+        const number = extractMigrationNumber(file);
+        if (number == null) continue;
+        filesByNumber.set(number, [...(filesByNumber.get(number) ?? []), file]);
+      }
+      const collidingNumbers = [...filesByNumber.entries()].filter(([, files]) => files.length > 1).map(([number]) => number);
+      for (const number of collidingNumbers) expect(KNOWN_MIGRATION_DUPLICATES.has(number)).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## What & why

`KNOWN_MIGRATION_DUPLICATES` (`src/db/migration-collisions.ts`) is already correct — 0090 is **not** a key, because #8897 renumbered `0090_pull_request_detail_sync_head_sha` to `0092`, leaving a single `0090_contributor_cap_label` file at 0090. But `scripts/check-migrations.ts`'s header still documented 0090 as a grandfathered duplicate and cross-referenced "same reasoning as 0074/0090", so a future reader could re-add the dead entry straight from git history.

## The fix

- Replace the 0090 header bullet with a one-line note that 0090 was **renumbered** to 0092 by #8897 (not grandfathered), so it must not be re-added.
- Correct the 0156 cross-reference to name only real grandfathers (0074).
- No behavioural change to the script or to `KNOWN_MIGRATION_DUPLICATES` (which is not edited). `npm run db:migrations:check` still reports the same "4 grandfathered duplicates: 0015, 0017, 0074, 0156".

## Tests (`test/unit/migration-collisions.test.ts`)

Two guards so the header comment and the data can't silently diverge again:

- Every filename in `KNOWN_MIGRATION_DUPLICATES` exists in the real `migrations/` directory — **a re-added 0090 entry (naming the renumbered-away file) fails this** (verified by injecting one).
- Every on-disk migration **number** with more than one file is a key of `KNOWN_MIGRATION_DUPLICATES` — the reverse direction, so a new un-grandfathered collision surfaces here, not only at premerge.

## Validation

- `npm run db:migrations:check` green; `npm run typecheck` green; the migration-collisions and check-migrations-script suites green.
- `scripts/**` is outside Codecov's include, so the comment change carries no coverage obligation; the new tests import `src/db/migration-collisions.ts`, so coverage collection sees real `src/**` files.
- `git diff --check <base> HEAD` clean; diff is two files, no `src/**` source or migration change.

Closes #9653
