### PR TITLE
fix(miner-ui): type a chat-dispatch mock against the union #9815 closed

### DIFF
--- a/apps/loopover-miner-ui/src/chat-conversation.test.tsx
+++ b/apps/loopover-miner-ui/src/chat-conversation.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
+import type { ChatActionDispatchResult } from "../../../packages/loopover-miner/lib/chat-action-dispatch.js";
 import { createChatActionRegistry } from "../../../packages/loopover-miner/lib/chat-action-registry.js";
 import { ChatConversation } from "./components/chat/conversation";
 import { GOVERNOR_CHAT_ACTION_PENDING_MESSAGE } from "./lib/chat-governor-action-copy";
@@ -288,7 +289,11 @@ describe("ChatConversation governor pause/resume chat actions (#8670)", () => {
   });
 
   it("surfaces a non-executed dispatch (flag off / gated) as a system note instead of an empty turn", async () => {
-    const runGovernorChatActionImpl = vi.fn(async () => ({ ok: false, status: "disabled", action: null }));
+    const runGovernorChatActionImpl = vi.fn(async (): Promise<ChatActionDispatchResult> => ({
+      ok: false,
+      status: "disabled",
+      action: null,
+    }));
     render(
       <ChatConversation
         streamChatImpl={async function* () {


### PR DESCRIPTION
## main is red, and it blocks every open PR

```
src/chat-conversation.test.tsx(297,9): error TS2322:
  Type 'Mock<() => Promise<{ ok: boolean; status: string; action: null; }>>'
  is not assignable to type '(...) => Promise<ChatActionDispatchResult>'
```

Reproduced on a clean `origin/main` checkout — not caused by any open PR. It's why #9840, #9821 and #9780 all show `validate-code` failures: they inherit it.

## Cause

#9659/#9815 **correctly** tightened `ChatActionDispatchResult`:

```ts
- { ok: boolean; status: string; action: string | null; [key: string]: unknown }
+ | ({ ok: true;  status: "dispatched";           action: string | null } & Record<string, unknown>)
+ | ({ ok: false; status: ChatActionRefusalStatus; action: string | null } & Record<string, unknown>)
```

That's a real improvement — the miner MCP server maps a refusal onto a closed error-code set, and a bare `string` made that mapping uncheckable.

But this miner-UI test mocks the dispatcher with a bare object literal:

```ts
vi.fn(async () => ({ ok: false, status: "disabled", action: null }))
```

Inference widens `ok` to `boolean` and `status` to `string`, and a widened literal can't satisfy the closed union. The root `typecheck` doesn't cover `apps/loopover-miner-ui` — only `ui:typecheck` does — which is how it reached main.

## Fix

Annotate the mock's return type and import the real `ChatActionDispatchResult`, so the mock is validated against the shipped contract rather than inference. That also stops it drifting the next time the union changes: the widened version would have kept compiling against literally any shape.

Only the one mock needed it — the sibling that throws is unaffected, and the other tests pass registries rather than inline literals.

## Verification

`ui:typecheck` clean, `ui:lint` clean (prettier applied), `ui:test` **645 passed**, miner-ui **407 passed**, root `tsc` clean.