### PR TITLE
fix(contract): regenerate api-schemas for #9813's ignoredCheckRuns

### DIFF
--- a/packages/loopover-contract/src/api-schemas.ts
+++ b/packages/loopover-contract/src/api-schemas.ts
@@ -452,6 +452,7 @@ export const RepositorySettingsSchema = z
     // the compile-time parity assertion in test/unit/openapi-settings-schema-parity.test.ts.
     expectedCiContexts: z.array(z.string()).readonly().nullable().optional(),
     advisoryCheckRuns: z.array(z.object({ name: z.string(), appSlug: z.string() })).readonly().nullable().optional(),
+    ignoredCheckRuns: z.array(z.object({ name: z.string(), appSlug: z.string() })).readonly().nullable().optional(),
     copycatGateMode: z.enum(["off", "warn", "label", "block"]).optional(),
     copycatGateMinScore: z.number().nullable().optional(),
     gateDryRun: z.boolean().optional(),


### PR DESCRIPTION
Closes #9836

`contract:api-schemas:check` fails on `main`. #9813 added `ignoredCheckRuns` to `RepositorySettingsSchema` in `src/` without committing the regenerated contract copy — the fourth piece of that PR's fallout, after the three #9829 fixed.

One generated line, directly beside the sibling it mirrors:

```ts
ignoredCheckRuns: z.array(z.object({ name: z.string(), appSlug: z.string() })).readonly().nullable().optional(),
```

**Why it is worth fixing rather than leaving stale.** `@loopover/contract` is the published package MCP and miner consume, and `api-schemas.ts` is what an external client validates a settings write against. A client built on the published contract silently strips `ignoredCheckRuns` — accepted by the server, absent from the schema — so the configuration appears to save and then does nothing, with no error at either end.

Generated output, produced by `npm run contract:api-schemas`, not hand-edited. `contract:api-schemas:check`, `tsc --noEmit` and `contract-api-requests.test.ts` (25 tests) all pass after.

**Noted:** this check does not appear to gate `ci.yml`, which is why `main` stayed green despite the drift. Whether it should is a separate question — a contract-drift check that never runs cannot catch the class of bug it exists for. Not changing CI wiring here.