### PR TITLE
ci(release): let release-please bump server.json's version itself

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,11 @@
     "packages/loopover-mcp": {
       "release-type": "node",
       "component": "mcp",
-      "package-name": "@loopover/mcp"
+      "package-name": "@loopover/mcp",
+      "extra-files": [
+        { "type": "json", "path": "/server.json", "jsonpath": "$.version" },
+        { "type": "json", "path": "/server.json", "jsonpath": "$.packages[0].version" }
+      ]
     },
     "packages/loopover-engine": {
       "release-type": "node",


### PR DESCRIPTION
Closes #9874. Unblocks #9780 (and every release PR after it).

## Problem

`check-server-manifest` requires `server.json`'s `version` and `packages[0].version` to equal `@loopover/mcp`'s, and it runs in `test:ci`. release-please bumps the package but never touches `server.json`, so **every generated release PR fails CI**:

```
server.json has 2 problem(s) (#9526):
  version: must equal @loopover/mcp's 3.17.0 (release automation owns it), got 3.15.2
  packages[0].version: must equal @loopover/mcp's 3.17.0, got 3.15.2
```

## A manual fix provably does not hold

I fixed #9780 by hand first. release-please then **regenerated the branch and discarded the commit** — `server.json` is back to `3.15.2` there now. That is the whole reason this belongs in the config and not in a script a human runs: the branch that needs the fix is the one the bot rewrites.

It also rules out the repo's existing `sync-release-manifest.ts` idiom, which is a fine pattern but only ever runs when a human runs it.

## The leading slash is load-bearing

release-please joins an extra-file path to the package directory **unless it starts with `/`** — `strategies/base.js`:

```js
addPath(file) {
  if (!this.path || this.path === ROOT_PROJECT_PATH || file.startsWith('/')) {
    file = file.replace(/^\/+/, '');   // repo-root relative
  } else {
    file = `${this.path.replace(/\/+$/, '')}/${file}`;  // package relative
  }
```

So a plain `"server.json"` would have resolved to `packages/loopover-mcp/server.json` and silently updated nothing — the failure mode being fixed, but harder to spot. I flagged this as the open question on #9874 rather than guessing; this PR lands it only because it is now verified.

## Verified, not assumed

Against the installed release-please **17.10.4**, exercising its real `addPath` logic and its real `GenericJson` updater on this repo's actual `server.json`:

```
root-relative  '/server.json' -> server.json
pkg-relative   'server.json'  -> packages/loopover-mcp/server.json
after update -> version: 9.9.9 | packages[0].version: 9.9.9
```

Both jsonpaths resolve and rewrite; `jsonpath-plus` handles `$.packages[0].version`, and both targets are strings (the updater skips non-strings with a warning).

## Effect

Once this is on `main`, release-please regenerates #9780 with `server.json` already carrying the new version, and `server-manifest:check` passes unaided. No human step between the bot opening a release PR and CI going green.

Config-only, 5 lines. Nothing to test locally beyond the verification above — the real confirmation is the next generated release PR, which is what #9874's acceptance asks for.