### PR TITLE
fix(github): guard the NaN expiry in mintInstallationToken

### DIFF
--- a/src/github/app.ts
+++ b/src/github/app.ts
@@ -361,9 +361,11 @@ async function mintInstallationToken(
     throw new Error(
       "GitHub installation token response did not include a token.",
     );
-  const expiresAtMs = payload.expires_at
-    ? Date.parse(payload.expires_at)
-    : Date.now() + 50 * 60_000;
+  // A present-but-UNPARSEABLE expires_at must fall back like an absent one (#10026): Date.parse returns NaN for
+  // a malformed string, and a NaN expiry makes `expiresAtMs - MARGIN > Date.now()` forever false — silently
+  // disabling the cache so every job re-mints and re-triggers the thundering-herd this cache exists to prevent.
+  const parsedExpiry = payload.expires_at ? Date.parse(payload.expires_at) : Number.NaN;
+  const expiresAtMs = Number.isFinite(parsedExpiry) ? parsedExpiry : Date.now() + 50 * 60_000;
   await writeCachedToken(installationId, { token: payload.token, expiresAtMs });
   return payload.token;
 }

--- a/test/unit/github-app.test.ts
+++ b/test/unit/github-app.test.ts
@@ -200,6 +200,47 @@ describe("GitHub check runs", () => {
     expect(mints).toBe(1);
   });
 
+  it("REGRESSION: an unparseable expires_at must not disable the installation-token cache (#10026)", async () => {
+    const privateKey = await generatePrivateKeyPem();
+    let mints = 0;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) {
+        mints += 1;
+        return Response.json({ token: `installation-token-${mints}`, expires_at: "not-a-date" }); // present but unparseable
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey });
+    const first = await createInstallationToken(env, 777);
+    const second = await createInstallationToken(env, 777);
+    // The NaN expiry used to make every cache comparison false, re-minting on every call. With the finite
+    // fallback the entry is honored: exactly one mint, the same token reused.
+    expect(first).toBe("installation-token-1");
+    expect(second).toBe("installation-token-1");
+    expect(mints).toBe(1); // NOT re-minted
+  });
+
+  it("a well-formed expires_at is unchanged: token reused on the second call (#10026)", async () => {
+    const privateKey = await generatePrivateKeyPem();
+    let mints = 0;
+    const expiresAt = "2030-01-01T00:00:00Z";
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) {
+        mints += 1;
+        return Response.json({ token: `installation-token-${mints}`, expires_at: expiresAt });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey });
+    expect(await createInstallationToken(env, 888)).toBe("installation-token-1");
+    expect(await createInstallationToken(env, 888)).toBe("installation-token-1");
+    expect(mints).toBe(1); // cached against the far-future, well-formed expiry
+  });
+
   it("(#3811) samples clock skew from the installation-token mint response's Date header", async () => {
     const privateKey = await generatePrivateKeyPem();
     vi.useFakeTimers();


### PR DESCRIPTION
## What & why

`mintInstallationToken`'s local App-JWT path parsed GitHub's `expires_at` straight into the cache entry with no finiteness check:

```ts
const expiresAtMs = payload.expires_at ? Date.parse(payload.expires_at) : Date.now() + 50 * 60_000;
```

`Date.parse` returns **NaN** for a present-but-unparseable string, and a NaN `expiresAtMs` makes the cache-freshness comparison `expiresAtMs - TOKEN_SAFETY_MARGIN_MS > Date.now()` **forever false**. So a single malformed `expires_at` silently disables the installation-token cache: every job re-mints, re-triggering exactly the thundering-herd (and the GitHub secondary-rate-limit on the token endpoint) the cache exists to prevent.

## The fix

Treat an unparseable `expires_at` identically to an absent one — fall back to `Date.now() + 50 * 60_000`:

```ts
const parsedExpiry = payload.expires_at ? Date.parse(payload.expires_at) : Number.NaN;
const expiresAtMs = Number.isFinite(parsedExpiry) ? parsedExpiry : Date.now() + 50 * 60_000;
```

- Well-formed `expires_at` → still exactly `Date.parse(payload.expires_at)` (byte-identical).
- Absent `expires_at` → still the `Date.now() + 50 * 60_000` fallback.
- Unparseable `expires_at` → now the same finite fallback instead of NaN.

No cache-lifetime constant changes (`TOKEN_SAFETY_MARGIN_MS`, the 50-minute fallback, all unchanged).

## Tests (`test/unit/github-app.test.ts`)

- **Regression** (named for the bug): after a mint whose `expires_at` is unparseable, a second `createInstallationToken` for the same installation issues **no** further `/access_tokens` request — asserted by the **mint-call count** (`mints === 1`), not just the token string (**fails on `main`**, which re-mints).
- Well-formed `expires_at`: the cached token is reused on the second call (mint count 1) — unchanged behaviour.

## Validation

- `npm run typecheck` clean for this file (the only local errors are a pre-existing missing-`release-please`-dep phantom in unrelated release-tooling, present on bare `main`); the github-app suite green.
- Diff coverage on `src/github/app.ts` is 100% (both `Number.isFinite` arms and both `expires_at?` arms).
- `git diff --check <base> HEAD` clean; single-file source change + its test.

Closes #10026
