### PR TITLE
fix(ci): allow dist/ in the MCP pack allowlist, which is the only thing it ships

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -153,7 +153,11 @@ jobs:
           PACK_JSON="$(npm pack --workspace @loopover/mcp --pack-destination "$RUNNER_TEMP" --json)"
           TARBALL="$(node -e 'const fs=require("fs"); const input=fs.readFileSync(0,"utf8"); process.stdout.write(JSON.parse(input)[0].filename)' <<< "$PACK_JSON")"
           TARBALL_PATH="$RUNNER_TEMP/$TARBALL"
-          UNEXPECTED_FILES="$(tar -tzf "$TARBALL_PATH" | grep -Ev '^(package/(bin|lib|scripts)/.+|package/(package.json|README.md|CHANGELOG.md|LICENSE))$' || true)"
+          # Allowlist mirrors packages/loopover-mcp/package.json's own `files`: the package ships COMPILED
+          # output under dist/ (its `bin` entries are dist/bin/*.js), plus the runtime scripts/ it declares.
+          # `bin|lib` here described a pre-dist source layout the package has not had for some time -- the
+          # mismatch stayed invisible only because the build step above failed first, so packing never ran.
+          UNEXPECTED_FILES="$(tar -tzf "$TARBALL_PATH" | grep -Ev '^(package/(dist|scripts)/.+|package/(package.json|README.md|CHANGELOG.md|LICENSE))$' || true)"
           if [ -n "$UNEXPECTED_FILES" ]; then
             printf '%s\n' "$UNEXPECTED_FILES"
             echo "Unexpected file in package tarball"


### PR DESCRIPTION
Follow-on to #9946/#9947. That fix unblocked the MCP publish **build**; packing then failed on the very next step with `Unexpected file in package tarball`.

## The stale rule

The smoke test allows `package/(bin|lib|scripts)/…`, which describes a source layout this package has not had for some time. Its manifest says:

```json
"files": ["dist", "scripts", "CHANGELOG.md", "!scripts/check-syntax.ts", "!scripts/strip-bin-sourcemap.ts"],
"bin": { "loopover-mcp": "dist/bin/loopover-mcp.js", "loopover-verify": "dist/bin/loopover-verify.js" }
```

`dist/` is not stray build output — it **is** the package.

## Verified against a real tarball

Ran `npm pack --workspace @loopover/mcp` and inspected it: contents are `dist/`, `scripts/`, `package.json`, `README.md`, `CHANGELOG.md`, `LICENSE`, and the old pattern rejected exactly the **9 `dist/` entries**. With the corrected pattern, all three smoke-test stages pass locally:

- allowlist — clean
- secret scan — clean
- `npm install <tarball>` then `loopover-mcp --help` — passes

`actionlint` clean.

## Why it hid

The build step failed first, so packing never ran. Fixing one exposed the next — this is the second half of the same publish that has never succeeded. The Miner publish, which had only the first problem, is already green on `main`.