### PR TITLE
fix(engine): stop parseAmsPolicySpec aliasing the frozen DEFAULT_AMS_POLICY_SPEC sub-objects

### DIFF
--- a/packages/loopover-engine/src/ams-policy-spec.ts
+++ b/packages/loopover-engine/src/ams-policy-spec.ts
@@ -208,10 +208,13 @@ function normalizeNonNegativeInteger(value: unknown, field: string, fallback: nu
 }
 
 function normalizeCapLimits(value: unknown, fallback: AmsCapLimits, warnings: string[]): AmsCapLimits {
-  if (value === undefined || value === null) return fallback;
+  // Fresh copy on the fallback paths too (same reasoning as normalizeNetworkAllowlist): `fallback` is the
+  // deep-frozen DEFAULT_AMS_POLICY_SPEC.capLimits, so returning it by reference would alias the shared
+  // singleton into a caller's parsed spec.
+  if (value === undefined || value === null) return { ...fallback };
   if (typeof value !== "object" || Array.isArray(value)) {
     warnings.push('AmsPolicySpec field "capLimits" must be a mapping; falling back to defaults.');
-    return fallback;
+    return { ...fallback };
   }
   const record = value as Record<string, unknown>;
   return {
@@ -226,10 +229,12 @@ function normalizeConvergenceThresholds(
   fallback: PortfolioConvergenceThresholds,
   warnings: string[],
 ): PortfolioConvergenceThresholds {
-  if (value === undefined || value === null) return fallback;
+  // Fresh copy on the fallback paths too: `fallback` is the deep-frozen
+  // DEFAULT_AMS_POLICY_SPEC.convergenceThresholds, so returning it by reference would alias the shared singleton.
+  if (value === undefined || value === null) return { ...fallback };
   if (typeof value !== "object" || Array.isArray(value)) {
     warnings.push('AmsPolicySpec field "convergenceThresholds" must be a mapping; falling back to defaults.');
-    return fallback;
+    return { ...fallback };
   }
   const record = value as Record<string, unknown>;
   return {

--- a/packages/loopover-engine/test/ams-policy-spec-parser.test.ts
+++ b/packages/loopover-engine/test/ams-policy-spec-parser.test.ts
@@ -189,3 +189,45 @@ test("parseAmsPolicySpecContent: JSON and YAML both parse, malformed content deg
   assert.equal(oversized.present, false);
   assert.match(oversized.warnings.join(" "), /exceeded/i);
 });
+
+test("REGRESSION (#9995): parsed capLimits/convergenceThresholds are fresh copies, never aliased to the frozen DEFAULT singleton", () => {
+  const parsed = parseAmsPolicySpec({ submissionMode: "enforce" }).spec;
+  // VALUES are unchanged...
+  assert.deepEqual(parsed.capLimits, DEFAULT_AMS_POLICY_SPEC.capLimits);
+  assert.deepEqual(parsed.convergenceThresholds, DEFAULT_AMS_POLICY_SPEC.convergenceThresholds);
+  // ...but the objects are distinct, not the shared frozen singleton returned by reference.
+  assert.notStrictEqual(parsed.capLimits, DEFAULT_AMS_POLICY_SPEC.capLimits);
+  assert.notStrictEqual(parsed.convergenceThresholds, DEFAULT_AMS_POLICY_SPEC.convergenceThresholds);
+  // The returned sub-objects are writable, and mutating them cannot corrupt the shared DEFAULT.
+  assert.equal(Object.isFrozen(parsed.capLimits), false);
+  assert.equal(Object.isFrozen(parsed.convergenceThresholds), false);
+  parsed.capLimits.budget = 999;
+  parsed.convergenceThresholds.maxReenqueues = 999;
+  assert.notEqual(DEFAULT_AMS_POLICY_SPEC.capLimits.budget, 999);
+  assert.notEqual(DEFAULT_AMS_POLICY_SPEC.convergenceThresholds.maxReenqueues, 999);
+});
+
+test("REGRESSION (#9995): the not-a-mapping fallback paths also return fresh, non-aliased copies", () => {
+  const parsed = parseAmsPolicySpec({ capLimits: "nope", convergenceThresholds: [] }).spec;
+  assert.deepEqual(parsed.capLimits, DEFAULT_AMS_POLICY_SPEC.capLimits);
+  assert.deepEqual(parsed.convergenceThresholds, DEFAULT_AMS_POLICY_SPEC.convergenceThresholds);
+  assert.notStrictEqual(parsed.capLimits, DEFAULT_AMS_POLICY_SPEC.capLimits);
+  assert.notStrictEqual(parsed.convergenceThresholds, DEFAULT_AMS_POLICY_SPEC.convergenceThresholds);
+
+  // With ANOTHER field configured (so the parser returns the normalized spec rather than the all-defaults
+  // clone), the not-a-mapping fallback is the path that actually reaches the caller — it must be fresh too.
+  const configured = parseAmsPolicySpec({ submissionMode: "enforce", capLimits: "nope", convergenceThresholds: [] }).spec;
+  assert.deepEqual(configured.capLimits, DEFAULT_AMS_POLICY_SPEC.capLimits);
+  assert.deepEqual(configured.convergenceThresholds, DEFAULT_AMS_POLICY_SPEC.convergenceThresholds);
+  assert.notStrictEqual(configured.capLimits, DEFAULT_AMS_POLICY_SPEC.capLimits);
+  assert.notStrictEqual(configured.convergenceThresholds, DEFAULT_AMS_POLICY_SPEC.convergenceThresholds);
+  assert.equal(Object.isFrozen(configured.capLimits), false);
+});
+
+test("DEFAULT_AMS_POLICY_SPEC and its three sub-objects remain deep-frozen after parsing (#9995)", () => {
+  parseAmsPolicySpec({ submissionMode: "enforce" });
+  assert.equal(Object.isFrozen(DEFAULT_AMS_POLICY_SPEC), true);
+  assert.equal(Object.isFrozen(DEFAULT_AMS_POLICY_SPEC.capLimits), true);
+  assert.equal(Object.isFrozen(DEFAULT_AMS_POLICY_SPEC.convergenceThresholds), true);
+  assert.equal(Object.isFrozen(DEFAULT_AMS_POLICY_SPEC.networkAllowlist), true);
+});


### PR DESCRIPTION
## Summary

`DEFAULT_AMS_POLICY_SPEC` (`packages/loopover-engine/src/ams-policy-spec.ts`) is a deep-frozen shared singleton, and its own doc says "clone before layering overrides on top." But `normalizeCapLimits` and `normalizeConvergenceThresholds` returned their `fallback` — which `parseAmsPolicySpec` passes as `DEFAULT_AMS_POLICY_SPEC.capLimits` / `.convergenceThresholds` — **by reference** on the `undefined`/`null` and not-a-mapping paths (only the valid-mapping path built a fresh object).

So a parsed spec that carries at least one configured field (and therefore returns the normalized spec at line 389, not the all-defaults `cloneDefaultAmsPolicySpec()` at line 387) aliased the frozen singleton's sub-objects into a caller's mutable `spec` — the exact hazard the singleton's doc warns about.

## Fix

Return `{ ...fallback }` on both fallback paths of each normalizer (a shallow copy fully de-aliases since every field is a primitive), mirroring how `normalizeNetworkAllowlist` / `normalizeEcosystemList` already copy their fallback on every return path. No production values change; `DEFAULT_AMS_POLICY_SPEC` and its sub-objects stay frozen.

## Tests

Added to `packages/loopover-engine/test/ams-policy-spec-parser.test.ts`:
- Parsed `capLimits`/`convergenceThresholds` are `deepEqual` to the defaults but `notStrictEqual` (distinct objects), are not frozen, and mutating them cannot corrupt `DEFAULT_AMS_POLICY_SPEC`.
- The not-a-mapping paths (`{ capLimits: "nope", convergenceThresholds: [] }`, and the configured-field variant that actually returns the normalized spec) also yield fresh, non-aliased copies.
- `DEFAULT_AMS_POLICY_SPEC` and all three of its sub-objects remain `Object.isFrozen`.

The two regression tests fail against the current by-reference code; the existing value assertions pass unchanged. Engine-flag coverage of the four changed lines verified (source-mapped lcov).

Closes #9995