### PR TITLE
fix(ci): build @loopover/contract before packing the MCP and miner packages

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -130,6 +130,15 @@ jobs:
       # specifically (imports packages/loopover-mcp and spawns the built binary), NOT the sibling
       # test/unit/mcp-*.test.ts files that exercise the Worker's separate remote MCP server
       # (src/mcp/server.ts, a different deployable entirely).
+      # packages/loopover-mcp imports @loopover/contract (api-schemas / tools / cli-config / client-config).
+      # That package's dist/ is gitignored exactly like the engine's above, so without building it here every
+      # one of those imports fails to resolve -- "Cannot find module '@loopover/contract/...'" -- and the
+      # build below exits 2. This publish has been red on EVERY main commit for as long as the run history
+      # goes back, retrying three times per push and never once succeeding, so the package has not actually
+      # been publishing. Same reason and same placement as the engine build directly above.
+      - name: Build loopover-contract
+        run: npm run build --workspace @loopover/contract
+
       - name: MCP package syntax validation
         run: npm run build:mcp
 

--- a/.github/workflows/publish-miner.yml
+++ b/.github/workflows/publish-miner.yml
@@ -125,6 +125,15 @@ jobs:
       # is gitignored, so this is the only place it ever exists), same as ci.yml's own "Build miner CLI"
       # step, followed by node --check syntax validation over every bin/lib file (the same two-part
       # script test:ci already runs on every PR).
+      # packages/loopover-miner imports @loopover/contract (api-schemas / tools / cli-config / client-config).
+      # That package's dist/ is gitignored exactly like the engine's above, so without building it here every
+      # one of those imports fails to resolve -- "Cannot find module '@loopover/contract/...'" -- and the
+      # build below exits 2. This publish has been red on EVERY main commit for as long as the run history
+      # goes back, retrying three times per push and never once succeeding, so the package has not actually
+      # been publishing. Same reason and same placement as the engine build directly above.
+      - name: Build loopover-contract
+        run: npm run build --workspace @loopover/contract
+
       - name: Miner build + syntax validation
         run: npm run build --workspace @loopover/miner
 


### PR DESCRIPTION
Closes #9946

Both publish workflows fail on **every** main commit, and have for as long as the run history goes back — three retries per push, never one success. **Neither package has actually been publishing.**

## Root cause

`packages/loopover-contract/dist` is gitignored. Both workflows already build `@loopover/engine` for exactly that reason, with a comment explaining it — but neither builds the contract, and both packages import it:

```
bin/loopover-mcp.ts(16,8):       TS2307: Cannot find module "@loopover/contract/api-schemas"
bin/loopover-miner-mcp.ts(5,44): TS2307: Cannot find module "@loopover/contract"
lib/github-token-resolution.ts(22,8): TS2307: Cannot find module "@loopover/contract/cli-config"
```

## Verified, not assumed

Deleted the contract `dist/` and ran each workflow’s own build command: **9** unresolved imports for MCP, **7** for the miner. Added `npm run build --workspace @loopover/contract` and both pass. `actionlint` clean.

Scope is exactly these two — `publish-contract` already builds itself, and `publish-engine` / `publish-mcp-registry` / `publish-ui-kit` don’t depend on the contract.

## Why it stayed invisible

The failure lives in a publish workflow, not `validate-*`, so PR CI stays green and the gate is unaffected. Main’s rollup showed red, but it read as release noise rather than "this package has not shipped since it started importing the contract".

Worth a separate look: three failed attempts per commit, indefinitely, is a pipeline telling nobody. A publish failing identically on consecutive commits should surface once, loudly, rather than re-failing quietly forever.