### PR TITLE
ci: run coco-dev-versions and import-specifiers drift checks in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
       rees: ${{ steps.filter.outputs.rees }}
       controlPlane: ${{ steps.filter.outputs.controlPlane }}
       observability: ${{ steps.filter.outputs.observability }}
+      cocoDev: ${{ steps.filter.outputs.cocoDev }}
     steps:
       # Debounce rapid re-pushes to an open PR: every job below (validate-code, validate-tests)
       # has `needs: changes` in its dependency chain, so none of
@@ -198,6 +199,13 @@ jobs:
             discoveryIndex:
               - 'packages/discovery-index/**'
               - 'package-lock.json'
+            # coco-dev-versions:check reconciles k8s/coco-dev/versions.json with the KBS kustomization's recorded
+            # version; both files live entirely outside every other filter (no src/** or packages/** import edge),
+            # so without a dedicated trigger a version bump to only those files would skip the check with zero CI
+            # signal (#9649).
+            cocoDev:
+              - 'k8s/coco-dev/**'
+              - 'scripts/check-coco-dev-versions*.ts'
             # 6 of the 7 MCP CLI-cluster test files, and ONLY these 6, are truly self-contained w.r.t. root
             # src/**: verified by direct-import inspection that test/unit/mcp-cli-*.test.ts (5 files) and
             # their shared test/unit/support/mcp-cli-harness.ts import nothing but node:* builtins + vitest,
@@ -438,6 +446,21 @@ jobs:
       - name: Branding drift check
         if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.mcp == 'true' || needs.changes.outputs.engine == 'true' || needs.changes.outputs.miner == 'true' || needs.changes.outputs.ui == 'true' || needs.changes.outputs.discoveryIndex == 'true' }}
         run: npm run branding-drift:check
+      # #9649: coco-dev-versions:check reconciles k8s/coco-dev/versions.json with the KBS kustomization's
+      # recorded version; nothing in this workflow previously ran it, so a version bump made in only one of the
+      # two files could silently ship a KBS deploy not matching its own manifest with zero CI signal. Same
+      # local-only-until-now gap as the drift checks above; gated on the new cocoDev filter, the only one
+      # covering k8s/coco-dev/** and the script.
+      - name: Coco-dev versions check
+        if: ${{ github.event_name == 'push' || needs.changes.outputs.cocoDev == 'true' }}
+        run: npm run coco-dev-versions:check
+      # #9649: import-specifiers:check (#9221) enforces the per-zone relative-import specifier convention over
+      # src, scripts, test and every packages/* workspace (BUNDLER_ROOTS/NODENEXT_ROOTS); #9240 and #9249 both
+      # drifted to main while the guard was local-only. Same gap as the drift checks above; gated on every
+      # filter that covers one of those roots.
+      - name: Import specifiers check
+        if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.mcp == 'true' || needs.changes.outputs.engine == 'true' || needs.changes.outputs.miner == 'true' || needs.changes.outputs.discoveryIndex == 'true' }}
+        run: npm run import-specifiers:check
       # Every engines.node in this repo used to be open-ended (">=22.0.0", no upper bound), so npm never
       # warned or blocked a Node 23+ install locally -- exactly how the Node 26 jsdom/localStorage gap
       # (nodejs/node#60303) went undetected in apps/loopover-miner-ui (#7592/#7597), then again in

--- a/test/unit/check-import-specifiers-script.test.ts
+++ b/test/unit/check-import-specifiers-script.test.ts
@@ -131,4 +131,13 @@ describe("check-import-specifiers script", () => {
     expect(multi.map((v) => v.file)).toEqual(["src/a.ts", "src/z.ts", "src/z.ts"]);
     expect(multi.map((v) => v.specifier)).toEqual(["./c.js", "./a.js", "./b.js"]);
   });
+
+  // #9649: the most important regression test in this file -- run findImportSpecifierViolations against the
+  // REAL repo tree (no injected listSourceFiles/readFile, so it walks src/scripts/test + every packages/*
+  // workspace via the default roots), the same real-tree guard the sibling checks close for themselves
+  // (check-coverage-bolt-on-filenames-script.test.ts, validate-no-hand-written-js.test.ts). #9240 and #9249
+  // both reached main while this guard was local-only -- enforced by neither a CI step nor a real-tree test.
+  it("the real repo has zero import-specifier violations (regression guard)", () => {
+    expect(findImportSpecifierViolations()).toEqual([]);
+  });
 });


### PR DESCRIPTION
## What

Two checks wired into `package.json`'s `test:ci` are run by **no** GitHub Actions job, so they can only
fail locally — the same "local-only-until-now" gap the many drift-check steps already in
`.github/workflows/ci.yml` were each added to close:

1. **`coco-dev-versions:check`** — reconciles `k8s/coco-dev/versions.json` with the KBS kustomization's
   recorded version. Nothing in `.github/workflows/` references `k8s`, so no job or path filter ran it.
2. **`import-specifiers:check`** (#9221) — enforces the per-zone relative-import specifier convention over
   `src`, `scripts`, `test` and every `packages/*` workspace. Not run by any job, and its test was
   entirely injection-based — `#9240` and `#9249` are two real drifts that reached main while the guard was
   local-only.

## Change

- `.github/workflows/ci.yml`: a new `cocoDev` path-filter output (matching `k8s/coco-dev/**` and
  `scripts/check-coco-dev-versions*.ts`) plus a **Coco-dev versions check** step gated on it; and an
  **Import specifiers check** step gated on `push || backend || mcp || engine || miner || discoveryIndex`
  (every filter covering one of the checker's `BUNDLER_ROOTS`/`NODENEXT_ROOTS`). Each step carries a
  comment naming the gap it closes, in the surrounding steps' style.
- `test/unit/check-import-specifiers-script.test.ts`: a **real-tree** regression test that calls
  `findImportSpecifierViolations()` with no injected `listSourceFiles`/`readFile` and asserts `[]` —
  mirroring the same real-tree guard `check-coverage-bolt-on-filenames-script.test.ts` and
  `validate-no-hand-written-js.test.ts` already have, with a comment naming #9240/#9249.

## Validation

- `npm run actionlint` and `npm run lint:composite-actions` pass on the edited workflow.
- Confirmed the real tree has **zero** import-specifier violations from real source: every entry the
  checker reports comes from a source the checker excludes on CI — `node_modules/**` (via
  `EXCLUDED_SEGMENT`) and the two fixture-bearing files in `ALLOWED_FILENAMES`
  (`check-import-specifiers-script.test.ts`, `check-dead-source-files-script.test.ts`) — so
  `findImportSpecifierViolations()` returns `[]`, and the new test passes.
- `.github/workflows/**` and `scripts/**` are outside Codecov's `coverage.include`, so no patch-coverage
  obligation applies to the workflow edit.

Closes #9649
