### PR TITLE
fix(miner): a rejecting captureError must not skip runCleanup()/exit in the crash handlers (#9688)

### DIFF
--- a/packages/loopover-miner/lib/process-lifecycle.ts
+++ b/packages/loopover-miner/lib/process-lifecycle.ts
@@ -23,8 +23,9 @@ export type InstallCliSignalHandlersOptions = {
   /** Called (in addition to `log`) for uncaughtException/unhandledRejection specifically -- not the clean
    *  SIGINT/SIGTERM exits, which are not errors. AWAITED before the process exits, so it should both capture
    *  AND flush (see captureMinerErrorAndFlush in bin/loopover-miner.js) -- a synchronous capture alone only
-   *  queues the event, which process.exit() would then likely never deliver. No-op default. Never expected to
-   *  throw/reject. */
+   *  queues the event, which process.exit() would then likely never deliver. No-op default. A synchronous throw
+   *  or a rejected promise from this hook is caught and logged (`error capture failed: ...`) so that the cleanup
+   *  sweep and the process exit always run -- a failing error sink can never leave the miner's stores open. */
   captureError?: (error: unknown, context?: Record<string, unknown>) => void | Promise<void>;
   /** Reinstall even if handlers were already installed (mainly for tests). */
   force?: boolean;
@@ -119,16 +120,28 @@ export function installCliSignalHandlers(options: InstallCliSignalHandlersOption
   // not require these handlers to be synchronous: nothing exits the process until this handler itself calls
   // `exit()`, so awaiting first is safe. captureError's own default is a synchronous no-op, so `await`-ing it
   // is a harmless no-op for every caller that doesn't pass one.
+  // captureError is a public injectable option whose "never throws/rejects" contract lived only in prose. Enforce
+  // it HERE, at the chokepoint: a synchronous throw or a rejected promise from the hook is caught and logged so
+  // runCleanup() + exit() always run -- otherwise a failing error sink would leave every registered store open and
+  // (on unhandledRejection) the async handler's own rejection would re-enter this same handler.
   proc.on("uncaughtException", async (error: unknown) => {
     log(`loopover-miner: uncaught exception: ${describeError(error)}`);
-    await captureError(error, { kind: "uncaughtException" });
+    try {
+      await captureError(error, { kind: "uncaughtException" });
+    } catch (captureFailure) {
+      log(`loopover-miner: error capture failed: ${describeError(captureFailure)}`);
+    }
     runCleanup();
     exit(1);
   });
 
   proc.on("unhandledRejection", async (reason: unknown) => {
     log(`loopover-miner: unhandled promise rejection: ${describeError(reason)}`);
-    await captureError(reason, { kind: "unhandledRejection" });
+    try {
+      await captureError(reason, { kind: "unhandledRejection" });
+    } catch (captureFailure) {
+      log(`loopover-miner: error capture failed: ${describeError(captureFailure)}`);
+    }
     runCleanup();
     exit(1);
   });

--- a/test/unit/miner-process-lifecycle.test.ts
+++ b/test/unit/miner-process-lifecycle.test.ts
@@ -240,6 +240,58 @@ describe("loopover-miner process lifecycle / crash-safety (#4826)", () => {
     expect(log.mock.calls.some((call) => String(call[0]).includes("cleanup boom"))).toBe(true);
   });
 
+  it("REGRESSION (#9688): a REJECTING captureError on uncaughtException is caught -- cleanup still runs and exit(1) still fires", async () => {
+    const { proc, handlers, exit } = makeFakeProcess();
+    const log = vi.fn();
+    const store = { close: vi.fn() };
+    registerCleanupResource(store);
+    const captureError = vi.fn(() => Promise.reject(new Error("sink flush failed")));
+    installCliSignalHandlers({ process: proc, log, exit, captureError });
+
+    await handlers.get("uncaughtException")?.(new Error("kaboom"));
+
+    expect(captureError).toHaveBeenCalledTimes(1);
+    expect(store.close).toHaveBeenCalledTimes(1); // the registered store was NOT left open
+    expect(cleanupResourceCount()).toBe(0);
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("error capture failed: "));
+    expect(log.mock.calls.some((call) => String(call[0]).includes("sink flush failed"))).toBe(true);
+  });
+
+  it("REGRESSION (#9688): a REJECTING captureError on unhandledRejection is caught -- cleanup still runs and exit(1) still fires", async () => {
+    const { proc, handlers, exit } = makeFakeProcess();
+    const log = vi.fn();
+    const store = { close: vi.fn() };
+    registerCleanupResource(store);
+    const captureError = vi.fn(() => Promise.reject(new Error("sink flush failed")));
+    installCliSignalHandlers({ process: proc, log, exit, captureError });
+
+    await handlers.get("unhandledRejection")?.("plain reason");
+
+    expect(captureError).toHaveBeenCalledTimes(1);
+    expect(store.close).toHaveBeenCalledTimes(1);
+    expect(cleanupResourceCount()).toBe(0);
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("error capture failed: "));
+  });
+
+  it("REGRESSION (#9688): a captureError that throws SYNCHRONOUSLY is also caught -- cleanup still runs and exit(1) still fires", async () => {
+    const { proc, handlers, exit } = makeFakeProcess();
+    const log = vi.fn();
+    const store = { close: vi.fn() };
+    registerCleanupResource(store);
+    const captureError = vi.fn(() => {
+      throw new Error("sync sink boom");
+    });
+    installCliSignalHandlers({ process: proc, log, exit, captureError });
+
+    await handlers.get("uncaughtException")?.(new Error("kaboom"));
+
+    expect(store.close).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(log.mock.calls.some((call) => String(call[0]).includes("sync sink boom"))).toBe(true);
+  });
+
   it("defaults to the real process when none is injected", () => {
     withRealProcessCleanup(() => {
       expect(installCliSignalHandlers({ log: vi.fn(), exit: vi.fn(), force: true })).toBe(true);


### PR DESCRIPTION
## What

`process-lifecycle.ts` calls itself "the single cleanup chokepoint", yet its `uncaughtException` / `unhandledRejection` handlers `await captureError(...)` with no guard. The "never throws/rejects" contract on the public injectable `captureError` option existed only as prose. If an injected hook rejects — or throws synchronously — `runCleanup()` and `exit(1)` are both skipped: every registered SQLite handle stays open and unflushed (the exact failure this module exists to prevent), and on `unhandledRejection` the handler's own rejected promise re-enters the same handler.

## How

- Wrap the `await captureError(...)` in **both** handlers in `try`/`catch`, logging a distinct `loopover-miner: error capture failed: ...` message via the same injected `log` and the module's existing `describeError` helper, so `runCleanup()` + `exit(1)` always run in their current order and exactly once.
- Update the `captureError` doc comment to document the catch-and-log behaviour instead of claiming it is "Never expected to throw/reject".
- The `SIGINT`/`SIGTERM` handlers and the production `bin/loopover-miner.ts` wiring are untouched.

## Tests

Three named regression tests in `test/unit/miner-process-lifecycle.test.ts`, each failing against the current code:

1. A rejecting `captureError` on `uncaughtException` — the registered store's `close()` still ran, `exit(1)` fired, and the failure was logged.
2. The same on `unhandledRejection`.
3. A `captureError` that throws **synchronously** is also caught.

These cover the new `catch` arm of both handlers plus the synchronous-throw path; the resolve arm is already covered by the existing `#6011` tests.

Closes #9688