### PR TITLE
queue(locks): register the actuation and contributor-cap locks in the shutdown held-lock registry

### DIFF
--- a/src/queue/transient-locks.ts
+++ b/src/queue/transient-locks.ts
@@ -20,6 +20,7 @@
 // delete a later claimer's live lock (#2129/#2135).
 
 import { randomUUID } from "node:crypto";
+import { registerHeldLock, unregisterHeldLock } from "./held-lock-registry";
 import { RetryableJobError } from "./retryable";
 
 /** Result of a transient-lock claim attempt. `ownerToken` is the random value THIS call wrote when it actually
@@ -212,11 +213,12 @@ export async function claimPrActuationLock(
   repoFullName: string,
   prNumber: number,
 ): Promise<TransientLockClaim> {
-  return claimTransientLock(
-    env,
-    prActuationLockKey(repoFullName, prNumber),
-    PR_ACTUATION_LOCK_TTL_SECONDS,
-  );
+  const key = prActuationLockKey(repoFullName, prNumber);
+  const claim = await claimTransientLock(env, key, PR_ACTUATION_LOCK_TTL_SECONDS);
+  if (claim.acquired && claim.ownerToken !== null) {
+    registerHeldLock(key, claim.ownerToken, () => releaseTransientLockIfOwner(env, key, claim.ownerToken));
+  }
+  return claim;
 }
 export async function releasePrActuationLock(
   env: Env,
@@ -224,7 +226,9 @@ export async function releasePrActuationLock(
   prNumber: number,
   ownerToken: string | null,
 ): Promise<void> {
-  await releaseTransientLockIfOwner(env, prActuationLockKey(repoFullName, prNumber), ownerToken);
+  const key = prActuationLockKey(repoFullName, prNumber);
+  await releaseTransientLockIfOwner(env, key, ownerToken);
+  if (ownerToken !== null) unregisterHeldLock(key, ownerToken);
 }
 
 // A plain thrown Error still reaches the queue's retry path (this call site is deliberately uncaught, same as
@@ -266,11 +270,12 @@ export async function claimContributorCapLock(
   repoFullName: string,
   authorLogin: string,
 ): Promise<TransientLockClaim> {
-  return claimTransientLock(
-    env,
-    contributorCapLockKey(repoFullName, authorLogin),
-    CONTRIBUTOR_CAP_LOCK_TTL_SECONDS,
-  );
+  const key = contributorCapLockKey(repoFullName, authorLogin);
+  const claim = await claimTransientLock(env, key, CONTRIBUTOR_CAP_LOCK_TTL_SECONDS);
+  if (claim.acquired && claim.ownerToken !== null) {
+    registerHeldLock(key, claim.ownerToken, () => releaseTransientLockIfOwner(env, key, claim.ownerToken));
+  }
+  return claim;
 }
 export async function releaseContributorCapLock(
   env: Env,
@@ -278,5 +283,7 @@ export async function releaseContributorCapLock(
   authorLogin: string,
   ownerToken: string | null,
 ): Promise<void> {
-  await releaseTransientLockIfOwner(env, contributorCapLockKey(repoFullName, authorLogin), ownerToken);
+  const key = contributorCapLockKey(repoFullName, authorLogin);
+  await releaseTransientLockIfOwner(env, key, ownerToken);
+  if (ownerToken !== null) unregisterHeldLock(key, ownerToken);
 }

--- a/test/unit/transient-locks.test.ts
+++ b/test/unit/transient-locks.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { heldLockCountForTest, releaseAllHeldLocksAtShutdown } from "../../src/queue/held-lock-registry";
 import { SubmissionLock } from "../../src/queue/submission-lock";
 import {
   claimContributorCapLock,
@@ -501,15 +502,18 @@ describe("domain wrappers + PrActuationLockContendedError (#8896)", () => {
     });
     delete env.SUBMISSION_LOCK;
 
-    await claimPrActuationLock(env, "acme/widgets", 7);
+    const prClaim = await claimPrActuationLock(env, "acme/widgets", 7);
     const [actuationTtl] = ttlCalls;
     ttlCalls.length = 0;
 
-    await claimContributorCapLock(env, "acme/widgets", "alice");
+    const capClaim = await claimContributorCapLock(env, "acme/widgets", "alice");
     const [capTtl] = ttlCalls;
 
     expect(capTtl).toBe(actuationTtl);
     expect(capTtl).toBe(600);
+
+    await releasePrActuationLock(env, "acme/widgets", 7, prClaim.ownerToken);
+    await releaseContributorCapLock(env, "acme/widgets", "alice", capClaim.ownerToken);
   });
 
   it("builds a fast-retry contended error with a distinct retryKind", () => {
@@ -839,5 +843,154 @@ describe("lock heartbeat end-to-end (#9467)", () => {
     beat.stop();
     await releaseTransientLockIfOwner(env, "lock:pr", held.ownerToken);
     expect((await claimTransientLock(env, "lock:pr", 60)).acquired).toBe(true);
+  });
+});
+
+// #10021: register actuation and contributor-cap locks in the shutdown held-lock registry (same shape as
+// claimAiReviewLock / releaseAiReviewLock in ai-review-orchestration.ts).
+describe("claimPrActuationLock / releasePrActuationLock register with the held-lock registry (#10021)", () => {
+  afterEach(async () => {
+    await releaseAllHeldLocksAtShutdown();
+  });
+
+  function cacheWithReleaseTracking() {
+    const releases: Array<{ key: string; value: string }> = [];
+    const held = new Map<string, string>();
+    const cache = {
+      get: async (key: string) => held.get(key) ?? null,
+      set: async () => undefined,
+      claim: async (key: string, value: string) => {
+        if (held.has(key)) return false;
+        held.set(key, value);
+        return true;
+      },
+      releaseIfValue: async (key: string, value: string) => {
+        releases.push({ key, value });
+        if (held.get(key) !== value) return false;
+        held.delete(key);
+        return true;
+      },
+    };
+    return { cache, releases };
+  }
+
+  it("registers a real claim, and shutdown release issues releaseIfValue for the pr-actuation-lock key", async () => {
+    const { cache, releases } = cacheWithReleaseTracking();
+    const env = createTestEnv({ SELFHOST_TRANSIENT_CACHE: cache });
+    delete env.SUBMISSION_LOCK;
+
+    const before = heldLockCountForTest();
+    const claim = await claimPrActuationLock(env, "acme/widgets", 7);
+    expect(claim.acquired).toBe(true);
+    expect(heldLockCountForTest()).toBe(before + 1);
+    expect(releases).toHaveLength(0);
+
+    expect(await releaseAllHeldLocksAtShutdown()).toBe(before + 1);
+    expect(releases).toEqual([
+      { key: "pr-actuation-lock:acme/widgets#7", value: claim.ownerToken },
+    ]);
+  });
+
+  it("unregisters on the normal release path with a matching owner token", async () => {
+    const env = createTestEnv();
+    const before = heldLockCountForTest();
+    const claim = await claimPrActuationLock(env, "acme/widgets", 8);
+    await releasePrActuationLock(env, "acme/widgets", 8, claim.ownerToken);
+    expect(heldLockCountForTest()).toBe(before);
+  });
+
+  it("does not register a fail-open claim — there is nothing real to release", async () => {
+    const env = createTestEnv();
+    delete (env as { SELFHOST_TRANSIENT_CACHE?: unknown }).SELFHOST_TRANSIENT_CACHE;
+    const before = heldLockCountForTest();
+    const claim = await claimPrActuationLock(env, "acme/widgets", 10);
+    expect(claim.ownerToken).toBeNull();
+    expect(heldLockCountForTest()).toBe(before);
+  });
+
+  it("a null-token release does not unregister a real held entry", async () => {
+    const env = createTestEnv();
+    const before = heldLockCountForTest();
+    await claimPrActuationLock(env, "acme/widgets", 11);
+    await releasePrActuationLock(env, "acme/widgets", 11, null);
+    expect(heldLockCountForTest()).toBe(before + 1);
+  });
+
+  it("#10021 releasePrActuationLock with a non-matching ownerToken does not evict the registry entry (#9468)", async () => {
+    const env = createTestEnv();
+    const before = heldLockCountForTest();
+    await claimPrActuationLock(env, "acme/widgets", 9);
+    expect(heldLockCountForTest()).toBe(before + 1);
+    await releasePrActuationLock(env, "acme/widgets", 9, "tok-someone-else");
+    expect(heldLockCountForTest()).toBe(before + 1);
+  });
+});
+
+describe("claimContributorCapLock / releaseContributorCapLock register with the held-lock registry (#10021)", () => {
+  afterEach(async () => {
+    await releaseAllHeldLocksAtShutdown();
+  });
+
+  function cacheWithReleaseTracking() {
+    const releases: Array<{ key: string; value: string }> = [];
+    const held = new Map<string, string>();
+    const cache = {
+      get: async (key: string) => held.get(key) ?? null,
+      set: async () => undefined,
+      claim: async (key: string, value: string) => {
+        if (held.has(key)) return false;
+        held.set(key, value);
+        return true;
+      },
+      releaseIfValue: async (key: string, value: string) => {
+        releases.push({ key, value });
+        if (held.get(key) !== value) return false;
+        held.delete(key);
+        return true;
+      },
+    };
+    return { cache, releases };
+  }
+
+  it("registers a real claim, and shutdown release issues releaseIfValue for the contributor-cap-lock key", async () => {
+    const { cache, releases } = cacheWithReleaseTracking();
+    const env = createTestEnv({ SELFHOST_TRANSIENT_CACHE: cache });
+    delete env.SUBMISSION_LOCK;
+
+    const before = heldLockCountForTest();
+    const claim = await claimContributorCapLock(env, "Acme/Widgets", "Alice");
+    expect(claim.acquired).toBe(true);
+    expect(heldLockCountForTest()).toBe(before + 1);
+    expect(releases).toHaveLength(0);
+
+    expect(await releaseAllHeldLocksAtShutdown()).toBe(before + 1);
+    expect(releases).toEqual([
+      { key: "contributor-cap-lock:acme/widgets:alice", value: claim.ownerToken },
+    ]);
+  });
+
+  it("unregisters on the normal release path with a matching owner token", async () => {
+    const env = createTestEnv();
+    const before = heldLockCountForTest();
+    const claim = await claimContributorCapLock(env, "acme/widgets", "bob");
+    await releaseContributorCapLock(env, "acme/widgets", "bob", claim.ownerToken);
+    expect(heldLockCountForTest()).toBe(before);
+  });
+
+  it("does not register a fail-open claim — there is nothing real to release", async () => {
+    const env = createTestEnv();
+    delete (env as { SELFHOST_TRANSIENT_CACHE?: unknown }).SELFHOST_TRANSIENT_CACHE;
+    const before = heldLockCountForTest();
+    const claim = await claimContributorCapLock(env, "acme/widgets", "dave");
+    expect(claim.ownerToken).toBeNull();
+    expect(heldLockCountForTest()).toBe(before);
+  });
+
+  it("a null-token release does not unregister a real held entry", async () => {
+    const env = createTestEnv();
+    const before = heldLockCountForTest();
+    await claimContributorCapLock(env, "acme/widgets", "carol");
+    await releaseContributorCapLock(env, "acme/widgets", "carol", null);
+    expect(heldLockCountForTest()).toBe(before + 1);
   });
 });


### PR DESCRIPTION
## Summary

`src/queue/held-lock-registry.ts` exists so a shutdown signal can release **every** transient lock this
process holds instead of letting each ride out its TTL. Its module doc
(`src/queue/held-lock-registry.ts:14-19`) states the goal:

```
 * This is the proactive half: a tiny process-local registry of "locks I currently hold and how to release
 * them", so the shutdown handler can best-effort release every one of them immediately on SIGTERM/SIGINT --
 * before, and independent of, whether the graceful drain itself has time to finish.
```

`registerHeldLock` has exactly **one** production call site: `claimAiReviewLock`
(`src/queue/ai-review-orchestration.ts:135-138`). A repo-wide grep for `registerHeldLock` outside
`src/queue/held-lock-registry.ts` returns only that line plus `test/unit/held-lock-registry.test.ts`.

The two other locks built on the same primitive are never registered:

- `claimPrActuationLock` (`src/queue/transient-locks.ts:210-220`), TTL `PR_ACTUATION_LOCK_TTL_SECONDS = 600`
  (`src/queue/transient-locks.ts:203`). Claimed at `src/queue/processors.ts:4420` and, through
  `withPrActuationLock`, by all five close-enforcement guards (`src/queue/review-evasion.ts:74-89`).
- `claimContributorCapLock` (`src/queue/transient-locks.ts:264-274`), TTL 600 seconds
  (`src/queue/transient-locks.ts:260`).

So `releaseAllHeldLocksAtShutdown()` at `src/server.ts:1590` — including the `LOOPOVER_SHUTDOWN_LOCK_RELEASE_AFTER_MS`
cut-short-drain path added by #9468 (`src/server.ts:1579-1587`) — can only ever release `ai-review-lock` keys.
A hard kill during a publish-and-maintain pass strands the PR's actuation lock for its full 600 seconds.

The boot-time flush is not a backstop for this. `src/server.ts:773-786` runs
`flushOrphanedLocksAtBoot` **only** when `isSingleInstanceDeployment(process.env)` is true
(`LOOPOVER_SINGLE_INSTANCE`), because on a shared-Redis multi-replica deployment the flush would delete a
sibling's live locks — the explicit #9468 reasoning at `src/server.ts:765-771`. On any deployment that does
not set that var (the default), the shutdown registry is the only proactive release path, and it covers one
of the three lock namespaces.

The concrete cost is documented in this repo: `src/queue/retryable.ts:44-50` records that "the only jobs in
the dead-letter queue over a 7-day window were three actuation-lock contentions, one of which was a
`reopen-reclose` -- a policy enforcement with a single webhook-gated trigger and no reconciler, so that
enforcement was lost outright." A waiter on an orphaned actuation lock is bounded by
`ATTEMPT_FREE_RETRY_DEADLINE_MS = 15 minutes` (`src/queue/retryable.ts:66`), so a 600-second orphaned lock
consumes two-thirds of that budget before the waiter can make any progress.

## Deliverables

- [ ] `claimPrActuationLock` registers the held lock on a real acquire; `releasePrActuationLock` unregisters
      it token-scoped.
- [ ] `claimContributorCapLock` registers the held lock on a real acquire; `releaseContributorCapLock`
      unregisters it token-scoped.
- [ ] A test in `test/unit/transient-locks.test.ts` asserting that after a successful
      `claimPrActuationLock` against a cache adapter with a working `claim`/`releaseIfValue`,
      `heldLockCountForTest()` increases by exactly 1, and that `releaseAllHeldLocksAtShutdown()` then issues
      a `releaseIfValue` for the `pr-actuation-lock:` key.
- [ ] The same assertion for `claimContributorCapLock` / the `contributor-cap-lock:` key in
      `test/unit/transient-locks.test.ts`.
- [ ] A test asserting that a FAIL-OPEN `claimPrActuationLock` (adapter with no `claim` primitive, so
      `ownerToken` is `null`) leaves `heldLockCountForTest()` unchanged.
- [ ] A regression test at `test/unit/transient-locks.test.ts` named for this bug asserting that
      `releasePrActuationLock` with a DIFFERENT `ownerToken` than the one registered does not remove the
      registry entry (the #9468 steal invariant, now applied to this lock too).

All Deliverables above are required in a single PR. A PR that satisfies only some of them — for example
registering the actuation lock but not unregistering it on release, so the registry grows unboundedly across a
long-lived process and shutdown issues deletes against keys already handed to other passes — does not resolve
this issue.

## Test plan

This repo enforces 99%+ Codecov patch coverage, **branch-counted**. `vitest.config.ts`'s `coverage.include`
covers `src/**/*.ts`, so `src/queue/transient-locks.ts` is measured and gated. Each added guard is a branch
with two real arms that both need a test: `claim.acquired && claim.ownerToken !== null` (register) vs the
fail-open claim (do not register), and `ownerToken !== null` (unregister) vs `null` (do not). Four new branch
arms across the two claim/release pairs, eight in total.

Fixes #10021