### PR TITLE
fix(settings): read the two remaining LOOPOVER_* flags via the codebase truthy convention

### DIFF
--- a/src/rules/advisory.ts
+++ b/src/rules/advisory.ts
@@ -376,7 +376,8 @@ export function buildPullRequestAdvisory(
     /** Duplicate-winner adjudication (#dup-winner). When true AND this PR is the cluster winner (the lowest
      *  open sibling number), the `duplicate_pr_risk` finding is suppressed so the winner is not gate-blocked /
      *  closed as a duplicate. Default/false ⇒ every duplicate sibling keeps the finding (byte-identical). The
-     *  caller sets this to `env.LOOPOVER_DUPLICATE_WINNER === "true"`. */
+     *  caller resolves this via `isDuplicateWinnerEnabledGlobally` (settings/duplicate-winner-mode.ts), which
+     *  applies the codebase truthy convention rather than a raw string comparison. */
     duplicateWinnerEnabled?: boolean;
     /** Author logins of the linked issues (one entry per resolved issue, may be null when unknown). Used to
      *  surface a `self_authored_linked_issue` finding when the PR author also opened the linked issue. Absent

--- a/src/settings/duplicate-winner-mode.ts
+++ b/src/settings/duplicate-winner-mode.ts
@@ -1,11 +1,13 @@
 export type DuplicateWinnerMode = "inherit" | "off" | "enabled";
 
-/** Truthy convention matches the rest of this codebase's `LOOPOVER_*` flags (exact `"true"` string, e.g. the
- *  raw checks this replaces) -- unlike `isSkipAutomationBotPullRequestsEnabledGlobally` (default ON, inverted
- *  truthy match), this flag is opt-in and default OFF: sparing a duplicate cluster's earliest claimant is a
- *  real behavior change to the close disposition, not a low-risk waste-elimination default. */
+/** Truthy convention matches the rest of this codebase's `LOOPOVER_*` flags (`/^(1|true|yes|on)$/i`,
+ *  trimmed + case-insensitive, e.g. `selfTuneFlagOn`/`isReputationEnabled`) -- so `1`, `on`, `TRUE`, and a
+ *  `.env` value carrying trailing whitespace all read as truthy, not silently as OFF. Unlike
+ *  `isSkipAutomationBotPullRequestsEnabledGlobally` (default ON, inverted truthy match), this flag is opt-in
+ *  and default OFF: sparing a duplicate cluster's earliest claimant is a real behavior change to the close
+ *  disposition, not a low-risk waste-elimination default. */
 export function isDuplicateWinnerEnabledGlobally(env: { LOOPOVER_DUPLICATE_WINNER?: string | undefined }): boolean {
-  return env.LOOPOVER_DUPLICATE_WINNER === "true";
+  return /^(1|true|yes|on)$/i.test((env.LOOPOVER_DUPLICATE_WINNER ?? "").trim());
 }
 
 /** Per-repo override resolved against the global default. Mirrors `resolveSkipAutomationBotPullRequests`'s

--- a/src/settings/open-pr-file-collision-mode.ts
+++ b/src/settings/open-pr-file-collision-mode.ts
@@ -1,11 +1,13 @@
 export type OpenPrFileCollisionMode = "inherit" | "off" | "enabled";
 
-/** Truthy convention matches the rest of this codebase's `LOOPOVER_*` flags (exact `"true"` string) -- opt-in
- *  and default OFF: the enrichment call this gates costs an extra GitHub API round-trip per open PR
+/** Truthy convention matches the rest of this codebase's `LOOPOVER_*` flags (`/^(1|true|yes|on)$/i`, trimmed
+ *  + case-insensitive, e.g. `selfTuneFlagOn`/`isReputationEnabled`) -- so `1`, `on`, `TRUE`, and a `.env`
+ *  value carrying trailing whitespace all read as truthy, not silently as OFF. Opt-in and default OFF: the
+ *  enrichment call this gates costs an extra GitHub API round-trip per open PR
  *  (enrichOpenPullRequestsWithChangedFiles), so an operator should deliberately turn it on rather than pay
  *  that cost by default. */
 export function isOpenPrFileCollisionEnabledGlobally(env: { LOOPOVER_OPEN_PR_FILE_COLLISION?: string | undefined }): boolean {
-  return env.LOOPOVER_OPEN_PR_FILE_COLLISION === "true";
+  return /^(1|true|yes|on)$/i.test((env.LOOPOVER_OPEN_PR_FILE_COLLISION ?? "").trim());
 }
 
 /** Per-repo override resolved against the global default. Mirrors `resolveDuplicateWinnerEnabled`'s

--- a/test/unit/duplicate-winner-mode.test.ts
+++ b/test/unit/duplicate-winner-mode.test.ts
@@ -8,14 +8,25 @@ describe("isDuplicateWinnerEnabledGlobally", () => {
     expect(isDuplicateWinnerEnabledGlobally({ LOOPOVER_DUPLICATE_WINNER: "" })).toBe(false);
   });
 
-  it("is ON only for the exact string \"true\"", () => {
-    expect(isDuplicateWinnerEnabledGlobally({ LOOPOVER_DUPLICATE_WINNER: "true" })).toBe(true);
+  it("is ON for every value the codebase truthy convention accepts (#10054)", () => {
+    // Was `=== "true"` only, which silently read `1` / `on` / `TRUE` / a whitespace-padded `.env` value as
+    // OFF. It now mirrors selfTuneFlagOn's `/^(1|true|yes|on)$/i.test((X ?? "").trim())`, trimmed + i-flag.
+    for (const value of ["1", "true", "TRUE", "yes", "on", " true "]) {
+      expect(isDuplicateWinnerEnabledGlobally({ LOOPOVER_DUPLICATE_WINNER: value }), value).toBe(true);
+    }
   });
 
-  it("stays OFF for any other value, including truthy-looking ones", () => {
-    for (const value of ["1", "yes", "on", "True", "TRUE", " true "]) {
-      expect(isDuplicateWinnerEnabledGlobally({ LOOPOVER_DUPLICATE_WINNER: value })).toBe(false);
+  it("stays OFF for a falsy or unrecognised value", () => {
+    for (const value of ["0", "false", "off", "no", "maybe"]) {
+      expect(isDuplicateWinnerEnabledGlobally({ LOOPOVER_DUPLICATE_WINNER: value }), value).toBe(false);
     }
+  });
+
+  it("the =1 form an operator naturally writes actually enables the feature through the resolver (#10054)", () => {
+    // The end-to-end regression: `1` is the value the convention regex accepts first and env.d.ts publishes
+    // for a sibling flag, but under `=== "true"` it read OFF -- so a repo on `inherit` stayed off even after
+    // the operator set it. The fix must carry all the way through resolveDuplicateWinnerEnabled.
+    expect(resolveDuplicateWinnerEnabled(isDuplicateWinnerEnabledGlobally({ LOOPOVER_DUPLICATE_WINNER: "1" }), "inherit")).toBe(true);
   });
 });
 

--- a/test/unit/open-pr-file-collision-mode.test.ts
+++ b/test/unit/open-pr-file-collision-mode.test.ts
@@ -8,13 +8,17 @@ describe("isOpenPrFileCollisionEnabledGlobally", () => {
     expect(isOpenPrFileCollisionEnabledGlobally({ LOOPOVER_OPEN_PR_FILE_COLLISION: "" })).toBe(false);
   });
 
-  it("is ON only for the exact string \"true\"", () => {
-    expect(isOpenPrFileCollisionEnabledGlobally({ LOOPOVER_OPEN_PR_FILE_COLLISION: "true" })).toBe(true);
+  it("is ON for every value the codebase truthy convention accepts (#10054)", () => {
+    // Was `=== "true"` only, which silently read `1` / `on` / `TRUE` / a whitespace-padded `.env` value as
+    // OFF. It now mirrors selfTuneFlagOn's `/^(1|true|yes|on)$/i.test((X ?? "").trim())`, trimmed + i-flag.
+    for (const value of ["1", "true", "TRUE", "yes", "on", " true "]) {
+      expect(isOpenPrFileCollisionEnabledGlobally({ LOOPOVER_OPEN_PR_FILE_COLLISION: value }), value).toBe(true);
+    }
   });
 
-  it("stays OFF for any other value, including truthy-looking ones", () => {
-    for (const value of ["1", "yes", "on", "True", "TRUE", " true "]) {
-      expect(isOpenPrFileCollisionEnabledGlobally({ LOOPOVER_OPEN_PR_FILE_COLLISION: value })).toBe(false);
+  it("stays OFF for a falsy or unrecognised value", () => {
+    for (const value of ["0", "false", "off", "no", "maybe"]) {
+      expect(isOpenPrFileCollisionEnabledGlobally({ LOOPOVER_OPEN_PR_FILE_COLLISION: value }), value).toBe(false);
     }
   });
 });


### PR DESCRIPTION
## What & why

This codebase has one documented truthy convention for a `LOOPOVER_*` boolean env flag — trimmed, case-insensitive `/^(1|true|yes|on)$/i` — used by ~12 flag readers and documented in `src/env.d.ts` for a sibling flag. Two flags did not follow it, yet each asserted in its own JSDoc that its `=== "true"` form **was** the convention:

```ts
// src/settings/duplicate-winner-mode.ts
export function isDuplicateWinnerEnabledGlobally(env) {
  return env.LOOPOVER_DUPLICATE_WINNER === "true";
}
```

So `LOOPOVER_DUPLICATE_WINNER=1` — the value the convention regex accepts first, and the form `env.d.ts` publishes as valid for a sibling flag — read as **OFF**. A `TRUE` spelling, or a `.env` value with trailing whitespace (routine in Docker/compose), also read as OFF, with **no warning**: the flag simply behaved as unset. The observable effect is a silent policy difference (every duplicate sibling closed instead of the earliest claimant spared) that an operator who set `=1` has no signal for.

## The fix

Route both through the exact convention, byte-identical in shape to `selfTuneFlagOn` (`src/settings/repository-settings.ts:12`):

```ts
return /^(1|true|yes|on)$/i.test((env.LOOPOVER_DUPLICATE_WINNER ?? "").trim());
```

- Both JSDoc blocks now name `/^(1|true|yes|on)$/i` as the convention (as `automation-bot-skip.ts` does) instead of claiming exact-`"true"` is it.
- `src/rules/advisory.ts`'s third restatement now names `isDuplicateWinnerEnabledGlobally` as the resolver rather than re-teaching the raw comparison.
- **Unchanged:** this only *widens* the accepted truthy set. `"true"` still enables; unset/empty still disables; `resolveDuplicateWinnerEnabled` / `resolveOpenPrFileCollisionEnabled`'s `inherit`/`off`/`enabled` resolution and the already-`"true"` `wrangler.jsonc` values keep their exact current behaviour. No new shared helper is introduced and the ~12 convention-following call sites are untouched (out of scope, per the issue).

## Tests

- `isDuplicateWinnerEnabledGlobally` and `isOpenPrFileCollisionEnabledGlobally` each return `true` for `"1"`, `"true"`, `"TRUE"`, `"yes"`, `"on"`, `" true "` and `false` for `undefined`, `""`, `"0"`, `"false"`, `"off"`, `"no"`, `"maybe"` — the old "ON only for exact `true`" / "OFF for truthy-looking values" tests are replaced (they **fail on `main`** with the new convention).
- **Regression (#10054):** `resolveDuplicateWinnerEnabled(isDuplicateWinnerEnabledGlobally({ LOOPOVER_DUPLICATE_WINNER: "1" }), "inherit")` is `true` — the `=1` form enables the feature end-to-end through the resolver, not just the global reader.

## Validation

- Both changed predicate files are at **100%** diff coverage line and branch (the new `?? ""` nullish arm is exercised on both the absent and present sides); `advisory.ts` is a JSDoc-only edit.
- `npm run typecheck` clean for these files (the only local errors are a pre-existing missing-`release-please`-dep phantom in unrelated release tooling, present on bare `main`).
- `git diff --check` clean; no schema/route/env-reference/wrangler change, so no generated artifact is affected.

Closes #10054
