### PR TITLE
fix(fairness): make the anchored ledger publicly verifiable, and stop misreporting an empty one

### DIFF
--- a/apps/loopover-ui/content/docs/fairness-methodology.mdx
+++ b/apps/loopover-ui/content/docs/fairness-methodology.mdx
@@ -16,8 +16,22 @@ Nothing here is a summary of intent. Every rule below is the rule the code imple
 
 <Callout variant="note">
   **Want the machine-checkable version?** `npx -p @loopover/mcp loopover-verify` recomputes the
-  published commitments from the public endpoints and prints a PASS/FAIL table. It needs no
-  credentials. See [Verify this review](/docs/verify-this-review).
+  published commitments and prints a PASS/FAIL table. It needs no credentials. See
+  [Verify this review](/docs/verify-this-review).
+
+  Two surfaces answer different questions, because they hold different data (#9940). Aggregate
+  stats and eval-score records come from `api.loopover.ai`, the default. The **anchored decision
+  ledger** lives on the Orb that actually reviews — its own hash chain, signed and anchored to
+  Rekor — so ledger and anchor checks need that one:
+
+  ```bash
+  npx -p @loopover/mcp loopover-verify                                    # stats + eval scores
+  npx -p @loopover/mcp loopover-verify --base-url https://shots.loopover.ai   # ledger + anchors
+  ```
+
+  The public API's own ledger is empty by design: it aggregates outcomes reported by Orbs rather
+  than holding their chains. A verifier run against it reports the ledger checks as *skipped*,
+  not failed.
 </Callout>
 
 ## The three data sources are not interchangeable

--- a/apps/loopover-ui/content/docs/verify-this-review.mdx
+++ b/apps/loopover-ui/content/docs/verify-this-review.mdx
@@ -16,6 +16,19 @@ figure stops supporting a conclusion — see the [fairness methodology](/docs/fa
 For a single command that recomputes the published commitments and exits non-zero if any fail,
 run `npx -p @loopover/mcp loopover-verify`.
 
+**Two surfaces, because they hold different things** (#9940). The commands on this page use
+`api.loopover.ai`, which serves aggregate stats and eval-score records. The **anchored decision
+ledger** — the hash chain, its signed checkpoints, and the Rekor anchors — lives on the Orb that
+performs the reviews, at `https://shots.loopover.ai`. Point the ledger and anchor checks there:
+
+```bash
+curl -s https://shots.loopover.ai/v1/public/decision-ledger/verify | jq '{ok, tipSeq, totalCount}'
+npx -p @loopover/mcp loopover-verify --base-url https://shots.loopover.ai
+```
+
+The public API's own ledger is empty by design — it aggregates outcomes Orbs report, rather than
+holding their chains — so a run against it reports the ledger checks as *skipped*, never failed.
+
 Everything below runs read-only against a corpus export and pure functions from `@loopover/engine`.
 Nothing posts anywhere, and nothing needs a LoopOver API key.
 

--- a/packages/loopover-mcp/bin/loopover-verify.ts
+++ b/packages/loopover-mcp/bin/loopover-verify.ts
@@ -109,11 +109,14 @@ export async function runVerify(args: readonly string[], baseUrlOverride?: strin
 
   // Fetched together: they are independent reads, and a verifier that serialises four round trips for no
   // reason is a slower verifier with no compensating property.
-  const [scoresOutcome, statsOutcome, checkpointOutcome, keysOutcome] = await Promise.all([
+  const [scoresOutcome, statsOutcome, checkpointOutcome, keysOutcome, ledgerOutcome] = await Promise.all([
     apiGet<{ records?: VerifiableEvalRecord[] }>(baseUrl, "/v1/public/eval-scores"),
     apiGet<{ totals?: { handled?: unknown }; reviewParity?: { verdicts?: unknown } }>(baseUrl, "/v1/public/stats"),
     apiGet<{ signed?: unknown; signingInput?: unknown }>(baseUrl, "/v1/public/decision-ledger/anchor-payload"),
     apiGet<{ keys?: unknown[] }>(baseUrl, "/v1/public/decision-ledger/anchor-key"),
+    // #9940: the ledger's own size, so an EMPTY surface is reported as such rather than as a missing
+    // signing key. Those are different findings and only one of them is a problem.
+    apiGet<{ totalCount?: unknown }>(baseUrl, "/v1/public/decision-ledger/verify"),
   ]);
 
   const records = scoresOutcome.ok && Array.isArray(scoresOutcome.value.records) ? scoresOutcome.value.records : [];
@@ -141,7 +144,7 @@ export async function runVerify(args: readonly string[], baseUrlOverride?: strin
   // so an unavailable checkpoint is passed through as `undefined` and reported as a skip by the check
   // itself rather than being special-cased into a second, subtly different skip message here.
   const keys = keysOutcome.ok && Array.isArray(keysOutcome.value.keys) ? (keysOutcome.value.keys as Parameters<typeof checkAnchorCheckpoint>[1]) : [];
-  results.push(await checkAnchorCheckpoint(checkpointOutcome.ok ? checkpointOutcome.value : undefined, keys));
+  results.push(await checkAnchorCheckpoint(checkpointOutcome.ok ? checkpointOutcome.value : undefined, keys, ledgerOutcome.ok ? ledgerOutcome.value : undefined));
 
   results.push(
     statsOutcome.ok

--- a/packages/loopover-mcp/lib/verify-public-claims.ts
+++ b/packages/loopover-mcp/lib/verify-public-claims.ts
@@ -179,11 +179,31 @@ export async function checkCorpusCommitments(
 export async function checkAnchorCheckpoint(
   checkpoint: { signed?: unknown; signingInput?: unknown } | undefined,
   keys: readonly AnchorPublicKey[],
+  ledger?: { totalCount?: unknown } | undefined,
 ): Promise<ClaimResult> {
   const claim = "The current signed ledger checkpoint verifies offline against a published key";
   const id = "anchor-checkpoint";
   if (checkpoint === undefined || !isSignedAnchor(checkpoint.signed)) {
-    return { id, claim, status: "skip", detail: "no signed checkpoint published (anchor signing not configured, or the ledger is empty)" };
+    // #9940: an EMPTY ledger and a misconfigured signer used to produce the same sentence, and the
+    // difference is the whole diagnosis. This surface holding no decisions is not a verifiability failure
+    // -- there is nothing to anchor -- whereas decisions with no signing key is a real gap. Conflating them
+    // sent me down the wrong path on a live deployment: I read "not configured" and went looking for a
+    // missing secret, when the deployment simply had no ledger and the anchoring worked fine elsewhere.
+    const totalCount = typeof ledger?.totalCount === "number" ? ledger.totalCount : null;
+    if (totalCount === 0) {
+      return {
+        id,
+        claim,
+        status: "skip",
+        detail: "this deployment's decision ledger is EMPTY (0 records), so there is nothing to anchor — check the deployment that actually records decisions, via --base-url",
+      };
+    }
+    return {
+      id,
+      claim,
+      status: "skip",
+      detail: totalCount === null ? "no signed checkpoint published, and the ledger size is unknown" : `no signed checkpoint published, though the ledger holds ${totalCount} record(s) — anchor signing looks unconfigured here`,
+    };
   }
   const signed = checkpoint.signed;
   if (keys.length === 0) {

--- a/test/unit/verify-public-claims.test.ts
+++ b/test/unit/verify-public-claims.test.ts
@@ -176,6 +176,25 @@ describe("checkAnchorCheckpoint", () => {
     expect(result.detail).toContain("not among");
   });
 
+  it("distinguishes an EMPTY ledger from a missing signing key (#9940)", async () => {
+    // These read identically before, and the difference is the whole diagnosis. Conflating them sent me
+    // looking for a missing secret on a deployment whose anchoring was working fine -- the surface simply
+    // held no ledger, because the records live on a different one.
+    const { checkAnchorCheckpoint } = await loadClaims();
+    const empty = await checkAnchorCheckpoint(undefined, [], { totalCount: 0 });
+    expect(empty.status).toBe("skip");
+    expect(empty.detail).toContain("EMPTY");
+    expect(empty.detail).toContain("--base-url");
+
+    // Records present but nothing signed: a real gap, and it must NOT read as "nothing to anchor".
+    const unsigned = await checkAnchorCheckpoint(undefined, [], { totalCount: 2190 });
+    expect(unsigned.detail).toContain("2190");
+    expect(unsigned.detail).not.toContain("EMPTY");
+
+    // Ledger size unknown (the endpoint itself was unreachable) is its own third case.
+    expect((await checkAnchorCheckpoint(undefined, [], undefined)).detail).toContain("ledger size is unknown");
+  });
+
   it("skips when no checkpoint is published, and when no key is published to check one against", async () => {
     const { checkAnchorCheckpoint } = await loadClaims();
     const { signed } = await realCheckpoint();


### PR DESCRIPTION
Closes #9940.

## What was wrong

The anchoring mechanism was never broken. `edge-nl-01` signs its ledger and anchors to Rekor on schedule. The problem was **topological**: the deployment holding the anchored ledger was bound to `127.0.0.1`, and the deployment the world can reach has an empty one.

| | `api.loopover.ai` (Worker) | `edge-nl-01` (Orb) |
|---|---|---|
| `decision-ledger/verify` | `totalCount: 0` | `totalCount: 2190+`, `ok: true` |
| `anchor-key` | `unconfigured`, 0 keys | `6b6490126ad44b51` |
| `anchor-payload` | 404 | signed checkpoint |
| decision record for a real PR | `not_found` | present |

So `/fairness`, `verify-this-review`, and the verifier from #9723 all pointed at a surface that could not serve what they described.

## Three fixes

**1. The Orb's public surface is now reachable.** Extended the existing Cloudflare Tunnel's ingress with a second path rule (`^/v1/public/.*$` → `localhost:8787`) on the hostname it already serves. No new DNS, no new credentials, no inbound port.

Scoped deliberately — verified from the open internet that everything else stays sealed:

```
/v1/public/decision-ledger/verify   HTTP 200   tipSeq 2197
/v1/repos                           HTTP 404
/v1/admin/config                    HTTP 404
/v1/orb/ingest                      HTTP 404
/metrics                            HTTP 404
```

And the end-to-end proof, run from outside:

```
$ npx -p @loopover/mcp loopover-verify --base-url https://shots.loopover.ai
PASS  The current signed ledger checkpoint verifies offline against a published key
      checkpoint at seq 2197 verifies against published key "6b6490126ad44b51"
```

That is also **the first time #9723's crypto path has verified a real production signature** rather than a fixture.

**2. The verifier no longer misattributes an empty ledger.** Both states produced one sentence — *"anchor signing not configured, or the ledger is empty"* — and that ambiguity is what sent me looking for a missing secret on a deployment whose anchoring worked fine. It now reads the ledger's size and reports three distinct states: empty (nothing to anchor, and it names `--base-url` as the fix), records-present-but-unsigned (a real gap, with the count), and size-unknown.

**3. The docs name both surfaces.** `/fairness` methodology and the walkthrough now say which surface answers which question, and that a skipped ledger check against the aggregate is expected rather than a failure.

## Validation

- 34 verifier tests, 1 new covering all three states including that "records present" must not read as `EMPTY`.
- `docs:drift-check`, `typecheck`, `import-specifiers`, `dead-exports`, `checkers-wired`, `contract:api-schemas` pass; `ui:test` 692 passing.
- Tunnel config validated with `cloudflared tunnel ingress validate` before reload; previous config backed up on the box.

## Not included

The corpus-commitment half of the original issue (a `corpusChecksum` published for `ai_consensus_defect` with no downloadable corpus) is a separate defect in `#9805`'s omission logic and gets its own issue rather than being folded in here.