### PR TITLE
fix(ci): unbreak main — two checkers in test:ci are failing on a clean tree

### DIFF
--- a/scripts/replay-runner-image-manifest.json
+++ b/scripts/replay-runner-image-manifest.json
@@ -2,12 +2,12 @@
   "schemaVersion": 1,
   "baseImageRef": "node:22-slim@sha256:6c74791e557ce11fc957704f6d4fe134a7bc8d6f5ca4403205b2966bd488f6b3",
   "dockerfileSha256": "18b434af0c6359105293a9bd6bdd890f4b5662ce72308df4bcfc3bb30ae7c1ee",
-  "packageLockSha256": "35c61915f0b21d5980f5f5aa1bff532da3d9d51c71257c8b28904f7b798e0d71",
+  "packageLockSha256": "70a2e5ae0e477c97e3bc6fb7c631af2d3a2cec4e56e0ff0bb27c11245b33d96f",
   "sourceFiles": {
     "scripts/attested-backtest-run-core.ts": "e5f5659dc9204f9406c9874317d71cb02fd7f4c993c9f5caa92545595f522167",
     "scripts/attested-backtest-run.ts": "49e0e046e3c4882c0e4afd422a464957b6c4789bad28f5b6682afa9d534424f7",
     "scripts/backtest-corpus-export-core.ts": "060d48a2a6073a7d859efc64c87c18ae1d3d25e06391ce94d6ed40874050b2e8",
     "scripts/snp-attester.ts": "b917e8541908150bd0c885fbe57e178247e5cd5f78f80eda7dc9e8b77da6deb3"
   },
-  "digest": "5b8665f586317a0f3d77c5ac76891b4cf2ba8f1784977d268b093ce6644b2210"
+  "digest": "c58858edac2bc9646edf4a82557dc815c796b4485002c1b37de95004f1db1235"
 }

--- a/src/review/automation-rate.ts
+++ b/src/review/automation-rate.ts
@@ -41,12 +41,14 @@ import { safeAll } from "./public-stats";
 export const AUTOMATION_RATE_PROVENANCE_HORIZON_ISO = "2026-07-29T00:00:00.000Z";
 
 /** The action classes that ENACT a decision. A PR reaching one of these, with no human signal, is what
- *  "automated" means. Exported so the read below filters on exactly the set the fold classifies on -- one
- *  definition, rather than a WHERE clause and a predicate that can drift apart. */
-export const AUTOMATION_ENACTING_ACTIONS = ["merge", "close"] as const;
+ *  "automated" means. Module-private: AUTOMATION_COUNTED_ACTIONS below is the exported surface, and it is
+ *  what both the fold and the read consume -- one definition, rather than a WHERE clause and a predicate
+ *  that can drift apart. */
+const AUTOMATION_ENACTING_ACTIONS = ["merge", "close"] as const;
 
-/** The action recording that the gate declined to decide and handed the PR to a person. */
-export const AUTOMATION_HOLD_ACTION = "hold";
+/** The action recording that the gate declined to decide and handed the PR to a person. Module-private for
+ *  the same reason as the set above. */
+const AUTOMATION_HOLD_ACTION = "hold";
 
 /** Every action that puts a PR in the series at all -- an enacted decision, or a hold. */
 export const AUTOMATION_COUNTED_ACTIONS: readonly string[] = [...AUTOMATION_ENACTING_ACTIONS, AUTOMATION_HOLD_ACTION];


### PR DESCRIPTION
`main` is red on **two** checkers that both run in `test:ci`. Verified by running them against a clean checkout of `origin/main`, not just against my branch.

## 1. `dead-exports:check`

My merged #9938 exported `AUTOMATION_ENACTING_ACTIONS` and `AUTOMATION_HOLD_ACTION`. `AUTOMATION_COUNTED_ACTIONS` is the surface both the fold and the SQL read consume, so those two are referenced only inside their own module — exactly what that checker exists to catch.

Made module-private. The exported vocabulary and every behaviour are unchanged; `test/unit/automation-rate.test.ts` passes unmodified (24/24).

My fault: I ran the checkers that seemed related to the change rather than the ones that actually gate it.

## 2. `replay-runner-manifest:check`

Pre-existing and unrelated to me. A merge changed `package-lock.json` without re-running `replay-runner-manifest:write`, so the committed `packageLockSha256` stopped matching the committed lockfile:

```
committed 35c61915f0b21d59…  fresh 70a2e5ae0e477c97…
```

Regenerated. Only the lockfile hash and the rolled-up digest move — no source-file hash, base image, or Dockerfile hash changes.

## Note

Both were found by a full sweep of every `check-*` script rather than a selected subset, which is the process I'm now using before pushing. That sweep is also what motivated #9945.