### PR TITLE
docs(selfhost): document ledger anchoring where operators actually look

### DIFF
--- a/.env.selfhost.example
+++ b/.env.selfhost.example
@@ -111,3 +111,40 @@ LOOPOVER_REVIEW_ENRICHMENT=false
 # The one way to disable it is the explicit air-gap flag below; see .env.example's Orb section for
 # full privacy detail.
 # ORB_AIR_GAP=true                            # air-gapped/OFFLINE deployments only: compute locally, never send
+
+# =============================================================================
+# 6. Decision-ledger anchoring — optional, and the one place self-host has that
+#    the hosted deployment does not
+# =============================================================================
+# Every verdict this instance persists appends to a hash-chained ledger, which already makes
+# tampering WITHIN the chain detectable. Anchoring additionally publishes a signed checkpoint of the
+# chain's tip somewhere you do not control, so rewriting history back past a published anchor means
+# forging a signature at an external log too -- not just editing your own database.
+#
+# This is genuinely self-host territory: the hosted deployment does not execute reviews, so its
+# decision_ledger is empty and there is nothing there to anchor. Your instance's ledger is YOURS --
+# only your decisions, never other operators'.
+#
+# Generate both halves with the encodings the runtime expects:
+#
+#   npm run ledger:anchor-keygen
+#
+# OPT-IN, but ALL-OR-NOTHING: setting only one half makes anchoring silently never run (preflight
+# flags this, see src/selfhost/preflight.ts). Leave both unset to keep anchoring off.
+# LOOPOVER_LEDGER_ANCHOR_KEYS=              # public half: the JSON array, served by /v1/public/decision-ledger/anchor-key
+# LOOPOVER_LEDGER_ANCHOR_PRIVATE_KEY=       # SECRET, PKCS8 PEM. Must be ONE line, with the newlines
+                                            # written as literal backslash-n escapes: a real multi-line
+                                            # value breaks Docker's env_file parsing.
+#
+# Rekor shards ANNUALLY as log<year>-<rev>.rekor.sigstore.dev, and the built-in default can only ever
+# lag behind the live one. If anchors record `status: failed` with a message naming this endpoint,
+# the shard has rotated -- point this at the current one and no code change is needed.
+# LOOPOVER_LEDGER_ANCHOR_REKOR_SHARD_URL=https://log2025-1.rekor.sigstore.dev
+#
+# Second backend, independent of Rekor: a git commit in a repo you own, cross-mirrored by GH Archive
+# and Software Heritage the moment it is pushed. Unset means this backend simply does not run.
+# LOOPOVER_LEDGER_ANCHOR_GIT_OWNER=
+# LOOPOVER_LEDGER_ANCHOR_GIT_REPO=          # a dedicated, public, otherwise-empty repo is the intended shape
+# LOOPOVER_LEDGER_ANCHOR_GIT_BRANCH=main
+# LOOPOVER_LEDGER_ANCHOR_GIT_PATH=anchors.jsonl
+# LOOPOVER_LEDGER_ANCHOR_GIT_INSTALLATION_ID=


### PR DESCRIPTION
Closes #9848

`.env.selfhost.example` covered provider selection and telemetry but never mentioned `LOOPOVER_LEDGER_ANCHOR_*` — despite anchoring being the one capability a self-host deployment uniquely *can* run. The hosted deployment retired review execution, so its `decision_ledger` is empty and there is nothing there to anchor.

The variables were documented in `self-hosting-configuration.mdx`, but nobody reads a docs table to discover a feature they don't know exists.

## Written from actually doing it

Provisioning anchoring on a live instance (1,626 ledger rows) hit three things in sequence, each of which this file is the natural place to prevent:

- **All-or-nothing.** Setting one half makes anchoring silently never run. Preflight catches it — but only once you knew to set anything at all.
- **The PEM must be single-line with `\n` escapes.** A real multi-line value breaks Docker's `env_file` parsing. `pemToBytes` handles the escapes, but nothing said so anywhere an operator would look.
- **The Rekor shard rotates annually.** When the default lags, anchors record `status: failed` and there was no pointer toward the override that fixes it (#9844, fixed separately).

Also states plainly that the ledger is per-instance — only your decisions, never other operators' — since that was the first question asked when turning it on.

## Validation

`docker-compose-env-example-parity` and `selfhost-preflight` suites pass (44 tests). `selfhost:config-lint` clean. Comments-only addition; every line is commented out, so no default behaviour changes.