### PR TITLE
chore(release): move the ORB target to 3.7.0 so the beta channel resumes

### DIFF
--- a/orb-manifest.json
+++ b/orb-manifest.json
@@ -1,4 +1,4 @@
 {
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "Source of truth for the self-hostable loopover-orb container image's target release version (ghcr.io/jsonbored/loopover-selfhost). Bumped by a maintainer when a feat/fix/breaking change since the last stable orb-v tag warrants moving to a new target version -- scripts/orb-release-core.ts and .github/workflows/orb-beta-release.yml read this file to decide what version the next automated beta snapshot targets. Promoting a beta to a stable orb-vX.Y.Z release is still a manual `git tag` -- this manifest only drives the automated beta channel."
 }


### PR DESCRIPTION
orb-v3.6.0 was promoted to stable, which by design halts the beta channel — `due = commitsSinceLastTag.length > 0 && !targetAlreadyStable`, and the manifest still targets the version that just went stable.

The due-check has been reporting:

```
"due": false, "manifestStale": true,
"latestStableTag": "orb-v3.6.0", "latestTag": "orb-v3.6.0",
"nextTag": "orb-v3.6.0-beta.1"
```

`orb-v3.6.0-beta.1` would sort *behind* the stable release it follows, so nothing can ship until the target moves forward. That move is deliberately a human step (see `orb-release-core.ts`: "Nothing is due until a human moves the manifest target forward").

44 image-relevant commits have landed since `orb-v3.6.0`, including a feat (`gate: guardrailEscalation.onCleanReview`), so semver puts the next target at a minor bump.

Verified locally after the change:

```
ORB beta due: orb-v3.7.0-beta.1
```

Same one-line move as #9777 made for 3.6.0.