### PR TITLE
docs(ci): record why the escalation job's setup-node scan finding was dismissed

### DIFF
--- a/.github/workflows/selfhost.yml
+++ b/.github/workflows/selfhost.yml
@@ -195,6 +195,15 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+      # Needed only for `node --experimental-strip-types` below (the escalation is a .ts script), and pinned to
+      # the same SHA as the other 32 setup-node uses in this repo -- including build-boot above -- so this job
+      # adds no dependency that was not already here.
+      #
+      # A scanner flagged this as a filesystem-read risk, citing `__tests__/authutil.test.ts` in setup-node's
+      # own repository. That is a test fixture, not runtime behaviour, and the feature it covers -- writing an
+      # auth token into .npmrc -- only engages when `registry-url` is supplied. It is supplied in the five
+      # publish-*.yml workflows and deliberately not here, so that path is inert in this job. Reviewed and
+      # dismissed rather than silenced; re-check if this step ever gains `registry-url`.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version-file: .nvmrc


### PR DESCRIPTION
Follow-up to #10147 (comment-only, no behaviour change).

A security scanner flagged `actions/setup-node` in the new `escalate-persistent-failure` job as a filesystem-read risk (P1), citing `__tests__/authutil.test.ts`.

**Reviewed and dismissed.** The evidence:

1. **Test fixture, not runtime.** `authutil.test.ts` lives inside setup-node's own repository and exercises its `.npmrc` auth-token feature. Test files in an action's repo do not execute when the action runs.
2. **The capability is inert in this job.** That feature only engages when `registry-url` is supplied. In this repo that happens in exactly five places — all `publish-*.yml` — and deliberately not here. This step passes only `node-version-file`, so setup-node never touches `.npmrc` or any credential path.
3. **No new surface.** The pin is the same SHA as all **32** other `setup-node` uses in the repo, including `build-boot` in this same file. The job introduced no dependency that was not already present.

The job is also already minimal: `persist-credentials: false` on checkout, permissions scoped to `contents: read` + `issues: write`, no `npm ci`, and a script whose only import is `node:child_process`.

This PR records that reasoning at the call site so the next scan does not cost another investigation — and names the condition that would **invalidate** it (this step gaining `registry-url`) rather than dismissing the rule outright.