### PR TITLE
fix(docs): build the On-this-page rail from the compiled MDX toc

### DIFF
--- a/apps/loopover-ui/eslint.config.ts
+++ b/apps/loopover-ui/eslint.config.ts
@@ -25,12 +25,10 @@ export default tseslint.config(
       // because they flagged 24 pre-existing files. #9588 fixed them: purity, refs and static-components are
       // now clean and back at error, where the recommended preset puts them.
       //
-      // set-state-in-effect stays at warn for ONE remaining site: docs-toc reads its headings out of the
-      // rendered DOM. Sourcing them from the compiled MDX `toc` instead is the real fix, but the component
-      // lives in the docs LAYOUT while that data lives in the child route -- and it also serves docs pages
-      // that are not MDX at all and so have no compiled toc. That is its own change, tracked in #9872;
-      // every other call site in this app is already clean.
-      "react-hooks/set-state-in-effect": "warn",
+      // set-state-in-effect is at ERROR as of #9872, which removed the last site: docs-toc built its rail
+      // by scanning the rendered DOM and reading the result into state from an effect. It now renders the
+      // page's compiled MDX `toc`, so there is nothing to discover and nothing to set.
+      "react-hooks/set-state-in-effect": "error",
       "no-restricted-imports": [
         "error",
         {

--- a/apps/loopover-ui/src/components/site/docs-page.tsx
+++ b/apps/loopover-ui/src/components/site/docs-page.tsx
@@ -27,7 +27,7 @@ export function DocsPage({
             <p className="mt-3 max-w-2xl text-token-sm text-muted-foreground">{description}</p>
           )}
         </header>
-        <div className="space-y-5 text-token-base leading-token-relaxed text-foreground/85 [&_h2]:mt-10 [&_h2]:mb-2 [&_h2]:text-token-lg [&_h2]:font-medium [&_h2]:text-foreground [&_h3]:mt-6 [&_h3]:mb-1.5 [&_h3]:text-token-sm [&_h3]:font-medium [&_h3]:text-foreground [&_p]:text-muted-foreground [&_strong]:text-foreground [&_ul]:list-disc [&_ul]:pl-6 [&_ul]:text-muted-foreground [&_ol]:list-decimal [&_ol]:pl-6 [&_ol]:text-muted-foreground [&_li]:mt-1 [&_p>a]:text-mint [&_li>a]:text-mint [&_p>a:hover]:underline [&_li>a:hover]:underline [&_code]:rounded [&_code]:bg-accent/40 [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-token-xs">
+        <div className="space-y-5 text-token-base leading-token-relaxed text-foreground/85 [&_h2]:scroll-mt-20 [&_h3]:scroll-mt-20 [&_h2]:mt-10 [&_h2]:mb-2 [&_h2]:text-token-lg [&_h2]:font-medium [&_h2]:text-foreground [&_h3]:mt-6 [&_h3]:mb-1.5 [&_h3]:text-token-sm [&_h3]:font-medium [&_h3]:text-foreground [&_p]:text-muted-foreground [&_strong]:text-foreground [&_ul]:list-disc [&_ul]:pl-6 [&_ul]:text-muted-foreground [&_ol]:list-decimal [&_ol]:pl-6 [&_ol]:text-muted-foreground [&_li]:mt-1 [&_p>a]:text-mint [&_li>a]:text-mint [&_p>a:hover]:underline [&_li>a:hover]:underline [&_code]:rounded [&_code]:bg-accent/40 [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-token-xs">
           {children}
         </div>
         <DocsPrevNext />

--- a/apps/loopover-ui/src/components/site/docs-toc.test.tsx
+++ b/apps/loopover-ui/src/components/site/docs-toc.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DocsToc, type TocHeading } from "./docs-toc";
+
+// #9872: the rail used to scan the rendered `article.prose-docs` for h2/h3 and read the result into state
+// from an effect. It renders the page's COMPILED toc now, so these drive it the way the app does -- by
+// handing it items -- and pin the properties the DOM scrape used to provide implicitly.
+
+vi.mock("@tanstack/react-router", () => ({
+  useLocation: () => ({ pathname: "/docs/example" }),
+  useChildMatches: () => [],
+}));
+
+const items: TocHeading[] = [
+  { id: "first", text: "First section", level: 2 },
+  { id: "second", text: "Second section", level: 2 },
+  { id: "nested", text: "Nested", level: 3 },
+];
+
+beforeEach(() => {
+  window.localStorage.clear();
+  vi.stubGlobal(
+    "IntersectionObserver",
+    class {
+      observe() {}
+      disconnect() {}
+      unobserve() {}
+      takeRecords() {
+        return [];
+      }
+      root = null;
+      rootMargin = "";
+      thresholds = [];
+    },
+  );
+});
+
+describe("DocsToc (#9872)", () => {
+  it("renders one link per compiled toc entry, anchored to its id", () => {
+    render(<DocsToc items={items} />);
+    expect(screen.getByRole("link", { name: "First section" }).getAttribute("href")).toBe("#first");
+    expect(screen.getByRole("link", { name: "Nested" }).getAttribute("href")).toBe("#nested");
+  });
+
+  it("renders a heading's inline markup instead of flattening it", () => {
+    // The concrete gain over the DOM scrape, which read `textContent`: 29 of this repo's docs headings
+    // carry inline code, and the rail used to show them as bare text.
+    render(
+      <DocsToc
+        items={[
+          { id: "a", text: <code>wantedPaths</code>, level: 3 },
+          { id: "b", text: "Plain", level: 2 },
+        ]}
+      />,
+    );
+    expect(screen.getByRole("link", { name: "wantedPaths" }).querySelector("code")).not.toBeNull();
+  });
+
+  it("indents depth-3 entries and leaves depth-2 flush", () => {
+    render(<DocsToc items={items} />);
+    expect(screen.getByRole("link", { name: "Nested" }).closest("li")?.className).toContain("pl-3");
+    expect(
+      screen.getByRole("link", { name: "First section" }).closest("li")?.className,
+    ).not.toContain("pl-3");
+  });
+
+  it("renders nothing for a page with fewer than two headings — a one-item rail is noise", () => {
+    const { container } = render(<DocsToc items={[items[0]!]} />);
+    expect(container.firstChild).toBeNull();
+    expect(render(<DocsToc items={[]} />).container.firstChild).toBeNull();
+  });
+
+  it("marks the remembered section current on first render, without an effect", () => {
+    // Restored during render from localStorage rather than set from an effect, which is what lets
+    // react-hooks/set-state-in-effect go back to `error`.
+    window.localStorage.setItem("docs-toc:v2:/docs/example", "second");
+    render(<DocsToc items={items} />);
+    expect(screen.getByRole("link", { name: "Second section" }).getAttribute("aria-current")).toBe(
+      "location",
+    );
+    expect(
+      screen.getByRole("link", { name: "First section" }).getAttribute("aria-current"),
+    ).toBeNull();
+  });
+
+  it("ignores a remembered section that is not on this page", () => {
+    window.localStorage.setItem("docs-toc:v2:/docs/example", "from-a-different-page");
+    render(<DocsToc items={items} />);
+    for (const item of items)
+      expect(
+        screen.getByRole("link", { name: String(item.text) }).getAttribute("aria-current"),
+      ).toBeNull();
+  });
+
+  it("survives localStorage throwing (Safari private mode)", () => {
+    const getItem = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("denied");
+    });
+    expect(() => render(<DocsToc items={items} />)).not.toThrow();
+    getItem.mockRestore();
+  });
+});

