### PR TITLE
fix(ci): unbreak main — drop the orphaned AUTOMATION_COUNTED_ACTIONS export

### DIFF
--- a/src/review/automation-rate.ts
+++ b/src/review/automation-rate.ts
@@ -47,12 +47,13 @@ export const AUTOMATION_RATE_PROVENANCE_HORIZON_ISO = "2026-07-29T00:00:00.000Z"
 const AUTOMATION_ENACTING_ACTIONS = ["merge", "close"] as const;
 
 /** The action recording that the gate declined to decide and handed the PR to a person. Module-private for
- *  the same reason as the set above. */
+ *  the same reason as the set above.
+ *
+ *  Together with the enacting set, this is what DECIDES a PR -- the published set the fold keys `decided` on.
+ *  There is deliberately no exported union of the two: #10013 removed the `action IN (...)` SQL filter that
+ *  was its only consumer, and an exported constant naming a set nothing selects on invites a reader to
+ *  believe the read still restricts by it. The fold tests each half directly instead. */
 const AUTOMATION_HOLD_ACTION = "hold";
-
-/** Every action that DECIDES a PR -- an enacted decision, or a hold. This is the published set the fold
- *  keys `decided` on; the read no longer restricts by it (#10013), so it does not gate what rows are seen. */
-export const AUTOMATION_COUNTED_ACTIONS: readonly string[] = [...AUTOMATION_ENACTING_ACTIONS, AUTOMATION_HOLD_ACTION];
 
 /** How completely a week could be measured. `full` weeks see every manual signal; `holds_only` weeks predate
  *  the provenance fields and can only under-count manual work. */


### PR DESCRIPTION
Closes #10109

`dead-exports:check` — part of `test:ci` — is red on a clean `main`, so **every open PR inherits the failure** and none can go green. Same class of breakage as #9944.

## What was wrong

`AUTOMATION_COUNTED_ACTIONS` existed for exactly one consumer: the `action IN (...)` restriction in `queryAutomationRows`. #10013 removed that filter on purpose — the read now selects every verdict in the window, because a human signal (`reevaluation_actor`, `reevaluation_reason = 'maintainer_request'`) can ride a **non-deciding** verdict such as a `label` or an `update_branch`, and the old filter dropped those rows so a PR a human had actually touched read as automated.

The fold still classifies `enacted` / `held`, but it tests `AUTOMATION_ENACTING_ACTIONS` and `AUTOMATION_HOLD_ACTION` **separately** — it needs to know which half matched, so the union is of no use to it. The symbol has had no reference of any kind since #10013; #10089 touched the file without re-homing it.

## The change

Delete the export. Its one piece of real documentation — *these two sets together are what DECIDES a PR* — moves onto `AUTOMATION_HOLD_ACTION`, together with the reason there is deliberately no exported union: a constant naming a set nothing selects on invites the reader to believe the read still restricts by it, which is the exact misreading #10013 existed to correct. Leaving that unsaid is how the symbol would get reintroduced.

## Verification

- `npm run dead-exports:check` → `no exported symbol is unreferenced outside its own file`
- `npm run typecheck` clean
- `test/unit/automation-rate.test.ts` — 25 passed, **file untouched**. That is the evidence the symbol was load-bearing for nothing: no test needed adjusting, because no behaviour changed.

Zero runtime diff — the deleted line is a `const` no code path read.
