### PR TITLE
ci(verifiability): verify our own public claims nightly, as an outsider

### DIFF
--- a/.github/workflows/verify-public-claims.yml
+++ b/.github/workflows/verify-public-claims.yml
@@ -74,21 +74,29 @@ jobs:
           # never consults git's credential config.
           persist-credentials: false
 
-      # AUDITED (#9724). A supply-chain scan flags this action for credential-file access, citing
-      # `__tests__/authutil.test.ts`. Checked at this exact SHA (v7.0.0) rather than waved through:
+      # DELIBERATELY NO actions/setup-node. This job needs a Node RUNTIME, not this repository's toolchain:
+      # it runs a published CLI through npx and one checked-in script, and builds nothing. The runner image
+      # already provides both node and npm, and three workflows here (ci.yml, mcp-release-watch.yml,
+      # package-release-watch.yml) already rely on that.
       #
-      #   • the entrypoint is `dist/setup/index.js`; `__tests__/` is never executed by the action;
-      #   • the credential writer is `auth.configAuthentication(registryUrl)`, and `src/main.ts` calls it
-      #     ONLY inside `if (registryUrl)`.
+      # Dropping it removes the last action that can write credentials. `actions/setup-node` writes an
+      # authenticated .npmrc via `auth.configAuthentication(registryUrl)` -- gated behind `if (registryUrl)`
+      # in its `src/main.ts`, so it was unreachable while that input stayed unset, but "unreachable because
+      # nobody has added one line yet" is a weaker property than "not present". For a job whose entire claim
+      # is that it holds no credentials, not present is the one worth having.
       #
-      # So the capability is real and unreachable here, because `registry-url` is not set below. That is a
-      # property of this file, not of the action -- adding `registry-url:` would make this job write an
-      # authenticated .npmrc while still claiming to hold no credentials -- so it is asserted in
-      # test/unit/verify-public-claims-workflow.test.ts rather than left to this comment.
-      - name: Setup Node
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        with:
-          node-version-file: .nvmrc
+      # The tradeoff is that the Node version is now the runner's rather than .nvmrc's, so it is ASSERTED
+      # rather than assumed. `--experimental-strip-types` needs 22.6+; if an image ever regresses below that,
+      # this fails immediately with the fix in the message instead of the nightly quietly breaking.
+      - name: Require a Node that can strip types
+        run: |
+          node -e '
+            const [major, minor] = process.versions.node.split(".").map(Number);
+            if (major > 22 || (major === 22 && minor >= 6)) process.exit(0);
+            console.error("::error::Node " + process.versions.node + " cannot run --experimental-strip-types (needs 22.6+). Re-add actions/setup-node with node-version-file: .nvmrc.");
+            process.exit(1);
+          '
+          echo "node $(node --version), npm $(npm --version)"
 
       # No `npm ci`: this step must not depend on the repository's own dependency tree, because a stranger has
       # none. `npx -p @loopover/mcp` fetches the published package exactly as the docs tell a reader to.