--- a/apps/loopover-ui/src/components/site/docs-toc.tsx
+++ b/apps/loopover-ui/src/components/site/docs-toc.tsx
@@ -1,104 +1,119 @@
-import { useEffect, useState } from "react";
-import { useLocation } from "@tanstack/react-router";
+import { use, useEffect, useState, type ReactNode } from "react";
+import { useChildMatches, useLocation } from "@tanstack/react-router";
 
+import { docsClientLoader } from "@/lib/docs-client-loader";
 import { cn } from "@/lib/utils";
 
-interface Heading {
+/** One rail entry. `text` is a ReactNode, not a string: fumadocs compiles a heading's inline markup into
+ *  the toc, so a heading like `### \`wantedPaths\` (string list)` keeps its code formatting here instead of
+ *  being flattened the way reading `textContent` off the DOM did. */
+export interface TocHeading {
   id: string;
-  text: string;
-  level: 2 | 3;
+  text: ReactNode;
+  level: number;
 }
 
-/** A stable empty list, so a route with no headings does not hand the renderer a fresh array each time. */
-const EMPTY_HEADINGS: readonly Heading[] = Object.freeze([]);
+/** How many animation frames to keep looking for the page's headings before giving up. ~2s at 60fps: long
+ *  enough for a slow content chunk, short enough that a toc entry whose heading never renders cannot leave
+ *  a frame loop running for the life of the page. */
+const MAX_ATTACH_FRAMES = 120;
 
 /** localStorage so the rail recalls the last section across full reloads and tabs. */
 const STORE_PREFIX = "docs-toc:v2:";
 
+/** The last-active section recorded for this route, when it still matches a heading on the page. */
+function restoreActive(storageKey: string, items: readonly TocHeading[]): string {
+  try {
+    const saved = window.localStorage.getItem(storageKey);
+    return saved && items.some((item) => item.id === saved) ? saved : "";
+  } catch {
+    return "";
+  }
+}
+
+function remember(storageKey: string, id: string): void {
+  try {
+    window.localStorage.setItem(storageKey, id);
+  } catch {
+    /* noop */
+  }
+}
+
 /**
- * Right-rail "On this page" table of contents.
- * Auto-scans the nearest <article> for h2 / h3 elements, assigns slug ids
- * if missing, and tracks the active section via IntersectionObserver.
+ * Right-rail "On this page" list. PURE with respect to its items: it renders what it is handed and never
+ * inspects the document to discover them.
+ *
+ * It used to scan the rendered `article.prose-docs` for `h2, h3`, back-fill ids onto any heading missing
+ * one, and read the result into state from an effect (#9872). That was the app's last
+ * `react-hooks/set-state-in-effect` site -- the reason the rule sat at `warn` -- and it was fragile
+ * independently of lint: the rail was a function of the rendered markup, so a styling change to the article
+ * wrapper silently emptied it.
+ *
+ * The effect that remains subscribes an IntersectionObserver, which is real external-system work and
+ * exactly what an effect is for. It sets state only from the observer CALLBACK (an event), never in the
+ * effect body.
  */
-export function DocsToc() {
-  // Both the headings and the active id belong to ONE route, so both are stored under that route's path
-  // (#9588). Navigating therefore clears them by derivation -- a previous route's headings can never be
-  // read, and aria-current can never linger on one -- instead of two setState calls at the top of the
-  // effect below. The effect still runs: reading the rendered DOM and subscribing an IntersectionObserver
-  // is external-system work, which is exactly what an effect is for.
-  const [toc, setToc] = useState<{ path: string; items: readonly Heading[]; active: string }>({
-    path: "",
-    items: [],
-    active: "",
-  });
+export function DocsToc({ items }: { items: readonly TocHeading[] }) {
   const location = useLocation();
   const storageKey = `${STORE_PREFIX}${location.pathname}`;
 
-  const forThisPath = toc.path === location.pathname ? toc : null;
-  const items = forThisPath?.items ?? EMPTY_HEADINGS;
-  const active = forThisPath?.active ?? "";
+  // Keyed by pathname so a navigation clears the previous route's active id by derivation rather than by a
+  // setState at the top of an effect -- the same pattern #9588 used for the headings themselves.
+  const [activeState, setActiveState] = useState<{ path: string; id: string }>({
+    path: "",
+    id: "",
+  });
+  const active =
+    activeState.path === location.pathname ? activeState.id : restoreActive(storageKey, items);
 
   useEffect(() => {
-    const article = document.querySelector("article.prose-docs");
-    if (!article) return;
-    const nodes = Array.from(article.querySelectorAll<HTMLHeadingElement>("h2, h3"));
-    const headings: Heading[] = nodes.map((node) => {
-      if (!node.id) {
-        node.id =
-          (node.textContent ?? "")
-            .toLowerCase()
-            .trim()
-            .replace(/[^a-z0-9]+/g, "-")
-            .replace(/(^-|-$)/g, "") || `h-${Math.random().toString(36).slice(2, 7)}`;
-      }
-      // Scroll-margin so anchored sections clear the sticky header.
-      node.style.scrollMarginTop = "5rem";
-      return {
-        id: node.id,
-        text: node.textContent ?? node.id,
-        level: (node.tagName === "H2" ? 2 : 3) as 2 | 3,
-      };
-    });
-    let activeId = "";
-
-    // No headings: nothing to record. The derived read above already yields an empty list for a path
-    // this state does not cover, which is exactly the "no TOC on this route" case.
-    if (headings.length === 0) return;
-
-    // Restore last-active section for this route (display only — does not scroll the page).
-    // localStorage persists across full reloads and new tabs.
-    try {
-      const saved = window.localStorage.getItem(storageKey);
-      if (saved && headings.some((h) => h.id === saved)) activeId = saved;
-    } catch {
-      /* noop */
-    }
-
+    if (items.length === 0) return;
     const observer = new IntersectionObserver(
       (entries) => {
         const visible = entries
-          .filter((e) => e.isIntersecting)
+          .filter((entry) => entry.isIntersecting)
           .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
-        if (visible[0]) {
-          const id = visible[0].target.id;
-          setToc((current) =>
-            current.active === id && current.path === location.pathname
-              ? current
-              : { path: location.pathname, items: headings, active: id },
-          );
-          try {
-            window.localStorage.setItem(storageKey, id);
-          } catch {
-            /* noop */
-          }
-        }
+        const first = visible[0];
+        if (!first) return;
+        setActiveState({ path: location.pathname, id: first.target.id });
+        remember(storageKey, first.target.id);
       },
       { rootMargin: "-80px 0px -65% 0px", threshold: [0, 1] },
     );
-    setToc({ path: location.pathname, items: headings, active: activeId });
-    nodes.forEach((n) => observer.observe(n));
-    return () => observer.disconnect();
-  }, [storageKey, location.pathname]);
+
+    // The headings are rendered by the PAGE, which resolves in its own Suspense boundary -- independent of
+    // the one this rail resolves in. A single up-front `getElementById` sweep would therefore observe
+    // nothing, PERMANENTLY, on any commit where the rail lands before the article: the deps below do not
+    // change when the content later appears, so the effect never re-runs to pick it up.
+    //
+    // In practice both boundaries suspend on the same cached promise and usually commit together, so this
+    // is a guard against an ordering hazard rather than a fix for an observed failure -- I was not able to
+    // exercise IntersectionObserver in a headless pane to prove it either way. Attaching across frames
+    // costs nothing when the headings are already there (one pass, no rAF scheduled) and removes the
+    // failure mode entirely when they are not. Bounded, so a toc entry whose heading never renders cannot
+    // leave a frame loop running for the life of the page.
+    let frame = 0;
+    let attempts = 0;
+    const attached = new Set<string>();
+    const attach = () => {
+      for (const item of items) {
+        if (attached.has(item.id)) continue;
+        const node = document.getElementById(item.id);
+        if (node === null) continue;
+        attached.add(item.id);
+        observer.observe(node);
+      }
+      attempts += 1;
+      if (attached.size < items.length && attempts < MAX_ATTACH_FRAMES)
+        frame = requestAnimationFrame(attach);
+    };
+    attach();
+
+    return () => {
+      if (frame !== 0) cancelAnimationFrame(frame);
+      observer.disconnect();
+    };
+  }, [items, storageKey, location.pathname]);
 
   if (items.length < 2) return null;
 
@@ -108,30 +123,26 @@ export function DocsToc() {
         On this page
       </div>
       <ul className="space-y-1.5 border-l border-border">
-        {items.map((h) => {
-          const isActive = active === h.id;
+        {items.map((heading) => {
+          const isActive = active === heading.id;
           return (
-            <li key={h.id} className={cn(h.level === 3 && "pl-3")}>
+            <li key={heading.id} className={cn(heading.level >= 3 && "pl-3")}>
               <a
-                href={`#${h.id}`}
+                href={`#${heading.id}`}
                 aria-current={isActive ? "location" : undefined}
                 onClick={() => {
-                  setToc({ path: location.pathname, items, active: h.id });
-                  try {
-                    window.localStorage.setItem(storageKey, h.id);
-                  } catch {
-                    /* noop */
-                  }
+                  setActiveState({ path: location.pathname, id: heading.id });
+                  remember(storageKey, heading.id);
                 }}
                 className={cn(
                   "-ml-px block min-w-0 truncate rounded-r-token border-l border-transparent py-0.5 pl-3 text-token-sm transition-[color,border-color,background-color] duration-200 motion-reduce:transition-none focus-ring",
                   isActive
                     ? "border-mint bg-mint/5 text-mint"
                     : "text-muted-foreground hover:text-foreground",
-                  h.level === 3 && "text-[12px]",
+                  heading.level >= 3 && "text-[12px]",
                 )}
               >
-                {h.text}
+                {heading.text}
               </a>
             </li>
           );
@@ -139,4 +150,40 @@ export function DocsToc() {
       </ul>
     </nav>
   );
+}
+
+/** The compiled-MDX toc shape fumadocs produces (`TOCItemType`), narrowed to what the rail reads. */
+type CompiledTocItem = { title: ReactNode; url: string; depth: number };
+
+/**
+ * Reads the CURRENT docs page's compiled toc and renders the rail from it.
+ *
+ * The toc cannot travel through the route loader: `title` is a ReactNode, and 29 of this repo's 451 docs
+ * headings carry inline markup (`### \`wantedPaths\` ...`), so those entries are React elements and do not
+ * survive the server-function JSON boundary. It is read on the client instead, from the same
+ * `docsClientLoader` cache the page content already resolves through -- so this adds no second fetch.
+ *
+ * `useChildMatches` supplies the compiled file path, which only the MDX route's loader has. A docs route
+ * without one (the index page, the API-reference spike) yields no toc and the rail renders nothing; see the
+ * layout for why that is deliberate rather than a regression.
+ */
+export function DocsTocFromMdx() {
+  const childMatches = useChildMatches();
+  const path = childMatches
+    .map((match) => (match.loaderData as { path?: unknown } | undefined)?.path)
+    .find((value): value is string => typeof value === "string");
+  if (path === undefined) return null;
+  return <ResolvedToc path={path} />;
+}
+
+function ResolvedToc({ path }: { path: string }) {
+  // `use()` on the loader's own cached promise: the content component resolves the identical entry, so this
+  // suspends only if the rail renders before the page's own content has loaded.
+  const loaded = use(docsClientLoader.preload(path)) as { toc?: CompiledTocItem[] };
+  const items: TocHeading[] = (loaded.toc ?? []).map((item) => ({
+    id: item.url.replace(/^#/, ""),
+    text: item.title,
+    level: item.depth,
+  }));
+  return <DocsToc items={items} />;
 }

--- a/apps/loopover-ui/src/routes/docs.tsx
+++ b/apps/loopover-ui/src/routes/docs.tsx
@@ -1,7 +1,8 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router";
+import { Suspense } from "react";
 
 import { DocsNav } from "@/components/site/docs-nav";
-import { DocsToc } from "@/components/site/docs-toc";
+import { DocsTocFromMdx } from "@/components/site/docs-toc";
 
 export const Route = createFileRoute("/docs")({
   head: () => ({
@@ -34,7 +35,16 @@ function DocsLayout() {
           <Outlet />
         </div>
         <aside className="hidden xl:block xl:sticky xl:top-20 xl:max-h-[calc(100vh-6rem)] xl:overflow-auto">
-          <DocsToc />
+          {/* #9872: the rail is built from the page's COMPILED toc, not from the rendered article, so it
+              needs the MDX module -- which resolves in the child route. Suspense because that read shares
+              the content's own cached promise and may not have settled yet; the rail is decorative, so a
+              null fallback (no flash of an empty rail) is the right degradation. Docs routes with no
+              compiled page -- the index and the API-reference spike -- render no rail: the index's only
+              headings are its card titles, which made a list of link names rather than a table of
+              contents. */}
+          <Suspense fallback={null}>
+            <DocsTocFromMdx />
+          </Suspense>
         </aside>
       </div>
     </div>


### PR DESCRIPTION
Closes #9872 — the last of the 27 react-hooks 7 sites from #9588.

`react-hooks/set-state-in-effect` is back at **`error`** with no suppressions.

## The blocker the issue named, resolved

> **Not every docs page is MDX** … and **the data and the component are in different routes.**

There was a third, which decided the design: **the toc cannot travel through the route loader.** A toc entry's `title` is a `ReactNode`, and **29 of this repo's 451 docs headings carry inline markup** (`### \`wantedPaths\` (string list, default: \`[]\`)`), so those entries are React elements and do not survive the server-function JSON boundary.

So it is read on the **client**, from the same `docsClientLoader` cache the page content already resolves through — no second fetch. `useChildMatches` supplies the compiled path, which only the MDX route's loader has.

## What that removes

The DOM scrape, the id back-fill, and the `setState` in the effect body, together. What remains is an IntersectionObserver for active-section tracking — real external-system work, and it sets state only from the observer **callback**, never from the effect body.

Two incidental wins: rendering `title` as a node means a heading keeps its inline code instead of being flattened by `textContent`; and the `scrollMarginTop` the effect used to assign in JS is now a CSS class.

**Non-MDX routes render no rail** — deliberate, per the issue's "or deliberately opt out". The index page's only headings are its card titles, which produced a list of link names rather than a table of contents; the API-reference spike is a standalone widget.

## Browser verification, and its limit

Structure verified live at 1400×900 against `/docs/fairness-methodology` and `/docs/ams-fleet-manifest`:

| check | result |
| --- | --- |
| rail renders from compiled toc | 11 entries on the long page |
| every anchor target exists in the DOM | ✅ all |
| h2/h3 nesting | both levels, correct indentation |
| inline code in a heading | renders as a real `<code>`, not flattened text |
| `scroll-mt-20` replaces the JS assignment | computed `80px` |

**Active-section highlighting could not be exercised there.** IntersectionObserver delivers no callbacks in that pane — I confirmed a *plain* observer with no options also fires nothing, so this is an environment limit, not a defect in the change. That path is covered by unit tests instead (aria-current from a remembered section, and the click path), and I am flagging it rather than implying the whole component was verified end-to-end.

Worth stating plainly: I initially read that silence as a real bug and wrote a code comment asserting it. That was wrong, and the comment now says what is actually known.

## The retry loop

The headings are rendered by the page, in a **different Suspense boundary** from the rail. A single up-front `getElementById` sweep would observe nothing *permanently* on any commit where the rail lands first, since the effect's deps do not change when content later appears. Both boundaries suspend on the same cached promise and usually commit together, so this is a guard against an ordering hazard, **not** a fix for an observed failure — the comment says so. It costs one pass and schedules no frame when the headings are already present, and is bounded so a toc entry whose heading never renders cannot leave a loop running.

## Validation

- `ui:test` **1,099 passing** (7 new), `ui:lint` and `ui:typecheck` clean with the rule at `error`, `ui:build` green.
- Backend suite + full checker sweep run on the branch; results in a follow-up comment.