### PR TITLE
orb(content-lane): canonicalize issue-body path tokens in `checkContentLaneDeliverable

### DIFF
--- a/src/review/content-lane/registry-logic.ts
+++ b/src/review/content-lane/registry-logic.ts
@@ -929,11 +929,14 @@ export function checkContentLaneDeliverable(
   changedFiles: readonly string[],
   issueTitle?: string,
 ): ContentLaneDeliverableCheck {
-  const matchesSpec = (candidate: string): boolean => spec.entryFilePattern.test(candidate) || (spec.providerFilePattern?.test(candidate) ?? false);
+  // Mirror classifyRegistryPrScope's matchesPattern: test on canonicalize(candidate) while keeping the original
+  // string for anything user-visible (mentionedPath in the public PR comment).
+  const matchesSpec = (candidate: string): boolean =>
+    spec.entryFilePattern.test(canonicalize(candidate)) || (spec.providerFilePattern?.test(canonicalize(candidate)) ?? false);
   const mentionedPath = extractPathTokens(issueText).find(matchesSpec);
   const titleImplies = !mentionedPath && Boolean(issueTitle && spec.issueTitleImpliesEntryPattern?.test(issueTitle));
   if (!mentionedPath && !titleImplies) return { verdict: "not-applicable" };
-  const delivered = changedFiles.some((file) => matchesSpec(canonicalize(file)));
+  const delivered = changedFiles.some((file) => matchesSpec(file));
   if (delivered) return { verdict: "delivered" };
   return { verdict: "missing", mentionedPath: mentionedPath ?? `a registry entry file matching ${spec.entryFilePattern} (implied by this issue's title)` };
 }

--- a/test/unit/content-lane-registry-logic.test.ts
+++ b/test/unit/content-lane-registry-logic.test.ts
@@ -669,6 +669,29 @@ describe("checkContentLaneDeliverable (generic, spec-driven — #content-lane-de
     expect(checkContentLaneDeliverable(spec, issueText, ["registry\\subnets\\foo.json"]).verdict).toBe("delivered");
   });
 
+  it("canonicalizes mixed-case issue-body path tokens while preserving the original mentionedPath (#9667)", () => {
+    const issueText = "Add the missing surfaces to Registry/Subnets/Foo.json.";
+    expect(checkContentLaneDeliverable(spec, issueText, ["tests/foo-verify.test.mjs"])).toEqual({
+      verdict: "missing",
+      mentionedPath: "Registry/Subnets/Foo.json",
+    });
+    expect(checkContentLaneDeliverable(spec, issueText, ["registry/subnets/foo.json"])).toEqual({ verdict: "delivered" });
+  });
+
+  it("keeps all-lowercase issue-body path behavior byte-identical (#9667)", () => {
+    const issueText = "Add the missing surfaces to registry/subnets/foo.json.";
+    expect(checkContentLaneDeliverable(spec, issueText, ["tests/foo-verify.test.mjs"])).toEqual({
+      verdict: "missing",
+      mentionedPath: "registry/subnets/foo.json",
+    });
+    expect(checkContentLaneDeliverable(spec, issueText, ["registry/subnets/foo.json"])).toEqual({ verdict: "delivered" });
+  });
+
+  it("stays not-applicable when the issue body names a path that matches no spec pattern (#9667)", () => {
+    const issueText = "Update the docs at Docs/Guides/Setup.md.";
+    expect(checkContentLaneDeliverable(spec, issueText, ["tests/unrelated.test.mjs"])).toEqual({ verdict: "not-applicable" });
+  });
+
   it("is not-applicable for a spec with no providerFilePattern configured, even if the issue mentions an entry-shaped path (guards the optional-chaining branch)", () => {
     const entryOnlySpec: RegistryLaneSpec = { entryFilePattern: SUBNET_ENTRY_PATTERN, collectionField: "surfaces" };
     const issueText = "Add registry/subnets/foo.json.";


### PR DESCRIPTION
## Summary

`checkContentLaneDeliverable` (`src/review/content-lane/registry-logic.ts:919-936`) is the
deterministic "did this PR actually deliver the content file its linked issue names?" check — the guard
against a test-only PR closing a content issue via a bare `Closes #N`. It compares two things against
the same predicate:

```ts
const matchesSpec = (candidate: string): boolean =>
  spec.entryFilePattern.test(candidate) || (spec.providerFilePattern?.test(candidate) ?? false);
const mentionedPath = extractPathTokens(issueText).find(matchesSpec);              // :929  RAW token
…
const delivered = changedFiles.some((file) => matchesSpec(canonicalize(file)));    // :932  canonicalized
```

`entryFilePattern`/`providerFilePattern` are compiled by `globToRegExp`
(`packages/loopover-engine/src/signals/change-guardrail.ts:82-103`), which canonicalizes the glob
first (`canonicalize` lowercases, `packages/loopover-engine/src/signals/change-guardrail.ts:11-13`) and
emits `new RegExp("^…$")` with **no `i` flag**. So the compiled pattern only ever matches lowercase
input.

Result: an issue body that writes the path with any capitalization — `Registry/subnets/foo.json`,
`registry/Subnets/Foo.json` — produces no `mentionedPath`. With no `issueTitleImpliesEntryPattern`
configured (or a title that doesn't match it), `checkContentLaneDeliverable` returns
`{ verdict: "not-applicable" }`, and the deliverable gate silently does not run for that issue —
the exact "test-only PR closes a content issue without ever delivering the content" gap the function's
own header (`src/review/content-lane/registry-logic.ts:875-882`) says it exists to close.

`classifyRegistryPrScope` in the same file already documents why this matters
(`src/review/content-lane/registry-logic.ts:778-781`): "globToRegExp compiles the spec patterns against
a CANONICALIZED path … so match on canonicalize(f), or an uppercase / `./`-prefixed / backslash-separated
changed path silently fails to classify as a registry submission." The issue-body side never got that
treatment.

## Deliverables

- [ ] `checkContentLaneDeliverable` in `src/review/content-lane/registry-logic.ts` returns
      `{ verdict: "missing", mentionedPath: "Registry/Subnets/Foo.json" }` for an issue body naming
      `Registry/Subnets/Foo.json` against a PR that changed no matching file — asserted by a new named
      case in `test/unit/content-lane-registry-logic.test.ts`.
- [ ] The same test asserts the `"delivered"` verdict for that mixed-case issue body when the PR DOES
      change `registry/subnets/foo.json`.
- [ ] A test asserts the existing all-lowercase path behaviour (both `delivered` and `missing`) is
      unchanged.
- [ ] A test asserts an issue body naming a path that matches NO spec pattern still returns
      `not-applicable` (the change does not over-broaden the match).

All Deliverables above are required in a single PR. A PR that satisfies only some of them — for
example canonicalizing the token (Deliverable 1) but also lowercasing the reported `mentionedPath`,
breaking the public-comment text — does not resolve this issue.

## Test plan

This repo enforces 99%+ Codecov patch coverage, branch-counted, and `vitest.config.ts`'s
`coverage.include` covers `src/**/*.ts` — this file is measured. Both arms of the
`find(matchesSpec)` outcome (a token that matches, and one that does not) need a test, as do both arms
of the `mentionedPath ?? …` fallback in the `missing` return.

Fixes #9667