--- a/.github/workflows/verify-public-claims.yml
+++ b/.github/workflows/verify-public-claims.yml
@@ -1,0 +1,157 @@
+# Nightly anonymous verification (#9724, epic #9722).
+#
+# LoopOver publishes fairness claims and tells a stranger they can check them without asking permission. This
+# job IS that stranger, on a schedule. It runs the verifier PUBLISHED ON NPM against PRODUCTION with no
+# credentials of any kind, so a regression in the public verification path is caught by us within a cycle
+# instead of by an outside reader whenever they happen to look.
+#
+# THE PUBLISHED TOOL, NOT THE ONE IN THIS TREE. `npx -p @loopover/mcp` deliberately resolves the release on npm
+# rather than building from the checkout. What is being asserted is "an outsider succeeds today", and an
+# outsider has the published CLI -- so a fix that is merged but unpublished must NOT turn this green. #9962 is
+# exactly that failure: the shipped verifier asked `/v1/public/eval-corpus?rule_id=`, the route reads `ruleId`,
+# every corpus fetch 400'd, and the tool reported production as unverifiable while production was fine. Both
+# sides were individually tested and individually correct. Only running the real pair catches it.
+#
+# NO CREDENTIALS ON THE VERIFY STEP. The job-level permission is `contents: read`, and the verify step is given
+# no token in its environment at all -- `issues: write` and the token live only on the step that files the
+# tracking issue, after verification is finished. A verifier that runs with repo credentials is not reproducing
+# an outsider's view, and could pass on access a stranger does not have.
+#
+# TWO SURFACES, because they hold different things (#9940): `api.loopover.ai` serves aggregate stats and
+# eval-score records, while the anchored decision ledger lives on the Orb at `shots.loopover.ai`. Checking only
+# one leaves the other free to regress silently, so both are verified and reported independently.
+name: Verify Public Claims
+
+on:
+  schedule:
+    # 04:12 UTC. Off the hour on purpose: the top of the hour is the busiest slot on GitHub's shared scheduler
+    # and the most likely to be delayed or dropped, which for a nightly is a silently skipped check.
+    - cron: "12 4 * * *"
+  workflow_dispatch:
+    inputs:
+      api-base-url:
+        description: "Base URL for the aggregate/eval surface"
+        required: false
+        default: "https://api.loopover.ai"
+      orb-base-url:
+        description: "Base URL for the anchored decision ledger"
+        required: false
+        default: "https://shots.loopover.ai"
+      dry-run:
+        description: "Report the verdict without filing, updating or closing the tracking issue"
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: verify-public-claims
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      issues: write
+    env:
+      API_BASE_URL: ${{ inputs.api-base-url || 'https://api.loopover.ai' }}
+      ORB_BASE_URL: ${{ inputs.orb-base-url || 'https://shots.loopover.ai' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version-file: .nvmrc
+
+      # No `npm ci`: this step must not depend on the repository's own dependency tree, because a stranger has
+      # none. `npx -p @loopover/mcp` fetches the published package exactly as the docs tell a reader to.
+      - name: Verify published claims anonymously
+        id: verify
+        run: |
+          # No `set -e`: a failing claim exits the verifier non-zero, and that is a RESULT to be captured and
+          # reported, not a reason to abort before the tracking issue is filed.
+          set -uo pipefail
+          run_surface() {
+            base="$1"
+            out="$2"
+            echo "::group::loopover-verify --base-url $base"
+            # `code` is assigned on its OWN line. `local code=$?` / `code=$(...)` would capture the assignment's
+            # own status instead of the command's, quietly making every run look like a clean exit 0.
+            npx --yes -p @loopover/mcp loopover-verify --base-url "$base" --json > "$out" 2>"$out.err"
+            code=$?
+            echo "$code" > "$out.code"
+            cat "$out"
+            # stderr matters most when stdout is unparseable -- that is the "the verifier itself broke" case,
+            # and it is the one where the JSON report cannot explain anything.
+            if [ -s "$out.err" ]; then echo "--- stderr ---"; cat "$out.err"; fi
+            echo "exit=$code"
+            echo "::endgroup::"
+          }
+          run_surface "$API_BASE_URL" api.json
+          run_surface "$ORB_BASE_URL" orb.json
+          # The script appends VERIFY_OK, VERIFY_SUMMARY and the heredoc-delimited body to $GITHUB_OUTPUT
+          # itself, as one write. Wrapping its stdout in a heredoc here instead would interleave the two
+          # writers and bury VERIFY_OK inside the body block.
+          npx --yes tsx scripts/verify-public-claims-report.ts \
+            "public API" "$API_BASE_URL" "$(cat api.json.code)" api.json \
+            "Orb ledger" "$ORB_BASE_URL" "$(cat orb.json.code)" orb.json
+
+      - name: Report verdict
+        run: |
+          {
+            echo "### Anonymous verification — ${{ steps.verify.outputs.VERIFY_SUMMARY }}"
+            echo ""
+            echo "- \`${{ env.API_BASE_URL }}\`"
+            echo "- \`${{ env.ORB_BASE_URL }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Open-or-update on failure, close on recovery. ONE issue, found by exact title, so a persistent outage
+      # is a single tracked thing rather than a nightly pile -- and so recovery has something unambiguous to
+      # close. This step is the only one holding a token.
+      - name: File or close the tracking issue
+        if: ${{ inputs.dry-run != 'true' }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          VERIFY_OK: ${{ steps.verify.outputs.VERIFY_OK }}
+          VERIFY_BODY: ${{ steps.verify.outputs.body }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          TITLE: "verifiability: the nightly anonymous verification run is failing"
+        run: |
+          set -euo pipefail
+          existing=$(gh issue list --state open --search "\"$TITLE\" in:title" --json number,title \
+            --jq "map(select(.title == env.TITLE)) | .[0].number // empty")
+          if [ "$VERIFY_OK" = "true" ]; then
+            if [ -n "$existing" ]; then
+              gh issue comment "$existing" --body "Recovered. The nightly anonymous verification run is green again as of [this run]($RUN_URL); closing automatically."
+              gh issue close "$existing" --reason completed
+              echo "Closed #$existing on recovery."
+            else
+              echo "Green, and nothing was open. Nothing to do."
+            fi
+            exit 0
+          fi
+          body="$VERIFY_BODY
+
+          [Failing run]($RUN_URL)"
+          if [ -n "$existing" ]; then
+            # Comment rather than overwrite the body: the history of WHICH claims failed on WHICH night is the
+            # most useful thing on a flapping issue, and rewriting the body destroys it.
+            gh issue comment "$existing" --body "$body"
+            echo "::error::Anonymous verification is failing -- updated #$existing."
+          else
+            gh issue create --title "$TITLE" --label maintainer-only --assignee JSONbored --body "$body"
+            echo "::error::Anonymous verification is failing -- tracking issue filed."
+          fi
+
+      # Last, so the issue is always filed or closed even when the job is about to go red. A red run with no
+      # issue would be a monitor that notices a problem and then drops it.
+      - name: Fail the run when a claim failed
+        if: ${{ steps.verify.outputs.VERIFY_OK != 'true' }}
+        run: |
+          echo "::error::One or more published claims could not be verified anonymously."
+          exit 1

--- a/.github/workflows/verify-public-claims.yml
+++ b/.github/workflows/verify-public-claims.yml
@@ -97,7 +97,12 @@ jobs:
           # The script appends VERIFY_OK, VERIFY_SUMMARY and the heredoc-delimited body to $GITHUB_OUTPUT
           # itself, as one write. Wrapping its stdout in a heredoc here instead would interleave the two
           # writers and bury VERIFY_OK inside the body block.
-          npx --yes tsx scripts/verify-public-claims-report.ts \
+          #
+          # `node --experimental-strip-types`, not `npx tsx`: this file is OURS and already checked out, so
+          # fetching an unpinned TypeScript runner from the registry to read it would add a second unvetted
+          # runtime dependency to a job whose one intentional unpinned fetch is the published verifier itself.
+          # Same invocation `npm run actionlint` already uses for its own TS script.
+          node --experimental-strip-types scripts/verify-public-claims-report.ts \
             "public API" "$API_BASE_URL" "$(cat api.json.code)" api.json \
             "Orb ledger" "$ORB_BASE_URL" "$(cat orb.json.code)" orb.json
 

--- a/.github/workflows/verify-public-claims.yml
+++ b/.github/workflows/verify-public-claims.yml
@@ -62,6 +62,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # `persist-credentials: false` is load-bearing here, not hygiene. actions/checkout defaults to TRUE,
+          # which writes an authenticated `http.extraheader` into `.git/config` -- so the verify step would run
+          # with a usable GitHub token sitting on disk, and this job's whole claim is that it reproduces what a
+          # stranger sees. Withholding the token from the step's `env:` while leaving it in `.git/config` is
+          # theatre: the credential is still there for anything the step runs to pick up.
+          #
+          # Nothing here needs it. The only step that talks to GitHub is the tracking-issue step, which uses
+          # `gh` with an explicit `GITHUB_TOKEN` in its own environment -- `gh` reads that variable directly and
+          # never consults git's credential config.
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7

--- a/.github/workflows/verify-public-claims.yml
+++ b/.github/workflows/verify-public-claims.yml
@@ -74,6 +74,17 @@ jobs:
           # never consults git's credential config.
           persist-credentials: false
 
+      # AUDITED (#9724). A supply-chain scan flags this action for credential-file access, citing
+      # `__tests__/authutil.test.ts`. Checked at this exact SHA (v7.0.0) rather than waved through:
+      #
+      #   • the entrypoint is `dist/setup/index.js`; `__tests__/` is never executed by the action;
+      #   • the credential writer is `auth.configAuthentication(registryUrl)`, and `src/main.ts` calls it
+      #     ONLY inside `if (registryUrl)`.
+      #
+      # So the capability is real and unreachable here, because `registry-url` is not set below. That is a
+      # property of this file, not of the action -- adding `registry-url:` would make this job write an
+      # authenticated .npmrc while still claiming to hold no credentials -- so it is asserted in
+      # test/unit/verify-public-claims-workflow.test.ts rather than left to this comment.
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:

--- a/apps/loopover-ui/content/docs/verify-this-review.mdx
+++ b/apps/loopover-ui/content/docs/verify-this-review.mdx
@@ -16,6 +16,15 @@ figure stops supporting a conclusion — see the [fairness methodology](/docs/fa
 For a single command that recomputes the published commitments and exits non-zero if any fail,
 run `npx -p @loopover/mcp loopover-verify`.
 
+[![Nightly anonymous verification](https://github.com/JSONbored/loopover/actions/workflows/verify-public-claims.yml/badge.svg)](https://github.com/JSONbored/loopover/actions/workflows/verify-public-claims.yml)
+
+**We run this against ourselves every night** (#9724). That badge is a scheduled job that executes
+the verifier *published on npm* against production, from a runner holding no credentials of any
+kind — the same position you are in. If it is green, an outsider following this page succeeded
+within the last 24 hours. If it is red, something on this page does not currently work, we already
+know, and there is an open issue saying which claim broke. The badge links to every run, including
+the failures; you do not have to take our word for the history.
+
 **Two surfaces, because they hold different things** (#9940). The commands on this page use
 `api.loopover.ai`, which serves aggregate stats and eval-score records. The **anchored decision
 ledger** — the hash chain, its signed checkpoints, and the Rekor anchors — lives on the Orb that

--- a/scripts/verify-public-claims-report.ts
+++ b/scripts/verify-public-claims-report.ts
@@ -1,0 +1,278 @@
+#!/usr/bin/env node
+// #9724: turn one or more `loopover-verify --json` reports into the nightly job's verdict and, when something
+// is wrong, the body of the tracking issue a maintainer will actually have to act on.
+//
+// WHY THIS IS A SCRIPT AND NOT INLINE BASH. The interesting logic here is a judgement -- which claims count as
+// a regression, and what a reader needs in order to fix it -- and that judgement is exactly the part that must
+// not be discovered to be wrong on the night it first fires. As a pure function it is unit-tested against real
+// report shapes, including the shapes that must NOT open an issue.
+//
+// SKIP IS NOT FAILURE, AND IS NOT SUCCESS EITHER. `loopover-verify` reports a surface it could not obtain as
+// `skip`, and the verifier's own header is emphatic that collapsing "could not check" into "checked, fine" is
+// how you build a monitor that always says green. So skips never open an issue -- a deployment legitimately
+// serves no corpus for a rule, and the public API's ledger is empty BY DESIGN (#9940), which is a permanent,
+// expected skip -- but they are always reported in the body, because "we verified nothing at all tonight" is
+// something a maintainer reading a green run deserves to see.
+
+import { pathToFileURL } from "node:url";
+import { readFileSync } from "node:fs";
+
+/** One claim as `loopover-verify --json` emits it. Structural, matching the verifier's own reasoning about
+ *  older deployments: the nightly must be able to parse a report from a CLI version it does not control. */
+export type VerifyClaim = {
+  id?: unknown;
+  claim?: unknown;
+  status?: unknown;
+  detail?: unknown;
+};
+
+export type VerifyRun = {
+  /** Human label for the surface, e.g. "public API". Appears in the issue body and the job log. */
+  label: string;
+  baseUrl: string;
+  /** The CLI's exit code. Non-zero with no failing claim means the tool itself broke -- see below. */
+  exitCode: number;
+  /** Parsed `--json` payload, or null when the CLI produced nothing parseable. */
+  report: { results?: unknown } | null;
+};
+
+export type ClaimLine = { surface: string; status: string; claim: string; detail: string };
+
+export type VerificationReport = {
+  ok: boolean;
+  failures: ClaimLine[];
+  skips: ClaimLine[];
+  passes: ClaimLine[];
+  title: string;
+  body: string;
+};
+
+const str = (value: unknown, fallback = ""): string => (typeof value === "string" ? value : fallback);
+
+/** PURE. Flatten one run's claims into labelled lines. A report whose `results` is absent or not an array
+ *  yields nothing here; {@link buildVerificationReport} turns that into its own failure rather than letting an
+ *  unreadable report read as "no failures". */
+export function claimLinesFor(run: VerifyRun): ClaimLine[] {
+  const results = run.report?.results;
+  if (!Array.isArray(results)) return [];
+  return results.map((entry) => {
+    const claim = entry as VerifyClaim;
+    return {
+      surface: run.label,
+      status: str(claim.status, "unknown").toLowerCase(),
+      claim: str(claim.claim, str(claim.id, "(unnamed claim)")),
+      detail: str(claim.detail, "(no detail published)"),
+    };
+  });
+}
+
+/**
+ * PURE. Decide whether the public verification path is healthy, and write the issue body if it is not.
+ *
+ * Four independent things count as broken, and every one after the first is a case that would otherwise
+ * present as a silent green:
+ *
+ *   1. any claim the verifier reports as `fail`;
+ *   2. a run that produced NO readable report at all (the CLI crashed, the JSON was malformed, npx could not
+ *      resolve the package). Nothing failed, because nothing ran -- which is a regression in the published
+ *      verification path itself, precisely what this job exists to notice;
+ *   3. a non-zero exit code with no failing claim to explain it. The tool is telling us something went wrong
+ *      in a way its own claim list does not describe, and trusting the empty claim list over the exit code
+ *      would be choosing the more comfortable of two contradictory signals;
+ *   4. a run in which NOTHING PASSED. This is the one that matters most, and it was found by pointing the real
+ *      verifier at a deliberately wrong base URL: every claim came back `skip` ("/v1/public/eval-scores
+ *      unavailable (HTTP 404)") and the CLI exited 0. Judged claim-by-claim that is four legitimate skips and
+ *      a clean exit -- so the monitor would have reported GREEN against a completely dead endpoint, which is
+ *      the exact failure this job exists to prevent.
+ *
+ *      The verifier is right to call them skips: from inside a single claim, "this surface is disabled" and
+ *      "this host is wrong" are indistinguishable. The MONITOR has the context the claim lacks -- production is
+ *      supposed to be serving these -- so requiring at least one positively verified claim per surface is a
+ *      judgement that belongs here rather than in the CLI.
+ *
+ *      The floor is one, not a proportion, because the two surfaces are legitimately lopsided and both must
+ *      clear it with room to spare (measured against production): `api.loopover.ai` passes record-digests,
+ *      corpus-commitments and stats-parity while skipping anchor-checkpoint (its ledger is empty BY DESIGN,
+ *      #9940), and `shots.loopover.ai` passes anchor-checkpoint while skipping the other three (it does not
+ *      publish stats). A threshold like "most claims pass" would fail the Orb on a healthy night.
+ */
+export function buildVerificationReport(runs: readonly VerifyRun[]): VerificationReport {
+  const all = runs.flatMap(claimLinesFor);
+  const failures = all.filter((line) => line.status === "fail");
+  const skips = all.filter((line) => line.status === "skip");
+  const passes = all.filter((line) => line.status === "pass");
+
+  const brokenRuns = runs.filter((run) => run.report === null || !Array.isArray(run.report.results));
+  const unexplained = runs.filter(
+    (run) => run.exitCode !== 0 && !brokenRuns.includes(run) && !claimLinesFor(run).some((line) => line.status === "fail"),
+  );
+  // Case 4. Only for runs that produced a readable report -- a broken run is already reported as such, and
+  // saying "and also nothing passed" about it would be two findings for one cause.
+  const verifiedNothing = runs.filter((run) => !brokenRuns.includes(run) && !claimLinesFor(run).some((line) => line.status === "pass"));
+
+  const ok = failures.length === 0 && brokenRuns.length === 0 && unexplained.length === 0 && verifiedNothing.length === 0;
+  const title = TRACKING_ISSUE_TITLE;
+  if (ok) {
+    return { ok, failures, skips, passes, title, body: "" };
+  }
+
+  const lines: string[] = [
+    "The nightly anonymous verification run failed. These are LoopOver's own published claims, checked the way",
+    "an outsider checks them: the verifier published on npm, run against production, with no credentials of any",
+    "kind. A failure here means a stranger following the walkthrough right now gets the same result.",
+    "",
+  ];
+
+  for (const run of brokenRuns) {
+    lines.push(`### ${run.label} — the verifier produced no readable report`, "");
+    lines.push(
+      `\`${run.baseUrl}\` exited ${run.exitCode} without emitting parseable \`--json\` output. Nothing was checked, which`,
+      "is itself the regression: the published verification path did not run. Check the job log for the raw output.",
+      "",
+    );
+  }
+
+  for (const run of unexplained) {
+    lines.push(`### ${run.label} — non-zero exit with no failing claim`, "");
+    lines.push(
+      `\`${run.baseUrl}\` exited ${run.exitCode} but reported no \`fail\` claim. The tool is signalling a problem its own`,
+      "claim list does not describe; the exit code is the signal to trust here, not the empty list.",
+      "",
+    );
+  }
+
+  for (const run of verifiedNothing) {
+    lines.push(`### ${run.label} — nothing was verified`, "");
+    lines.push(
+      `Every claim against \`${run.baseUrl}\` came back skipped, so not one published commitment was actually`,
+      "recomputed. The most common cause is that the surface is not reachable at that host at all -- a wrong or",
+      "renamed base URL returns 404 for every endpoint, which the verifier reports claim-by-claim as \"unavailable\"",
+      "and exits 0. A healthy surface always positively verifies at least one claim.",
+      "",
+    );
+  }
+
+  if (failures.length > 0) {
+    lines.push("### Failing claims", "");
+    lines.push("| Surface | Claim | Detail |", "| --- | --- | --- |");
+    for (const line of failures) lines.push(`| ${line.surface} | ${escapeCell(line.claim)} | ${escapeCell(line.detail)} |`);
+    lines.push("");
+  }
+
+  if (skips.length > 0) {
+    // Reported, never counted. A permanent skip is expected (the public API's ledger is empty by design), but a
+    // NEW one next to a failure is often the actual cause, so it has to be visible in the same body.
+    lines.push("### Skipped (not counted as failures)", "");
+    lines.push("| Surface | Claim | Detail |", "| --- | --- | --- |");
+    for (const line of skips) lines.push(`| ${line.surface} | ${escapeCell(line.claim)} | ${escapeCell(line.detail)} |`);
+    lines.push("");
+  }
+
+  lines.push("### Reproduce", "");
+  lines.push("```bash");
+  for (const run of runs) lines.push(`npx -p @loopover/mcp loopover-verify --base-url ${run.baseUrl}`);
+  lines.push("```", "");
+  lines.push(
+    "This issue is updated in place while the failure persists and closed automatically by the next green run,",
+    "so it never needs manual triage to stay accurate. Filed by `.github/workflows/verify-public-claims.yml` (#9724).",
+  );
+
+  return { ok, failures, skips, passes, title, body: lines.join("\n") };
+}
+
+/** The single tracking issue's title. A CONSTANT, not templated with a date or a claim name: the workflow finds
+ *  the existing issue by exact title, and anything varying per run would file a new issue every night instead of
+ *  updating one. */
+export const TRACKING_ISSUE_TITLE = "verifiability: the nightly anonymous verification run is failing";
+
+/** Markdown table cells cannot contain a raw pipe or newline; verifier details legitimately contain both. */
+export function escapeCell(value: string): string {
+  return value.replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
+}
+
+/** PURE. The one-line job summary, printed whether or not anything failed. */
+export function summarize(report: VerificationReport): string {
+  return `${report.passes.length} passed, ${report.failures.length} failed, ${report.skips.length} skipped`;
+}
+
+/** Parse one run from the CLI's stdout. Never throws: unparseable output IS a result (see case 2 above). */
+export function parseRun(label: string, baseUrl: string, exitCode: number, stdout: string): VerifyRun {
+  try {
+    const parsed: unknown = JSON.parse(stdout);
+    if (parsed === null || typeof parsed !== "object") return { label, baseUrl, exitCode, report: null };
+    return { label, baseUrl, exitCode, report: parsed as { results?: unknown } };
+  } catch {
+    return { label, baseUrl, exitCode, report: null };
+  }
+}
+
+/** The heredoc delimiter for the multi-line `body` output. GitHub requires a delimiter that does not occur in
+ *  the value; this one is long and structured enough that verifier prose cannot collide with it, and
+ *  {@link renderGithubOutput} asserts that rather than assuming it. */
+export const OUTPUT_DELIMITER = "VERIFY_BODY_EOF_9d3f1c";
+
+/**
+ * PURE. The exact bytes to append to `$GITHUB_OUTPUT`.
+ *
+ * Built here, as one string, rather than by the workflow shell echoing around the script's stdout. That shape
+ * was subtly broken: the script appending its own scalars while the shell wrapped its stdout in a heredoc
+ * interleaves the two writers, and `VERIFY_OK=` lands INSIDE the body block -- leaving the workflow reading an
+ * empty verdict and, because an empty string is not `"true"`, filing an outage issue on a healthy night.
+ */
+export function renderGithubOutput(report: VerificationReport): string {
+  if (report.body.includes(OUTPUT_DELIMITER)) {
+    // Unreachable with the delimiter above, but an unguarded heredoc is an output-injection primitive: a body
+    // containing the delimiter would terminate the block early and let the rest be parsed as more outputs.
+    throw new Error("verification body contains the output delimiter");
+  }
+  return [`VERIFY_OK=${report.ok ? "true" : "false"}`, `VERIFY_SUMMARY=${summarize(report)}`, `body<<${OUTPUT_DELIMITER}`, report.body, OUTPUT_DELIMITER, ""].join("\n");
+}
+
+/** PURE. Parse the CLI's positional arguments into runs. Four per surface. */
+export function parseArgs(argv: readonly string[], readFile: (path: string) => string): VerifyRun[] {
+  const runs: VerifyRun[] = [];
+  for (let index = 0; index < argv.length; index += 4) {
+    const label = argv[index] ?? "";
+    const baseUrl = argv[index + 1] ?? "";
+    const exitCode = Number.parseInt(argv[index + 2] ?? "", 10);
+    const file = argv[index + 3] ?? "";
+    let stdout = "";
+    try {
+      stdout = readFile(file);
+    } catch {
+      // An unreadable capture file is the same finding as unparseable output: nothing was verified.
+    }
+    // A non-numeric exit code is treated as a failure rather than a zero -- "we could not tell how it exited"
+    // must never be the optimistic branch.
+    runs.push(parseRun(label, baseUrl, Number.isFinite(exitCode) ? exitCode : 1, stdout));
+  }
+  return runs;
+}
+
+/** CLI: `verify-public-claims-report.ts <label> <baseUrl> <exitCode> <stdoutFile> [...]`, four arguments per
+ *  run. Appends the structured outputs via `writeOutput` and logs a human summary to stdout. */
+export function runCli(argv: readonly string[], writeOutput: (chunk: string) => void, readFile: (path: string) => string = (path) => readFileSync(path, "utf8")): number {
+  if (argv.length === 0 || argv.length % 4 !== 0) {
+    process.stderr.write("usage: verify-public-claims-report <label> <baseUrl> <exitCode> <stdoutFile> [...]\n");
+    return 2;
+  }
+  const report = buildVerificationReport(parseArgs(argv, readFile));
+  writeOutput(renderGithubOutput(report));
+  process.stdout.write(`${summarize(report)}\n`);
+  if (!report.ok) process.stdout.write(`\n${report.body}\n`);
+  // Always 0 on a produced verdict: the workflow reads VERIFY_OK and decides. A non-zero exit here would abort
+  // the step that has to go on to file or close the tracking issue -- the job's actual deliverable.
+  return 0;
+}
+
+/* v8 ignore start -- the self-execution guard; every branch above is driven directly in tests. */
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const outputPath = process.env["GITHUB_OUTPUT"];
+  const { appendFileSync } = await import("node:fs");
+  const code = runCli(process.argv.slice(2), (chunk) => {
+    if (outputPath) appendFileSync(outputPath, chunk);
+    else process.stderr.write(chunk);
+  });
+  process.exit(code);
+}
+/* v8 ignore stop */

--- a/test/unit/verify-public-claims-report.test.ts
+++ b/test/unit/verify-public-claims-report.test.ts
@@ -1,0 +1,296 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  buildVerificationReport,
+  claimLinesFor,
+  escapeCell,
+  OUTPUT_DELIMITER,
+  parseArgs,
+  parseRun,
+  renderGithubOutput,
+  runCli,
+  summarize,
+  TRACKING_ISSUE_TITLE,
+  type VerifyRun,
+} from "../../scripts/verify-public-claims-report";
+
+// #9724: the nightly job's judgement, tested away from the network.
+//
+// The whole value of this monitor is that it says something true on the night it fires, and the ways a monitor
+// goes wrong are asymmetric: a false red wastes an hour, a false GREEN means the published verification path is
+// broken and nobody is told. So the cases that must NOT be green are pinned at least as hard as the happy path.
+
+const claim = (status: string, over: Record<string, unknown> = {}) => ({
+  id: "corpus-commitments",
+  claim: "Every corpusChecksum matches a downloadable corpus",
+  status,
+  detail: "3 case(s) rehashed exactly",
+  ...over,
+});
+
+const run = (over: Partial<VerifyRun> = {}): VerifyRun => ({
+  label: "public API",
+  baseUrl: "https://api.loopover.ai",
+  exitCode: 0,
+  report: { results: [claim("pass")] },
+  ...over,
+});
+
+describe("claimLinesFor", () => {
+  it("labels each claim with its surface", () => {
+    expect(claimLinesFor(run())).toEqual([
+      { surface: "public API", status: "pass", claim: "Every corpusChecksum matches a downloadable corpus", detail: "3 case(s) rehashed exactly" },
+    ]);
+  });
+
+  it("falls back through the identifying fields rather than indexing blindly into a malformed claim", () => {
+    const lines = claimLinesFor(run({ report: { results: [{ id: "stats-parity" }, {}] } }));
+    expect(lines[0]).toMatchObject({ status: "unknown", claim: "stats-parity", detail: "(no detail published)" });
+    expect(lines[1]).toMatchObject({ claim: "(unnamed claim)" });
+  });
+
+  it("yields nothing for a report with no results array (the caller turns that into its own failure)", () => {
+    expect(claimLinesFor(run({ report: null }))).toEqual([]);
+    expect(claimLinesFor(run({ report: {} }))).toEqual([]);
+    expect(claimLinesFor(run({ report: { results: "nope" } }))).toEqual([]);
+  });
+
+  it("compares status case-insensitively, so an upper-cased report is still understood", () => {
+    expect(claimLinesFor(run({ report: { results: [claim("FAIL")] } }))[0]?.status).toBe("fail");
+  });
+});
+
+describe("buildVerificationReport", () => {
+  it("is green when every claim passes", () => {
+    const report = buildVerificationReport([run(), run({ label: "Orb ledger", baseUrl: "https://shots.loopover.ai" })]);
+    expect(report.ok).toBe(true);
+    expect(report.body).toBe("");
+    expect(summarize(report)).toBe("2 passed, 0 failed, 0 skipped");
+  });
+
+  it("INVARIANT: skips alone are green -- a disabled surface is not a broken one", () => {
+    // The public API's ledger is empty BY DESIGN (#9940), so its ledger claims skip every single night. If a
+    // skip opened an issue, this job would file an outage on day one and be muted by week one.
+    const report = buildVerificationReport([run({ report: { results: [claim("skip"), claim("pass")] } })]);
+    expect(report.ok).toBe(true);
+    expect(report.skips).toHaveLength(1);
+  });
+
+  it("reports a failing claim, naming the surface and carrying the detail through", () => {
+    const report = buildVerificationReport([
+      run({ report: { results: [claim("fail", { detail: "committed abc…, corpus hashes to def…" })] } }),
+    ]);
+    expect(report.ok).toBe(false);
+    expect(report.title).toBe(TRACKING_ISSUE_TITLE);
+    expect(report.body).toContain("public API");
+    expect(report.body).toContain("committed abc…, corpus hashes to def…");
+    expect(report.body).toContain("npx -p @loopover/mcp loopover-verify --base-url https://api.loopover.ai");
+  });
+
+  it("REGRESSION: a run that produced NO readable report is a failure, not a silent pass", () => {
+    // The subtle false-green. Nothing failed because nothing RAN -- npx could not resolve the package, or the
+    // CLI crashed before emitting JSON. Counting zero failing claims as health is how a monitor reports green
+    // for a verification path that no longer works at all.
+    const report = buildVerificationReport([run({ report: null, exitCode: 1 })]);
+    expect(report.ok).toBe(false);
+    expect(report.body).toContain("the verifier produced no readable report");
+  });
+
+  it("REGRESSION: a non-zero exit with no failing claim is a failure", () => {
+    // Two contradictory signals, and the comfortable one is wrong. An empty claim list next to a non-zero exit
+    // means the tool hit something its own claims do not describe.
+    const report = buildVerificationReport([run({ exitCode: 2, report: { results: [claim("pass")] } })]);
+    expect(report.ok).toBe(false);
+    expect(report.body).toContain("non-zero exit with no failing claim");
+  });
+
+  it("does not double-report a run that both failed a claim and exited non-zero", () => {
+    // The ordinary failing case: exit 1 BECAUSE a claim failed. It must be described once, as the claim.
+    const report = buildVerificationReport([run({ exitCode: 1, report: { results: [claim("fail")] } })]);
+    expect(report.ok).toBe(false);
+    expect(report.body).not.toContain("non-zero exit with no failing claim");
+    expect(report.body).toContain("Failing claims");
+  });
+
+  it("lists skips alongside failures, since a new skip is often the cause", () => {
+    const report = buildVerificationReport([run({ report: { results: [claim("fail"), claim("skip", { claim: "anchor checkpoint" })] } })]);
+    expect(report.body).toContain("Skipped (not counted as failures)");
+    expect(report.body).toContain("anchor checkpoint");
+  });
+
+  it("names every surface in the reproduce block, not just the failing one", () => {
+    // A reader debugging one surface almost always needs to know what the other one said.
+    const report = buildVerificationReport([
+      run({ report: { results: [claim("fail")] } }),
+      run({ label: "Orb ledger", baseUrl: "https://shots.loopover.ai" }),
+    ]);
+    expect(report.body).toContain("--base-url https://api.loopover.ai");
+    expect(report.body).toContain("--base-url https://shots.loopover.ai");
+  });
+
+  it("handles no runs at all as green rather than throwing", () => {
+    expect(buildVerificationReport([]).ok).toBe(true);
+  });
+
+  // Case 4, and the reason this job is worth having. Found by pointing the real verifier at a deliberately
+  // wrong base URL, which is the self-verification #9724's acceptance asks for.
+  describe("a run that verified NOTHING (#9724 acceptance)", () => {
+    // Captured verbatim from `loopover-verify --base-url https://api.loopover.ai/definitely-not-the-api --json`.
+    // Four legitimate skips and exit 0 -- judged claim-by-claim this looks entirely healthy, which is exactly
+    // why the monitor has to apply a rule the CLI cannot.
+    const wrongBaseUrl = (): VerifyRun => ({
+      label: "public API",
+      baseUrl: "https://api.loopover.ai/definitely-not-the-api",
+      exitCode: 0,
+      report: {
+        results: [
+          { id: "record-digests", claim: "Every eval-score record's recordDigest recomputes from its own contents", status: "skip", detail: "/v1/public/eval-scores unavailable (HTTP 404)" },
+          { id: "corpus-commitments", claim: "Every corpusChecksum matches a downloadable corpus", status: "skip", detail: "/v1/public/eval-scores unavailable (HTTP 404)" },
+          { id: "anchor-checkpoint", claim: "The current signed ledger checkpoint verifies offline against a published key", status: "skip", detail: "no signed checkpoint published, and the ledger size is unknown" },
+          { id: "stats-parity", claim: "Published headline stats agree with the ledger-derived parity rollups", status: "skip", detail: "/v1/public/stats unavailable (HTTP 404)" },
+        ],
+      },
+    });
+
+    it("REGRESSION: turns the job RED, though every claim skipped and the CLI exited 0", () => {
+      const report = buildVerificationReport([wrongBaseUrl()]);
+      expect(report.ok).toBe(false);
+      expect(report.body).toContain("nothing was verified");
+      expect(report.body).toContain("https://api.loopover.ai/definitely-not-the-api");
+    });
+
+    it("goes green again the moment the base URL is corrected", () => {
+      // The other half of the acceptance criterion: restoring the config recovers, so the tracking issue gets
+      // closed rather than needing a human to notice it is stale.
+      const corrected = { ...wrongBaseUrl(), baseUrl: "https://api.loopover.ai", report: { results: [claim("pass"), claim("skip")] } };
+      expect(buildVerificationReport([corrected]).ok).toBe(true);
+    });
+
+    it("holds each surface to the floor independently, so one dead host cannot hide behind a healthy one", () => {
+      const healthy = run({ report: { results: [claim("pass")] } });
+      expect(buildVerificationReport([healthy, wrongBaseUrl()]).ok).toBe(false);
+    });
+
+    it("INVARIANT: production's real, lopsided pass/skip mixes both clear the floor", () => {
+      // Measured against production, and the reason the floor is ONE rather than a proportion. api.loopover.ai
+      // skips anchor-checkpoint (its ledger is empty by design, #9940) while shots.loopover.ai skips the three
+      // stats claims (it publishes no stats). "Most claims pass" would fail the Orb every healthy night.
+      const api = run({
+        label: "public API",
+        report: { results: [claim("pass", { id: "record-digests" }), claim("pass", { id: "corpus-commitments" }), claim("skip", { id: "anchor-checkpoint" }), claim("pass", { id: "stats-parity" })] },
+      });
+      const orb = run({
+        label: "Orb ledger",
+        baseUrl: "https://shots.loopover.ai",
+        report: { results: [claim("skip", { id: "record-digests" }), claim("skip", { id: "corpus-commitments" }), claim("pass", { id: "anchor-checkpoint" }), claim("skip", { id: "stats-parity" })] },
+      });
+      expect(buildVerificationReport([api, orb]).ok).toBe(true);
+    });
+
+    it("does not also report 'nothing verified' for a run that produced no report at all", () => {
+      // One cause, one finding. A broken run trivially has no passing claims too.
+      const report = buildVerificationReport([run({ report: null, exitCode: 1 })]);
+      expect(report.body).toContain("no readable report");
+      expect(report.body).not.toContain("nothing was verified");
+    });
+  });
+});
+
+describe("escapeCell", () => {
+  it("neutralises pipes and newlines, which verifier details genuinely contain", () => {
+    // A raw pipe silently splits a markdown cell and shifts every later column -- the failure detail would be
+    // rendered as a different column's content.
+    expect(escapeCell("a | b")).toBe("a \\| b");
+    expect(escapeCell("line1\nline2")).toBe("line1 line2");
+    expect(escapeCell("line1\r\nline2")).toBe("line1 line2");
+  });
+});
+
+describe("parseRun", () => {
+  it("parses a JSON report", () => {
+    expect(parseRun("l", "u", 0, '{"results":[]}').report).toEqual({ results: [] });
+  });
+
+  it("never throws on unparseable or non-object output -- that IS a result", () => {
+    expect(parseRun("l", "u", 1, "not json").report).toBeNull();
+    expect(parseRun("l", "u", 1, "null").report).toBeNull();
+    expect(parseRun("l", "u", 1, "42").report).toBeNull();
+    expect(parseRun("l", "u", 1, "").report).toBeNull();
+  });
+});
+
+describe("parseArgs", () => {
+  it("reads four arguments per surface", () => {
+    const runs = parseArgs(["public API", "https://a.test", "0", "a.json", "Orb", "https://b.test", "1", "b.json"], () => '{"results":[]}');
+    expect(runs.map((entry) => [entry.label, entry.baseUrl, entry.exitCode])).toEqual([
+      ["public API", "https://a.test", 0],
+      ["Orb", "https://b.test", 1],
+    ]);
+  });
+
+  it("treats an unreadable capture file as 'nothing was verified', not as an empty pass", () => {
+    const runs = parseArgs(["l", "u", "0", "missing.json"], () => {
+      throw new Error("ENOENT");
+    });
+    expect(runs[0]?.report).toBeNull();
+    expect(buildVerificationReport(runs).ok).toBe(false);
+  });
+
+  it("treats a non-numeric exit code as a failure rather than an optimistic zero", () => {
+    const runs = parseArgs(["l", "u", "", "a.json"], () => '{"results":[]}');
+    expect(runs[0]?.exitCode).toBe(1);
+  });
+});
+
+describe("renderGithubOutput", () => {
+  it("emits the verdict BEFORE the heredoc, so the body cannot swallow it", () => {
+    // The bug this shape exists to prevent: the workflow shell wrapping the script's stdout in a heredoc while
+    // the script separately appended its scalars interleaved the two writers, putting VERIFY_OK inside the body
+    // block. The workflow then read an empty verdict -- which is not "true" -- and filed an outage on a green
+    // night. One writer, one ordering.
+    const rendered = renderGithubOutput(buildVerificationReport([run({ report: { results: [claim("fail")] } })]));
+    const lines = rendered.split("\n");
+    expect(lines[0]).toBe("VERIFY_OK=false");
+    expect(lines[1]).toMatch(/^VERIFY_SUMMARY=/);
+    expect(lines[2]).toBe(`body<<${OUTPUT_DELIMITER}`);
+    expect(lines.at(-2)).toBe(OUTPUT_DELIMITER);
+  });
+
+  it("emits VERIFY_OK=true on a green run", () => {
+    expect(renderGithubOutput(buildVerificationReport([run()]))).toContain("VERIFY_OK=true");
+  });
+
+  it("refuses to render a body containing the delimiter, rather than emitting an injectable block", () => {
+    const poisoned = { ...buildVerificationReport([run()]), body: `x\n${OUTPUT_DELIMITER}\nVERIFY_OK=true` };
+    expect(() => renderGithubOutput(poisoned)).toThrow(/output delimiter/);
+  });
+});
+
+describe("runCli", () => {
+  it("writes the outputs and reports success", () => {
+    const chunks: string[] = [];
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const code = runCli(["public API", "https://a.test", "0", "a.json"], (chunk) => chunks.push(chunk), () => '{"results":[{"status":"pass","claim":"c","detail":"d"}]}');
+    stdout.mockRestore();
+    expect(code).toBe(0);
+    expect(chunks.join("")).toContain("VERIFY_OK=true");
+  });
+
+  it("still exits 0 when verification failed, so the tracking-issue step still runs", () => {
+    // A non-zero exit here would abort the job before it could file the issue -- a monitor that notices a
+    // problem and then drops it. The workflow reads VERIFY_OK and fails the run in its own last step.
+    const chunks: string[] = [];
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const code = runCli(["public API", "https://a.test", "1", "a.json"], (chunk) => chunks.push(chunk), () => "not json");
+    stdout.mockRestore();
+    expect(code).toBe(0);
+    expect(chunks.join("")).toContain("VERIFY_OK=false");
+  });
+
+  it("rejects an argument count that is not a multiple of four", () => {
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    expect(runCli(["only-one"], () => undefined, () => "")).toBe(2);
+    expect(runCli([], () => undefined, () => "")).toBe(2);
+    stderr.mockRestore();
+  });
+});

--- a/test/unit/verify-public-claims-workflow.test.ts
+++ b/test/unit/verify-public-claims-workflow.test.ts
@@ -1,0 +1,77 @@
+import { readFileSync } from "node:fs";
+
+import { parse } from "yaml";
+import { describe, expect, it } from "vitest";
+
+// #9724: the nightly verification job's "no credentials" claim, as a TESTED property rather than a comment.
+//
+// The job asserts it reproduces what an anonymous stranger sees. That claim is only as good as the absence of
+// every credential path, and those paths are easy to reopen by accident — each is one innocuous-looking line:
+//
+//   • `actions/checkout` defaults to `persist-credentials: true`, writing an authenticated `http.extraheader`
+//     into `.git/config`. Superagent caught this in review; the claim was false until it was set to false.
+//   • `actions/setup-node` writes an authenticated `.npmrc` via `auth.configAuthentication(registryUrl)` —
+//     verified at the pinned SHA (v7.0.0) to be gated behind `if (registryUrl)` in `src/main.ts`, so it is
+//     unreachable while the input is unset. Adding `registry-url:` later would silently reach it.
+//   • giving the verify step a token in its own `env:` would hand it one directly.
+//
+// A comment saying "do not add these" is what the codebase calls a snapshot presented as a guarantee. This
+// reads the shipped workflow and fails if any of them comes back.
+const WORKFLOW_PATH = ".github/workflows/verify-public-claims.yml";
+
+type Step = { name?: string; uses?: string; with?: Record<string, unknown>; env?: Record<string, unknown>; run?: string };
+type Workflow = { permissions?: Record<string, string>; jobs?: Record<string, { permissions?: Record<string, string>; steps?: Step[] }> };
+
+const workflow = parse(readFileSync(WORKFLOW_PATH, "utf8")) as Workflow;
+const verifyJob = workflow.jobs?.["verify"];
+const steps = verifyJob?.steps ?? [];
+const stepUsing = (action: string): Step | undefined => steps.find((step) => typeof step.uses === "string" && step.uses.startsWith(action));
+
+describe("verify-public-claims workflow — the anonymous-run guarantees (#9724)", () => {
+  it("reads a workflow with a verify job and steps (guards against a vacuous suite)", () => {
+    // Every assertion below is over `steps`. If the file moved or the job were renamed, they would all pass
+    // against an empty array and this file would guard nothing.
+    expect(verifyJob, `no "verify" job in ${WORKFLOW_PATH}`).toBeDefined();
+    expect(steps.length).toBeGreaterThan(3);
+  });
+
+  it("REGRESSION: checkout does not persist credentials to disk", () => {
+    // The bug Superagent found. `persist-credentials` defaults to TRUE, so this must be set explicitly —
+    // asserting it is absent-or-false would pass on the broken default.
+    const checkout = stepUsing("actions/checkout");
+    expect(checkout, "the job no longer checks out — re-point this test").toBeDefined();
+    expect(checkout?.with?.["persist-credentials"]).toBe(false);
+  });
+
+  it("REGRESSION: setup-node is not given a registry-url, which is what reaches its credential writer", () => {
+    // At the pinned SHA, `src/main.ts` calls `auth.configAuthentication(registryUrl)` only inside
+    // `if (registryUrl)`. Unset means the `.npmrc`-writing path is unreachable; setting it would make this
+    // job write a credential to disk while still claiming to hold none.
+    const setupNode = stepUsing("actions/setup-node");
+    expect(setupNode, "the job no longer sets up node — re-point this test").toBeDefined();
+    expect(setupNode?.with?.["registry-url"]).toBeUndefined();
+  });
+
+  it("INVARIANT: the step that runs the verifier is given no environment secrets at all", () => {
+    const verifyStep = steps.find((step) => typeof step.run === "string" && step.run.includes("loopover-verify"));
+    expect(verifyStep, "no step runs loopover-verify — re-point this test").toBeDefined();
+    // Not "no token" but "no env": an allowlist of forbidden names would miss the next secret someone adds.
+    expect(verifyStep?.env ?? {}).toEqual({});
+  });
+
+  it("INVARIANT: only the tracking-issue step holds a token, and the job's default permission is read-only", () => {
+    const withToken = steps.filter((step) => JSON.stringify(step.env ?? {}).includes("github.token") || JSON.stringify(step.env ?? {}).includes("secrets."));
+    expect(withToken).toHaveLength(1);
+    expect(withToken[0]?.name ?? "").toMatch(/tracking issue/i);
+    // Top-level default stays read-only; write is granted at the job, where it is visible next to the step
+    // that needs it.
+    expect(workflow.permissions).toEqual({ contents: "read" });
+    expect(verifyJob?.permissions).toEqual({ contents: "read", issues: "write" });
+  });
+
+  it("INVARIANT: no step installs the repo's dependency tree, which a stranger does not have", () => {
+    // `npm ci` here would mean verifying against this checkout's node_modules rather than the published
+    // package — the property that makes #9962 (a shipped verifier that could not reach production) catchable.
+    for (const step of steps) expect(step.run ?? "", step.name ?? "unnamed step").not.toMatch(/\bnpm (ci|install)\b/);
+  });
+});

--- a/test/unit/verify-public-claims-workflow.test.ts
+++ b/test/unit/verify-public-claims-workflow.test.ts
@@ -19,7 +19,7 @@ import { describe, expect, it } from "vitest";
 // reads the shipped workflow and fails if any of them comes back.
 const WORKFLOW_PATH = ".github/workflows/verify-public-claims.yml";
 
-type Step = { name?: string; uses?: string; with?: Record<string, unknown>; env?: Record<string, unknown>; run?: string };
+type Step = { name?: string; uses?: string; with?: Record<string, unknown>; env?: Record<string, unknown>; run?: string; if?: string };
 type Workflow = { permissions?: Record<string, string>; jobs?: Record<string, { permissions?: Record<string, string>; steps?: Step[] }> };
 
 const workflow = parse(readFileSync(WORKFLOW_PATH, "utf8")) as Workflow;
@@ -43,13 +43,28 @@ describe("verify-public-claims workflow — the anonymous-run guarantees (#9724)
     expect(checkout?.with?.["persist-credentials"]).toBe(false);
   });
 
-  it("REGRESSION: setup-node is not given a registry-url, which is what reaches its credential writer", () => {
-    // At the pinned SHA, `src/main.ts` calls `auth.configAuthentication(registryUrl)` only inside
-    // `if (registryUrl)`. Unset means the `.npmrc`-writing path is unreachable; setting it would make this
-    // job write a credential to disk while still claiming to hold none.
-    const setupNode = stepUsing("actions/setup-node");
-    expect(setupNode, "the job no longer sets up node — re-point this test").toBeDefined();
-    expect(setupNode?.with?.["registry-url"]).toBeUndefined();
+  it("REGRESSION: setup-node is not used at all — it is the last action that can write credentials", () => {
+    // `actions/setup-node` writes an authenticated .npmrc via `auth.configAuthentication(registryUrl)`,
+    // gated behind `if (registryUrl)` in its src/main.ts. Keeping it and leaving that input unset made the
+    // safety "unreachable because nobody has added one line yet"; not present is the stronger property, and
+    // the one a job claiming to hold no credentials should have. The runner's own node is used instead, with
+    // an explicit version precondition in the workflow.
+    expect(stepUsing("actions/setup-node")).toBeUndefined();
+  });
+
+  it("INVARIANT: checkout is the ONLY third-party action, so the credential surface stays one reviewed item", () => {
+    // Not a blocklist of known-risky actions — an allowlist of the one that is actually needed. A new action
+    // arriving in this job is a decision that should be made deliberately, not noticed later by a scanner.
+    const used = steps.flatMap((step) => (typeof step.uses === "string" ? [step.uses.split("@")[0]!] : []));
+    expect(used).toEqual(["actions/checkout"]);
+  });
+
+  it("asserts a Node version rather than assuming one, since the runner's node is now what runs", () => {
+    // The tradeoff of dropping setup-node: the version is the image's. `--experimental-strip-types` needs
+    // 22.6+, so the job fails loudly with the remedy rather than breaking quietly if an image regresses.
+    const guard = steps.find((step) => (step.name ?? "").toLowerCase().includes("node"));
+    expect(guard?.run ?? "").toMatch(/22/);
+    expect(guard?.run ?? "").toMatch(/experimental-strip-types/);
   });
 
   it("INVARIANT: the step that runs the verifier is given no environment secrets at all", () => {
@@ -67,6 +82,15 @@ describe("verify-public-claims workflow — the anonymous-run guarantees (#9724)
     // that needs it.
     expect(workflow.permissions).toEqual({ contents: "read" });
     expect(verifyJob?.permissions).toEqual({ contents: "read", issues: "write" });
+  });
+
+  it("REGRESSION: the token-holding step stays gated on dry-run, so --dry-run cannot file an issue", () => {
+    // Raised alongside the persist-credentials finding: with a token readable from .git/config, a compromised
+    // verifier could have created issues even on a dry run. `persist-credentials: false` closes the disk half;
+    // this pins the other half, so the gate cannot be dropped while the token stays.
+    const withToken = steps.filter((step) => JSON.stringify(step.env ?? {}).includes("github.token"));
+    expect(withToken).toHaveLength(1);
+    expect(withToken[0]?.if ?? "").toContain("dry-run");
   });
 
   it("INVARIANT: no step installs the repo's dependency tree, which a stranger does not have", () => {


### PR DESCRIPTION
## What this is

A scheduled job that is the stranger the docs invite. It runs the verifier **published on npm** against **production**, from a runner holding **no credentials of any kind**, and turns a regression in the public verification path into our problem within a cycle instead of an outside reader's discovery.

Both design choices are load-bearing:

- **The published tool, not this tree.** `npx -p @loopover/mcp` resolves the npm release rather than building from the checkout. What is asserted is "an outsider succeeds today", and an outsider has the published CLI — so a fix that is merged but unpublished must *not* turn this green. #9962 was exactly that: the shipped verifier asked `/v1/public/eval-corpus?rule_id=` while the route reads `ruleId`, every corpus fetch 400'd, and the tool reported production as unverifiable while production was fine. Both sides were individually tested and individually correct. Only running the real pair catches it.
- **No token on the verify step.** Job permission is `contents: read`; `issues: write` and the token exist only on the step that files the tracking issue, after verification finishes. A verifier running with repo credentials is not reproducing an outsider's view and could pass on access a stranger does not have.

Both surfaces are checked (#9940): `api.loopover.ai` for aggregates and eval-score records, `shots.loopover.ai` for the anchored ledger. Checking one leaves the other free to regress silently.

## Self-verification found a false-green

Per the agreed approach, I pointed the real verifier at a deliberately wrong base URL rather than staging a broken config. It found a bug in my first draft of the decision logic:

```
$ loopover-verify --base-url https://api.loopover.ai/definitely-not-the-api --json
skip  record-digests      /v1/public/eval-scores unavailable (HTTP 404)
skip  corpus-commitments  /v1/public/eval-scores unavailable (HTTP 404)
skip  anchor-checkpoint   no signed checkpoint published, and the ledger size is unknown
skip  stats-parity        /v1/public/stats unavailable (HTTP 404)
exit=0
```

Four legitimate skips and a clean exit. Judged claim-by-claim that looks entirely healthy — **the monitor would have reported green against a completely dead endpoint**, which is the precise failure this job exists to prevent.

The verifier is right to call them skips: from inside a single claim, "this surface is disabled" and "this host is wrong" are indistinguishable. The *monitor* has the context the claim lacks — production is supposed to be serving these — so **a run that positively verified nothing is now red**.

The floor is **one** passing claim, not a proportion, because the two surfaces are legitimately lopsided. Measured against production right now:

| Surface | pass | skip |
| --- | --- | --- |
| `api.loopover.ai` | record-digests, corpus-commitments, stats-parity | anchor-checkpoint (ledger empty **by design**, #9940) |
| `shots.loopover.ai` | anchor-checkpoint | the three stats/eval claims (publishes no stats) |

"Most claims pass" would fail the Orb every healthy night.

### End-to-end result

| Input | Verdict |
| --- | --- |
| Both real production surfaces | `VERIFY_OK=true` — *4 passed, 0 failed, 4 skipped* |
| Wrong base URL + healthy Orb | `VERIFY_OK=false` — names **which** surface is dead; the healthy one still passes |

Restoring the URL goes green, which is what closes the tracking issue — the recovery half of the acceptance criterion.

## Other false-greens rejected

- a run that produced **no readable report** (CLI crashed, malformed JSON, npx could not resolve the package): nothing failed because nothing *ran*;
- a **non-zero exit with no failing claim** — two contradictory signals, and the comfortable one is wrong;
- an **unreadable capture file**, and a non-numeric exit code, which is treated as failure rather than an optimistic zero.

Skips alone never file an issue — the API's ledger skips nightly by design, and a monitor that files an outage on day one is muted by week one — but they are always *listed*, since a new skip beside a failure is often its cause.

## Tracking issue lifecycle

One issue, found by exact title: filed on failure, **commented on** while it persists, closed automatically on recovery. Comments rather than body rewrites, because which claim failed on which night is the useful history. The filing step runs before the step that fails the run, so a red job always leaves the issue behind — a monitor that notices a problem and then drops it is worse than none.

## Why the logic is a script

`scripts/verify-public-claims-report.ts` is pure and unit-tested (**30 tests**), because the judgement of what counts as a regression must not be discovered to be wrong on the night it first fires. It also caught an output-interleaving bug: the workflow wrapping the script's stdout in a heredoc while the script separately appended its scalars buried `VERIFY_OK` inside the body block — the workflow would have read an empty verdict, which is not `"true"`, and filed an outage on a healthy night. The script now writes all outputs itself, in one ordered write, and refuses to emit a body containing the delimiter.

## Docs

A status line and badge on the walkthrough page, which is the surface the issue asks for: green means an outsider succeeded within 24 hours, red means we already know and there is an issue naming the broken claim. The badge links to every run including the failures.

## Not included — needs your call

`workflow_dispatch` takes `api-base-url`, `orb-base-url` and `dry-run` inputs, so the job can be pointed anywhere on demand.

**PagerDuty is not wired.** The issue asks to notify "via the existing alerting path (PagerDuty)", but that path is Alertmanager on the Orb — there is no PagerDuty secret in GitHub Actions, and no workflow references one. Adding it means introducing a new repository secret, which is an operator decision rather than something to slip into this PR. The tracking issue plus the red run is the notification today. Happy to add the routing step as a follow-up if you want the secret provisioned.

## Verification

- `actionlint`, `lint:composite-actions`, `typecheck`, `docs:drift-check`, `dead-source-files:check`, `dead-exports:check`, `import-specifiers:check`, `coverage-boltons:check`, `fixture-clock-races:check`, `checkers-wired:check`, `validate:no-hand-written-js`, `ui:typecheck`, `ui:test` — all green
- `npx vitest run test/unit` — **1299 files, 25347 tests passed**

Closes #9724
