### PR TITLE
fix(miner): give `queue dashboard` the same store-failure handling as its siblings (#9690)

### DIFF
--- a/packages/loopover-miner/lib/portfolio-dashboard.ts
+++ b/packages/loopover-miner/lib/portfolio-dashboard.ts
@@ -8,7 +8,7 @@
 // any future consumer beyond this CLI's own text/JSON output.
 
 import { initPortfolioQueueStore } from "./portfolio-queue.js";
-import { argsWantJson, reportCliFailure } from "./cli-error.js";
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
 
 const QUEUE_STATUS_KEYS = ["queued", "in_progress", "done"] as const;
 type QueueStatusKey = (typeof QUEUE_STATUS_KEYS)[number];
@@ -149,16 +149,23 @@ export function runPortfolioDashboard(
   if ("error" in parsed) {
     return reportCliFailure(argsWantJson(args), parsed.error);
   }
+  // Open the store INSIDE the try so an opener failure (a corrupt portfolio-queue.sqlite3, an unreadable state
+  // dir, an invalid LOOPOVER_MINER_PORTFOLIO_QUEUE_DB) returns 2 like every sibling `queue` subcommand instead of
+  // escaping runQueueCli with a raw stack trace; the finally guards the close with `?.` since the initializer may
+  // have thrown before assigning (mirrors runQueueClaimBatch, portfolio-queue-cli.ts:520-541).
   const ownsQueue = options.initPortfolioQueue === undefined;
-  const portfolioQueue = (options.initPortfolioQueue ?? initPortfolioQueueStore)();
+  let portfolioQueue: { listQueue(repoFullName: string | null): unknown[]; close(): void } | undefined;
   try {
+    portfolioQueue = (options.initPortfolioQueue ?? initPortfolioQueueStore)();
     const summary = collectPortfolioDashboard(
       { portfolioQueue },
       { nowMs: Number.isFinite(options.nowMs) ? (options.nowMs as number) : Date.now() },
     );
     console.log(parsed.json ? JSON.stringify(summary, null, 2) : renderPortfolioDashboardTable(summary));
     return 0;
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
   } finally {
-    if (ownsQueue) portfolioQueue.close();
+    if (ownsQueue) portfolioQueue?.close();
   }
 }

--- a/test/unit/miner-portfolio-dashboard.test.ts
+++ b/test/unit/miner-portfolio-dashboard.test.ts
@@ -184,3 +184,64 @@ describe("runPortfolioDashboard (#4287)", () => {
     expect(String(log.mock.calls[0]?.[0])).toContain("portfolio queue is empty");
   });
 });
+
+describe("runPortfolioDashboard store-failure handling (#9690)", () => {
+  it("REGRESSION: an opener failure returns 2 instead of escaping runQueueCli (was: threw)", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const boom = () => {
+      throw new Error("invalid_portfolio_queue_db_path");
+    };
+    // Before the fix the store was opened OUTSIDE the try, so this threw straight out of runQueueCli.
+    expect(runPortfolioDashboard([], { initPortfolioQueue: boom })).toBe(2);
+    expect(error).toHaveBeenCalledWith("invalid_portfolio_queue_db_path");
+  });
+
+  it("REGRESSION: an opener failure under --json emits { ok: false, error } on stdout and returns 2", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const boom = () => {
+      throw new Error("invalid_portfolio_queue_db_path");
+    };
+    expect(runPortfolioDashboard(["--json"], { initPortfolioQueue: boom })).toBe(2);
+    expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+      ok: false,
+      error: "invalid_portfolio_queue_db_path",
+    });
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it("REGRESSION: a store whose listQueue throws mid-run still closes the owned store and returns 2", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const store = {
+      listQueue: () => {
+        throw new Error("db_read_failed");
+      },
+      close: vi.fn(),
+    };
+    // No injected initPortfolioQueue → ownsQueue=true → the default factory is used and must be closed in `finally`.
+    const pqModule = await import("../../packages/loopover-miner/lib/portfolio-queue");
+    const initSpy = vi.spyOn(pqModule, "initPortfolioQueueStore").mockReturnValue(store as never);
+    try {
+      expect(runPortfolioDashboard([])).toBe(2);
+      expect(error).toHaveBeenCalledWith("db_read_failed");
+      expect(store.close).toHaveBeenCalledTimes(1);
+    } finally {
+      initSpy.mockRestore();
+    }
+  });
+
+  it("REGRESSION: an owned-store opener failure returns 2 with nothing to close (`?.` guard)", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    // ownsQueue=true AND the default factory throws before assigning → the `?.` in finally must short-circuit.
+    const pqModule = await import("../../packages/loopover-miner/lib/portfolio-queue");
+    const initSpy = vi.spyOn(pqModule, "initPortfolioQueueStore").mockImplementation(() => {
+      throw new Error("invalid_portfolio_queue_db_path");
+    });
+    try {
+      expect(runPortfolioDashboard([])).toBe(2);
+      expect(error).toHaveBeenCalledWith("invalid_portfolio_queue_db_path");
+    } finally {
+      initSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## What

`queue dashboard` was the only `queue` subcommand that let a store failure escape `runQueueCli`. `runPortfolioDashboard` opened the portfolio-queue store **outside** its `try` and had only a `finally`, so an opener failure — a corrupt `portfolio-queue.sqlite3`, an unreadable state dir, an invalid `LOOPOVER_MINER_PORTFOLIO_QUEUE_DB` — propagated out of the CLI as a raw Node stack trace with exit `1`, where every sibling subcommand prints `{ "ok": false, "error": ... }` under `--json` and exits `2`.

## How

Mirror `runQueueClaimBatch` (`portfolio-queue-cli.ts:520-541`) exactly:

- Open the store **inside** the `try`.
- `catch (error) { return reportCliFailure(parsed.json, describeCliError(error)); }`.
- Import `describeCliError` from `./cli-error.js`.
- Guard the `finally` close with `?.` (the initializer may throw before assigning).

The success path, the parse-error path, and the `ownsQueue` ownership rule are unchanged.

## Tests

Four named regression tests in `test/unit/miner-portfolio-dashboard.test.ts`, each failing against the current code:

1. An injected opener failure returns `2` (was: threw out of `runQueueCli`).
2. The same under `--json` emits `{ ok: false, error }` on stdout and returns `2`.
3. A store whose `listQueue` throws mid-run still closes the owned store and returns `2`.
4. An owned-store opener failure returns `2` with nothing to close (the `?.` guard short-circuits).

Together they cover both `parsed.json` arms of the new `catch` and both arms of the `ownsQueue` / `?.` close.

Closes #9690