### PR TITLE
fix(ci): regenerate workspace codegen even when the node_modules cache hits

### DIFF
--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -91,6 +91,31 @@ runs:
         echo "::error::npm ci failed after 3 attempts"
         exit 1
 
+    # UNCONDITIONAL -- this is the whole point, so read the `if:` above before adding one here.
+    #
+    # A cache HIT skips `npm ci`, and skipping `npm ci` skips every workspace's lifecycle scripts. The one
+    # that matters is `apps/loopover-ui`'s `postinstall: fumadocs-mdx`, which generates `.source/` -- the
+    # directory `tsconfig.json` maps `collections/*` onto. So on a cache hit the UI typechecked against
+    # modules that did not exist:
+    #
+    #   src/lib/docs-client-loader.tsx(1,32): error TS2307: Cannot find module 'collections/browser'
+    #   src/lib/docs-source.server.ts(1,22):  error TS2307: Cannot find module 'collections/server'
+    #
+    # This is the same shape as the `@eslint/js` hoist bug the cache step above documents: it reproduces on
+    # no developer machine, because a real `npm ci` always runs postinstall. It first bit when a lockfile
+    # change minted a fresh cache key -- the first run MISSED, installed, generated `.source`, passed, and
+    # saved; every run after that HIT and failed, so `main` went red four runs in a row while nothing in the
+    # tree had changed.
+    #
+    # REGENERATED, NOT CACHED. Adding `.source` to the cache paths would look like a smaller fix and would be
+    # wrong: the cache key is derived from the manifests and lockfile, while `.source` is derived from
+    # `source.config.ts` and `content/docs/**`. Caching it would serve a docs collection generated from
+    # different MDX than the commit under test -- a stale pass, which is worse than the honest failure. It is
+    # cheap to regenerate, so it is regenerated every time.
+    - name: Generate workspace codegen
+      shell: bash
+      run: npm run postinstall --workspace @loopover/ui
+
     # Placed immediately after install (not as an automatic post-job hook) so a cache is only ever
     # saved once npm ci has actually succeeded -- a job that fails here never reaches this step, so a
     # broken/partial node_modules can never get written to the cache for a future run to inherit.


### PR DESCRIPTION
## Unblocks `main` and every open PR

`main` has been red for four consecutive runs with nothing wrong in the tree, and every PR fails `validate-code` regardless of what it changes — including a **test-only** PR (#9972) that touches no UI file at all.

## Root cause

`setup-workspace` restores a `node_modules` cache and, on a hit, **skips `npm ci` entirely**. Skipping `npm ci` skips every workspace lifecycle script — and `apps/loopover-ui` has one that matters:

```json
"postinstall": "fumadocs-mdx"
```

That generates `.source/`, which is the directory `tsconfig.json` maps `collections/*` onto:

```json
"collections/*": ["./.source/*"]
```

`.source/` is gitignored and is **not** among the cached paths (`node_modules`, `apps/*/node_modules`, `packages/*/node_modules`). So on a cache hit the UI typechecks against modules that do not exist:

```
src/lib/docs-client-loader.tsx(1,32): error TS2307: Cannot find module 'collections/browser'
src/lib/docs-client-loader.tsx(17,24): error TS7031: Binding element 'MDXContent' implicitly has an 'any' type
src/lib/docs-source.server.ts(1,22): error TS2307: Cannot find module 'collections/server'
```

### Why it started when it did

The cache key includes the lockfile. A lockfile change mints a fresh key: the first run **misses**, installs, generates `.source`, passes, and saves the cache. Every run afterwards **hits** and fails. That is exactly the observed pattern — green through `507960134`, red from `40133d789` onward, with no relevant change in between.

This is the same shape as the `@eslint/js` hoist bug the cache step's own comment already documents:

> a failure that reproduces on no developer machine, because a real `npm ci` always creates those directories

## Reproduced, then confirmed fixed

Simulating the cache-hit state locally — `node_modules` intact, `.source` removed:

```
$ rm -rf apps/loopover-ui/.source && npm run ui:typecheck
error TS2307: Cannot find module 'collections/browser'
error TS7031: Binding element 'MDXContent' implicitly has an 'any' type
error TS2307: Cannot find module 'collections/server'

$ npm run postinstall --workspace @loopover/ui && npm run ui:typecheck
ui:typecheck PASSES after codegen
```

## Regenerated, not cached

Adding `.source` to the cache paths looks like the smaller fix and is the wrong one. The cache key derives from **manifests + lockfile**, while `.source` derives from **`source.config.ts` and `content/docs/**`**. A cached copy would serve a docs collection generated from different MDX than the commit under test — a stale pass, which is worse than an honest failure. It is cheap to regenerate, so it is regenerated every run.

The step is deliberately unconditional, with a comment saying so, because the obvious "optimisation" of gating it on the cache miss reintroduces the exact bug.

## Verification

- `actionlint` and `lint:composite-actions` green
- Failure reproduced and fix confirmed locally, as above
- Only `apps/loopover-ui` declares a lifecycle script (`postinstall`/`prepare`) across all workspaces and the root — checked, so this one step covers the whole tree today

Closes #9975
