### PR TITLE
fix(ui-kit): expose PaginationEllipsis More pages outside aria-hidden

### DIFF
--- a/packages/loopover-ui-kit/src/components/pagination.test.tsx
+++ b/packages/loopover-ui-kit/src/components/pagination.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import {
+  PaginationEllipsis,
   PaginationLink,
   PaginationNext,
   PaginationPrevious,
@@ -45,5 +46,32 @@ describe("PaginationLink aria-disabled styling (#8307)", () => {
     const link = screen.getByLabelText("active");
     // isActive/aria-current is untouched by this fix.
     expect(link.getAttribute("aria-current")).toBe("page");
+  });
+});
+
+// #10052: aria-hidden on the outer wrapper removed the sr-only "More pages" label from the a11y tree.
+// Scope aria-hidden to the decorative icon only — same pattern as TypingIndicator.
+describe("PaginationEllipsis sr-only label not inside aria-hidden (#10052)", () => {
+  it("exposes \"More pages\" with no aria-hidden ancestor; icon is aria-hidden", () => {
+    const { container } = render(<PaginationEllipsis />);
+    const label = screen.getByText("More pages");
+    expect(label.closest("[aria-hidden='true'], [aria-hidden='']")).toBeNull();
+    const icon = container.querySelector("svg");
+    expect(icon).not.toBeNull();
+    expect(icon!.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("merges caller className through cn (mx-2 + h-9)", () => {
+    const { container } = render(<PaginationEllipsis className="mx-2" />);
+    const outer = container.firstElementChild as HTMLElement;
+    expect(outer.tagName).toBe("SPAN");
+    expect(outer.className).toContain("mx-2");
+    expect(outer.className).toContain("h-9");
+  });
+
+  it("lets an explicit aria-hidden prop win on the outer span", () => {
+    const { container } = render(<PaginationEllipsis aria-hidden />);
+    const outer = container.firstElementChild as HTMLElement;
+    expect(outer.getAttribute("aria-hidden")).toBe("true");
   });
 });

--- a/packages/loopover-ui-kit/src/components/pagination.tsx
+++ b/packages/loopover-ui-kit/src/components/pagination.tsx
@@ -99,11 +99,10 @@ const PaginationEllipsis = ({
   ...props
 }: React.ComponentProps<"span">) => (
   <span
-    aria-hidden
     className={cn("flex h-9 w-9 items-center justify-center", className)}
     {...props}
   >
-    <MoreHorizontal className="h-4 w-4" />
+    <MoreHorizontal className="h-4 w-4" aria-hidden />
     <span className="sr-only">More pages</span>
   </span>
 );


### PR DESCRIPTION
## Summary
- Move `aria-hidden` from `PaginationEllipsis`'s outer span onto the decorative `MoreHorizontal` icon so the `sr-only` "More pages" label is announced.
- Mirror the TypingIndicator pattern; keep `{...props}` last so an explicit caller `aria-hidden` still wins.

Closes #10052

## Test plan
- [x] `npm --workspace @loopover/ui-kit run test -- src/components/pagination.test.tsx` (6 pass)
- [x] Label has no aria-hidden ancestor; icon is aria-hidden
- [x] className merge + props override covered