### PR TITLE
fix(eval): state the coverage an EvalScoreRecord already determines

### DIFF
--- a/src/review/eval-score-records.ts
+++ b/src/review/eval-score-records.ts
@@ -70,6 +70,17 @@ async function finalizeRecord(input: EvalScoreRecordDigestInput): Promise<EvalSc
   return { ...input, recordDigest };
 }
 
+/** #9215's coverage definition -- `decided / (decided + abstained)` -- as the single implementation every
+ *  work-unit kind derives from, so a record's published `coverage` and a validator's re-derivation of it can
+ *  never disagree. `null` only when nothing was seen at all (`0/0` is undefined, not zero): that is the same
+ *  guard-the-denominator-else-null shape {@link PublicRulePrecisionRow.precision} uses below its sample floor
+ *  (`public-rule-precision.ts`), never a masked `0`. Exported so a future emitter (#9265's `benchmark_run`)
+ *  states coverage by calling this rather than restating the formula. */
+export function evalScoreCoverage(decided: number, abstained: number): number | null {
+  const total = decided + abstained;
+  return total > 0 ? decided / total : null;
+}
+
 /**
  * Build `EvalScoreRecord`s from the already-computed public rule-precision block. Returns an empty array
  * when there is no persisted backtest run yet (`latestBacktestRun === null`) -- per #9215's own requirement,
@@ -99,8 +110,13 @@ async function finalizeRecord(input: EvalScoreRecordDigestInput): Promise<EvalSc
  * `recall` and `abstained` do not apply to this work-unit kind: ORB's gate rules fire deterministically (no
  * agent choosing to abstain) and this data measures precision, not a false-negative rate. `recall` is
  * `null` (genuinely inapplicable, never a misleading `0`); `abstained` is `0` (there is no abstention
- * concept here, so `0` is the correct value, not a masked null). PURE -- no IO, no clock (the caller
- * supplies `issuedAt`).
+ * concept here, so `0` is the correct value, not a masked null). `coverage` follows from that `abstained`:
+ * with no abstention concept the denominator is just `decided`, so every rule that decided anything covered
+ * all of it and states `1` -- computed via {@link evalScoreCoverage}, never hardcoded, so it stays correct
+ * for a kind that does abstain. It was previously `null` by symmetry with `recall`, which published "coverage
+ * unknown" for a quantity the record's own `decided`/`abstained` pin down exactly, so a validator re-deriving
+ * per #9215 computed `1` and disagreed with the field (#9643). Only `decided === 0` is genuinely undefined
+ * (`0/0`) and stays `null`. PURE -- no IO, no clock (the caller supplies `issuedAt`).
  */
 export async function buildEvalScoreRecordsFromRulePrecision(
   precision: PublicRulePrecision,
@@ -136,7 +152,9 @@ export async function buildEvalScoreRecordsFromRulePrecision(
           confirmed: row.confirmed,
           precision: row.precision,
           recall: null,
-          coverage: null,
+          // Same literal `0` the sibling `abstained` publishes, passed rather than re-stated, so the two can
+          // never drift into a record whose coverage contradicts its own abstention count.
+          coverage: evalScoreCoverage(row.decided, 0),
           abstained: 0,
         },
         commitments: {

--- a/test/integration/public-eval-scores-route.test.ts
+++ b/test/integration/public-eval-scores-route.test.ts
@@ -56,7 +56,9 @@ describe("GET /v1/public/eval-scores (#9266, epic #8534, spec #9215)", () => {
     expect(body.records).toHaveLength(1);
     const [record] = body.records;
     expect(record?.workUnit).toEqual({ kind: "outcome_confirmed_precision", ruleId: "ai_consensus_defect" });
-    expect(record?.score).toEqual({ decided: 20, confirmed: 16, precision: 0.8, recall: null, coverage: null, abstained: 0 });
+    // coverage is 1, not null: abstained is structurally 0 for this work-unit kind, so the record's own
+    // decided/(decided+abstained) is fully determined and the published field states it (#9643).
+    expect(record?.score).toEqual({ decided: 20, confirmed: 16, precision: 0.8, recall: null, coverage: 1, abstained: 0 });
     expect(record?.commitments.corpusChecksum).toBe("freeze-point-checksum");
     expect(record?.subject).toEqual({ kind: "agent", id: ORB_GATE_SUBJECT_ID });
 

--- a/test/unit/eval-score-records.test.ts
+++ b/test/unit/eval-score-records.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildEvalScoreRecordsFromRulePrecision,
   EVAL_SCORE_RECORD_SCHEMA_VERSION,
+  evalScoreCoverage,
   filterEvalScoreRecords,
   ORB_GATE_SUBJECT_ID,
   OUTCOME_CONFIRMED_PRECISION_SCORING_RULE_VERSION,
@@ -26,6 +27,18 @@ const PRECISION_WITH_FREEZE_POINT: PublicRulePrecision = {
   reversals: { reopened: 2, reverted: 1, superseded: 3 },
   latestBacktestRun: { corpusChecksum: "abc123def456", at: "2026-07-27T10:00:00.000Z" },
 };
+
+describe("evalScoreCoverage (#9643)", () => {
+  it("is #9215's decided/(decided+abstained), so a validator re-deriving it agrees with the published field", () => {
+    expect(evalScoreCoverage(25, 0)).toBe(1); // no abstention concept: everything seen was decided
+    expect(evalScoreCoverage(3, 1)).toBe(0.75); // a kind that DOES abstain needs no second implementation
+    expect(evalScoreCoverage(0, 4)).toBe(0); // decided nothing of what it saw -- a real 0, not undefined
+  });
+
+  it("returns null only when nothing was seen at all (0/0 is undefined, never a masked 0)", () => {
+    expect(evalScoreCoverage(0, 0)).toBeNull();
+  });
+});
 
 describe("buildEvalScoreRecordsFromRulePrecision (#9266)", () => {
   it("returns an empty array when there is no persisted backtest run to commit to", async () => {
@@ -72,11 +85,37 @@ describe("buildEvalScoreRecordsFromRulePrecision (#9266)", () => {
   it("carries decided/confirmed/precision through verbatim, with recall null and abstained 0 (not applicable to this work-unit kind)", async () => {
     const records = await buildEvalScoreRecordsFromRulePrecision(PRECISION_WITH_FREEZE_POINT, ISSUED_AT);
     const withPrecision = records.find((r) => r.workUnit.kind === "outcome_confirmed_precision" && r.workUnit.ruleId === "ai_consensus_defect");
-    expect(withPrecision?.score).toEqual({ decided: 25, confirmed: 20, precision: 0.8, recall: null, coverage: null, abstained: 0 });
+    // coverage is 1, not null: abstained is structurally 0 here, so 25/(25+0) is fully determined (#9643).
+    expect(withPrecision?.score).toEqual({ decided: 25, confirmed: 20, precision: 0.8, recall: null, coverage: 1, abstained: 0 });
 
     const sparse = records.find((r) => r.workUnit.kind === "outcome_confirmed_precision" && r.workUnit.ruleId === "sparse_rule");
     // Below the public sample floor: precision is null (never a misleading 0), decided/confirmed still real counts.
-    expect(sparse?.score).toEqual({ decided: 9, confirmed: 9, precision: null, recall: null, coverage: null, abstained: 0 });
+    // coverage is still 1 -- the sample floor gates precision only, and 9 decided of 9 seen is full coverage.
+    expect(sparse?.score).toEqual({ decided: 9, confirmed: 9, precision: null, recall: null, coverage: 1, abstained: 0 });
+  });
+
+  it("REGRESSION (#9643): a rule that decided nothing keeps coverage null -- 0/0 is undefined, not zero", async () => {
+    // The one case where null is the honest answer, and the arm that makes `coverage: 1` a computation rather
+    // than a hardcoded constant. Previously EVERY record published null, including the 25-decided one above,
+    // so a validator re-deriving decided/(decided+abstained) per #9215 computed 1 and disagreed with the field.
+    const records = await buildEvalScoreRecordsFromRulePrecision(
+      { ...PRECISION_WITH_FREEZE_POINT, rules: [{ ruleId: "never_fired", decided: 0, confirmed: 0, precision: null }] },
+      ISSUED_AT,
+    );
+    expect(records).toHaveLength(1);
+    expect(records[0]?.score).toEqual({ decided: 0, confirmed: 0, precision: null, recall: null, coverage: null, abstained: 0 });
+  });
+
+  it("REGRESSION (#9643): records built after the coverage change still verify against their own digest", async () => {
+    // recordDigest is computed over the whole record, so changing coverage changes the digest. Records are
+    // built on read (routes.ts), never persisted, so nothing needs migrating -- but the round-trip a consumer
+    // runs to verify a fetched record must still hold.
+    const records = await buildEvalScoreRecordsFromRulePrecision(PRECISION_WITH_FREEZE_POINT, ISSUED_AT);
+    expect(records).toHaveLength(2);
+    for (const record of records) {
+      expect(record.score.coverage).toBe(1);
+      await expect(verifyEvalScoreRecordDigest(record)).resolves.toBe(true);
+    }
   });
 
   it("each record's recordDigest is the sha256 of its own canonical content (independently recomputable)", async () => {


### PR DESCRIPTION
## Summary

`buildEvalScoreRecordsFromRulePrecision` hardcoded `coverage: null` while asserting
`abstained: 0` two lines below. #9215 defines `coverage = decided / (decided + abstained)`,
so with `abstained` structurally `0` the value is fully determined: any rule that decided
anything covered all of it. Publishing `null` told a consumer "this record does not state
its coverage" about a quantity the record itself pins down, and a validator re-deriving the
score per the #9215 contract computed `1` and disagreed with the published field — the one
thing an independently re-derivable record format exists to prevent.

**Root cause.** The doc comment justifies `recall: null` and `abstained: 0` explicitly, per
field. `coverage` was filled in as `null` by symmetry with `recall` and never reasoned about
— an omission in a justification block rather than a logic error, which is why it survived
review.

**Changes.**

1. New exported `evalScoreCoverage(decided, abstained): number | null` in
   `src/review/eval-score-records.ts` — `total > 0 ? decided / total : null`, mirroring the
   guard-the-denominator-else-null shape `PublicRulePrecisionRow.precision` uses below its
   sample floor. Exported so #9265's `benchmark_run` emitter states coverage by calling this
   rather than restating the formula.
2. The emit site calls it: `coverage: evalScoreCoverage(row.decided, 0)`, passing the same
   literal `0` the sibling `abstained` field publishes so the two cannot drift into a record
   whose coverage contradicts its own abstention count.
3. The doc comment gains a `coverage` justification in the established per-field
   null-vs-zero style.

`decided === 0` still yields `null` — `0/0` is genuinely undefined, never a masked zero.

`recordDigest` covers the whole record, so digests change for `outcome_confirmed_precision`
records. No migration is needed: records are built on read (`routes.ts`), never persisted,
and no golden-corpus or fixture file pins a digest.

Closes #9643

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`
- [x] I linked a currently open issue this PR resolves (Closes #9643)

## Validation

- [x] `git diff --check` — clean
- [x] `npm run actionlint`
- [x] `npm run typecheck` — exit 0 (root + packages)
- [ ] `npm run test:coverage` — see note below
- [ ] `npm run test:workers`
- [x] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

Targeted runs that passed in full:

- `npx vitest run test/unit/eval-score-records.test.ts` — 27/27
- Affected set (`eval-score-records`, `public-eval-scores-route`, `benchmark-eval-records`,
  `threshold-backtest-run`, `public-rule-precision`) — 74/74
- Fix reverted, tests kept: 7 failed. Fix restored: 0 failed. Every new assertion genuinely
  fails without the change.
- 22 repository drift/lint checks pass individually (actionlint, db:migrations:check,
  db:migrations:immutable:check, db:schema-drift:check, cf-typegen:check,
  coverage-boltons:check, selfhost:env-reference:check, miner:env-reference:check,
  selfhost:validate-observability, docs:drift-check, manifest:drift-check,
  engine-parity:drift-check, branding-drift:check, engines-nvmrc:check,
  release-manifest:sync:check, command-reference:check, ui:openapi:check,
  workspace-dep-ranges:check, server-manifest:check, dispatch-gate-reasons:check,
  ui-derived-types:check, contract:api-schemas:check)

`npm run test:coverage` ran to completion locally (1013 s, 1320 files): 1258 files / 25084
tests passed; 58 files / 207 tests failed, exit 1. Those 58 files fail identically on
unmodified `main` — verified with a baseline run over the same file set at the same base
commit (57 failed / 206 tests). The one-file delta,
`test/unit/miner-cross-repo-evaluation.test.ts`, passes 60/60 with these changes applied in
isolation and references nothing this PR touches; it is a load-sensitive flake. The failures
are environmental to a Windows dev box (`spawn claude ENOENT`, `spawn codex ENOENT`, missing
sqlite temp state, Windows path handling in several of the repo's own scripts). No failure
anywhere in the run log references `evalScoreCoverage`, `eval-score-records`, or
`public-eval-scores`. The unchecked boxes above were not run to completion for the same
reason — they are not skipped as unnecessary, and CI is the authoritative signal for them.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests — n/a, no auth/CORS surface touched
- [x] API/OpenAPI/MCP behavior is updated and tested where needed — the `coverage` field was already typed `number | null`; `ui:openapi:check` is clean
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks — n/a, no UI change
- [x] Visible UI changes include a `UI Evidence` section — n/a, no visible change
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs — no changelog edit

## UI Evidence

Not applicable — backend-only change to a published JSON field with no visible UI, frontend,
docs, or extension surface. `.loopover.yml`'s `screenshotTableGate` is scoped to
`apps/loopover-ui/src/{components,routes}/**` and `styles.css`; this PR touches none of them.

## Notes

**Risks and limitations.**

- Three committed assertions pinned the old `coverage: null` (`eval-score-records.test.ts`
  lines 75/79, `public-eval-scores-route.test.ts` line 59). They are corrected to `1`, which
  is the behavioural change this issue asks for, not a weakened test.
- `deriveBenchmarkLeaderboard` ranks ties by `coverage ?? -1`, so `null → 1` could in
  principle reorder it. It filters to `workUnit.kind === "benchmark_run"` first and these are
  `outcome_confirmed_precision` records, so they never reach the ranking — no ordering change.
- `benchmark-eval-records.ts` reads `coverage` straight off `report.coverage.coverage` rather
  than re-deriving it, so there is no existing duplicate formula to unify. Retrofitting it to
  call the helper is deliberately out of scope here: the Deliverables do not ask for it and
  the value originates in `packages/loopover-engine`.
- Consumers caching a `recordDigest` across the deploy will see it change once, by design.
