### PR TITLE
ci: two `test:ci` drift checks are never executed by any GitHub Actions job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
       rees: ${{ steps.filter.outputs.rees }}
       controlPlane: ${{ steps.filter.outputs.controlPlane }}
       observability: ${{ steps.filter.outputs.observability }}
+      cocoDev: ${{ steps.filter.outputs.cocoDev }}
     steps:
       # Debounce rapid re-pushes to an open PR: every job below (validate-code, validate-tests)
       # has `needs: changes` in its dependency chain, so none of
@@ -198,6 +199,9 @@ jobs:
             discoveryIndex:
               - 'packages/discovery-index/**'
               - 'package-lock.json'
+            cocoDev:
+              - 'k8s/coco-dev/**'
+              - 'scripts/check-coco-dev-versions*.ts'
             # 6 of the 7 MCP CLI-cluster test files, and ONLY these 6, are truly self-contained w.r.t. root
             # src/**: verified by direct-import inspection that test/unit/mcp-cli-*.test.ts (5 files) and
             # their shared test/unit/support/mcp-cli-harness.ts import nothing but node:* builtins + vitest,
@@ -400,6 +404,20 @@ jobs:
       - name: Dead source-file check
         if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' }}
         run: npm run dead-source-files:check
+      # Same local-only-until-now gap as the drift checks above: coco-dev-versions:check was wired into
+      # `npm run test:ci` but nothing in this workflow previously ran it, so a version bump in only one of
+      # k8s/coco-dev/versions.json and k8s/coco-dev/kbs/base/kustomization.yaml could silently ship with zero
+      # CI signal (#9213).
+      - name: Coco-dev versions drift check
+        if: ${{ github.event_name == 'push' || needs.changes.outputs.cocoDev == 'true' }}
+        run: npm run coco-dev-versions:check
+      # Same local-only-until-now gap as the drift checks above: import-specifiers:check (#9221) was wired into
+      # `npm run test:ci` but nothing in this workflow previously ran it -- #9240 and #9249 are two separate
+      # relative-import drifts that reached main while the guard was local-only. Gated on every filter covering a
+      # packages/* workspace plus backend (src/scripts/test are under backend).
+      - name: Import specifiers check
+        if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.mcp == 'true' || needs.changes.outputs.engine == 'true' || needs.changes.outputs.miner == 'true' || needs.changes.outputs.discoveryIndex == 'true' }}
+        run: npm run import-specifiers:check
       # #9499: an agent-regate-pr producer that omits prCreatedAt does not merely lose the oldest-first
       # ordering, it INVERTS it -- the legacy sort fallback places such a job ahead of every real PR. Five of
       # eight producers had drifted that way before this check existed.

--- a/test/unit/check-import-specifiers-script.test.ts
+++ b/test/unit/check-import-specifiers-script.test.ts
@@ -131,4 +131,12 @@ describe("check-import-specifiers script", () => {
     expect(multi.map((v) => v.file)).toEqual(["src/a.ts", "src/z.ts", "src/z.ts"]);
     expect(multi.map((v) => v.specifier)).toEqual(["./c.js", "./a.js", "./b.js"]);
   });
+
+  // Most important regression test in this file: the real repo must have zero import-specifier violations.
+  // #9240 and #9249 reached main while this guard was local-only; this closes the same gap the workflow
+  // step alone cannot (vitest runs unconditionally on every backend PR).
+  it("the real repo has zero import-specifier violations (regression guard)", () => {
+    const violations = findImportSpecifierViolations();
+    expect(violations).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary

`.github/workflows/ci.yml` runs each drift check as its own path-gated step — `db:migrations:check` (line 302),
`db:schema-drift:check` (308), `docs:drift-check` (357), `dead-source-files:check` (372),
`regate-sort-key:check` (378), `branding-drift:check` (410), and so on. Several of those steps carry the same
comment: *"Same local-only-until-now gap as the drift checks above: nothing in this workflow previously ran it,
so the two could silently diverge with zero CI signal."*

Two checks in `package.json`'s `test:ci` still have that gap:

1. **`coco-dev-versions:check`** → `scripts/check-coco-dev-versions.ts`. Its own header states it is *"wired
   into `npm run test:ci` so a version bump made in only one of the two files (`k8s/coco-dev/versions.json`,
   `k8s/coco-dev/kbs/base/kustomization.yaml`) fails CI instead of silently shipping a KBS deploy that doesn't
   match its own recorded version manifest."* No CI job runs it. Its only test,
   `test/unit/check-coco-dev-versions-core.test.ts`, exercises the pure core against fabricated inputs and
   never reads the two real files. `.github/workflows/` contains no reference to `k8s` at all, so no path
   filter would trigger such a job either.
2. **`import-specifiers:check`** → `scripts/check-import-specifiers.ts` (#9221). No CI job runs it, and
   `test/unit/check-import-specifiers-script.test.ts` is entirely injection-based
   (`listSourceFiles`/`readFile` fakes) with no assertion against the real tree — unlike its sibling
   `test/unit/check-coverage-bolt-on-filenames-script.test.ts:51` ("the real repo has zero coverage bolt-on
   filenames (regression guard)") and `test/unit/validate-no-hand-written-js.test.ts:80-82` ("The real gate,
   run against the real tree"), both of which close the same gap for their own checks. This is not theoretical:
   #9240 and #9249 are two separate drifts that landed after #9221 shipped the guard.

Every other entry in `test:ci` that has no explicit ci.yml step is covered another way — the contract/parity
suites and `validate:mcp` run inside the main vitest job, the `ui:*` and `build*` scripts run via `npx turbo`
steps, and `coverage-boltons:check` / `validate:no-hand-written-js` are enforced by their real-tree tests
above. These two are the only ones with no enforcement path at all.

## Deliverables

- [ ] `.github/workflows/ci.yml` `changes` job declares a `cocoDev` filter output covering `k8s/coco-dev/**`
      and `scripts/check-coco-dev-versions*.ts`.
- [ ] `.github/workflows/ci.yml` has a named step running `npm run coco-dev-versions:check`, gated on that
      filter plus the push clause.
- [ ] `.github/workflows/ci.yml` has a named step running `npm run import-specifiers:check`, gated as specified
      above.
- [ ] `test/unit/check-import-specifiers-script.test.ts` contains a real-tree regression test that calls
      `findImportSpecifierViolations()` with NO injected `listSourceFiles`/`readFile` and asserts the result is
      `[]`, with a comment naming #9240/#9249 as the drifts that reached main while the guard was local-only.
- [ ] `npm run actionlint` and `npm run lint:composite-actions` pass on the edited workflow.

All Deliverables above are required in a single PR. A PR that satisfies only some of them — for example adding
the two workflow steps but skipping the real-tree test in Deliverable 4 — does not resolve this issue.

## Test plan

`.github/workflows/**` and `scripts/**` are OUTSIDE Codecov's `coverage.include` (which covers `src/**`,
`packages/loopover-engine/src/**`, `packages/loopover-miner/{lib,bin}/**`, `packages/discovery-index/src/**`,
`packages/loopover-contract/src/**` and `packages/loopover-mcp/{lib,bin}/**`), so Codecov's patch gate does not
apply to the workflow edit or to `scripts/check-import-specifiers.ts`. Real tests are still required:
Deliverable 4 is a genuine vitest assertion against the real tree, not a placeholder. Do not add `no-op` or
`expect(true)` tests to satisfy the checkbox.

Fixes #9649