### PR TITLE
fix(db): track ALTER TABLE … RENAME TO so column-collision detection survives a rebuild

### DIFF
--- a/src/db/migration-column-extraction.ts
+++ b/src/db/migration-column-extraction.ts
@@ -154,6 +154,7 @@ function stripSqlComments(text: string): string {
 export type SchemaEvent =
   | { type: "define_column"; table: string; column: string }
   | { type: "drop_table"; table: string }
+  | { type: "rename_table"; from: string; to: string }
   | { type: "remove_column"; table: string; column: string };
 
 /** Extract the schema-affecting events a single SQL statement produces. Statements that don't affect table
@@ -162,6 +163,13 @@ export function extractSchemaEvents(rawStatement: string): SchemaEvent[] {
   const statement = stripSqlComments(rawStatement);
   const dropTableMatch = /^\s*DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?(\w+)/i.exec(statement);
   if (dropTableMatch) return [{ type: "drop_table", table: dropTableMatch[1]!.toLowerCase() }];
+
+  // `ALTER TABLE <old> RENAME TO <new>` — a whole-table rebuild: every column tracked under <old> must move to
+  // <new> so a collision detector does not go blind on the renamed table (#9647). Checked BEFORE the column
+  // rename below: `RENAME\s+TO` requires TO immediately after RENAME, which the column form (RENAME [COLUMN]
+  // <a> TO <b>, an identifier between RENAME and TO) never has, so the two can't be confused either direction.
+  const renameTableMatch = /\bALTER\s+TABLE\s+(\w+)\s+RENAME\s+TO\s+(\w+)/i.exec(statement);
+  if (renameTableMatch) return [{ type: "rename_table", from: renameTableMatch[1]!.toLowerCase(), to: renameTableMatch[2]!.toLowerCase() }];
 
   const renameColumnMatch = /\bALTER\s+TABLE\s+(\w+)\s+RENAME\s+(?:COLUMN\s+)?(\w+)\s+TO\s+(\w+)/i.exec(statement);
   if (renameColumnMatch) {
@@ -218,6 +226,17 @@ export function detectColumnCollisions(orderedFileContents: ReadonlyArray<readon
         if (event.type === "drop_table") {
           for (const [key, entry] of tracked) {
             if (entry.table === event.table) tracked.delete(key);
+          }
+          continue;
+        }
+        if (event.type === "rename_table") {
+          // Re-key every column tracked under the old name to the new one (#9647): a later CREATE/ALTER against
+          // the renamed table must still collide with a column it already carries, and must NOT collide with the
+          // now-vacated old name. Rebuild the map entries rather than mutating keys in place.
+          for (const [key, entry] of [...tracked]) {
+            if (entry.table !== event.from) continue;
+            tracked.delete(key);
+            tracked.set(`${event.to}.${entry.column}`, { table: event.to, column: entry.column, files: entry.files });
           }
           continue;
         }

--- a/test/unit/migration-column-extraction.test.ts
+++ b/test/unit/migration-column-extraction.test.ts
@@ -107,6 +107,21 @@ describe("extractSchemaEvents (#2551)", () => {
     ]);
   });
 
+  it("extracts ALTER TABLE … RENAME TO as a single rename_table event, disambiguated from column rename (#9647)", () => {
+    // The exact rebuild-and-rename statement from migrations/0201_ledger_anchor_bittensor.sql.
+    expect(extractSchemaEvents("ALTER TABLE decision_ledger_anchors_new RENAME TO decision_ledger_anchors;")).toEqual([
+      { type: "rename_table", from: "decision_ledger_anchors_new", to: "decision_ledger_anchors" },
+    ]);
+    // The column-rename forms (with and without the COLUMN keyword) must NOT be misparsed as a table rename —
+    // they still produce the remove+define pair.
+    expect(extractSchemaEvents("ALTER TABLE widgets RENAME color TO hue;")).toEqual([
+      { type: "remove_column", table: "widgets", column: "color" },
+      { type: "define_column", table: "widgets", column: "hue" },
+    ]);
+    // And a table named like the "to" keyword must not confuse either regex.
+    expect(extractSchemaEvents("ALTER TABLE t RENAME TO t2;")).toEqual([{ type: "rename_table", from: "t", to: "t2" }]);
+  });
+
   it("extracts ADD COLUMN's terser SQLite form that omits the COLUMN keyword (#8368)", () => {
     expect(extractSchemaEvents("ALTER TABLE widgets ADD color TEXT;")).toEqual([{ type: "define_column", table: "widgets", column: "color" }]);
   });
@@ -206,6 +221,28 @@ describe("detectColumnCollisions (#2551)", () => {
       ["0001_a.sql", "CREATE TABLE t (id INTEGER, temp_col TEXT);"],
       ["0002_b.sql", "ALTER TABLE t DROP COLUMN temp_col;"],
       ["0003_c.sql", "ALTER TABLE t ADD COLUMN temp_col TEXT;"],
+    ];
+    expect(detectColumnCollisions(files)).toEqual([]);
+  });
+
+  it("REGRESSION: re-keys columns across a rebuild-and-rename so a later duplicate is still caught (#9647)", () => {
+    // The standard SQLite rebuild-and-rename (as migrations/0201 does): a new table is built with `backend`,
+    // then RENAMEd over the old one. Before #9647 the detector tracked the column under the *_new name and
+    // went blind — a later ADD COLUMN backend on the real table read as a fresh, non-colliding definition.
+    const files: Array<[string, string]> = [
+      ["0001_a.sql", "CREATE TABLE t (id INTEGER, backend TEXT);"],
+      ["0002_b.sql", "CREATE TABLE t_new (id INTEGER, backend TEXT); ALTER TABLE t_new RENAME TO t;"],
+      ["0003_c.sql", "ALTER TABLE t ADD COLUMN backend TEXT;"],
+    ];
+    // Exactly one collision on t.backend — the re-keyed column from 0002's renamed table collides with 0003's.
+    expect(detectColumnCollisions(files)).toEqual([{ table: "t", column: "backend", files: ["0002_b.sql", "0003_c.sql"] }]);
+  });
+
+  it("does not flag the renamed table's columns against the now-vacated old name (#9647)", () => {
+    const files: Array<[string, string]> = [
+      ["0001_a.sql", "CREATE TABLE t_new (id INTEGER, c TEXT); ALTER TABLE t_new RENAME TO t;"],
+      // A brand-new table reusing the OLD (vacated) name must not collide with the columns that moved off it.
+      ["0002_b.sql", "CREATE TABLE t_new (id INTEGER, c TEXT);"],
     ];
     expect(detectColumnCollisions(files)).toEqual([]);
   });


### PR DESCRIPTION
## What & why

`detectColumnCollisions` (`src/db/migration-column-extraction.ts`) replays every migration's schema events in order to catch a same-table/same-column definition split across two individually-valid migrations. But `extractSchemaEvents` emitted **nothing** for `ALTER TABLE <old> RENAME TO <new>` — the standard SQLite rebuild-and-rename (`migrations/0201_ledger_anchor_bittensor.sql` does exactly this, since SQLite can't `ALTER` a CHECK constraint).

So every column tracked under the temporary `_new` table stayed keyed to it, and the detector went **blind** on the real table: a later duplicate `ADD COLUMN` read as a fresh, non-colliding definition — the very class of collision this check exists to catch.

## The fix

- Add a `{ type: "rename_table"; from; to }` `SchemaEvent` variant.
- Parse `ALTER TABLE <old> RENAME TO <new>` into it — matched **before** the column-rename rule and requiring `RENAME` immediately followed by `TO`. The column form (`RENAME [COLUMN] <a> TO <b>`, an identifier between `RENAME` and `TO`) never matches that, and the table form never matches the column rule, so the two are disambiguated in both directions.
- `detectColumnCollisions` handles `rename_table` by **re-keying** every column tracked under the old table name to the new one — and vacating the old name, so a fresh table reusing it doesn't falsely collide.

## Tests (`test/unit/migration-column-extraction.test.ts`)

- `extractSchemaEvents` returns a single `rename_table` for 0201's exact statement; the two column-rename forms still produce `remove_column` + `define_column` (disambiguation proven) — **fails on `main`**.
- Regression: `CREATE t(backend)` → rebuild-and-rename `t_new → t` → `ALTER t ADD COLUMN backend` yields exactly one collision on `t.backend` (**fails on `main`**, which sees none).
- A fresh table reusing the vacated old name does not falsely collide.
- The existing "zero false positives against the real migrations/ directory" invariant still passes (0201 no longer confuses it, and nothing new is flagged).

## Validation

- `npm run typecheck` green; the extraction suite (39 tests) green.
- Diff coverage on the changed file is 100% line and branch.
- `git diff --check <base> HEAD` clean; no migration or schema change.

Closes #9647
