### PR TITLE
fix(scripts): grade export class/enum in dead-exports check

### DIFF
--- a/scripts/check-dead-exports.ts
+++ b/scripts/check-dead-exports.ts
@@ -38,10 +38,10 @@ const REFERENCE_ROOTS = ["src", "packages", "test", "scripts", "apps/loopover-ui
 const SOURCE_PATTERN = /(?<!\.d)\.tsx?$/;
 const EXCLUDED_SEGMENT = /(?:^|\/)(?:node_modules|dist|dist-test)(?:\/|$)/;
 
-/** `export const NAME` / `export function NAME` / `export async function NAME` at the top level. Types and
- *  interfaces are deliberately out of scope: an unused type costs nothing at runtime and TypeScript's own
- *  `noUnusedLocals` already covers the local case. */
-const EXPORTED_RUNTIME_SYMBOL = /^export (?:async )?(?:const|function) ([A-Za-z_][A-Za-z0-9_]*)/gm;
+/** `export const|function|class|enum NAME` (plus `async function` / `abstract class` / `const enum`) at the
+ *  top level. Types and interfaces stay out of scope: an unused type costs nothing at runtime and
+ *  TypeScript's own `noUnusedLocals` already covers the local case. */
+const EXPORTED_RUNTIME_SYMBOL = /^export (?:async )?(?:abstract )?(?:const\s+enum|const|function|class|enum) ([A-Za-z_][A-Za-z0-9_]*)/gm;
 
 /**
  * Exports with no in-repo reference that are nonetheless legitimate, each with the reason.

--- a/test/unit/check-dead-exports-script.test.ts
+++ b/test/unit/check-dead-exports-script.test.ts
@@ -81,3 +81,80 @@ describe("findDeadExports (#9852)", () => {
     expect(found.map((v) => v.symbol)).toEqual(["FOO"]);
   });
 });
+
+describe("findDeadExports class/enum (#10047)", () => {
+  it("REGRESSION (#10047): flags an orphan export class with internalUses including the declaration", () => {
+    const found = findDeadExports({
+      sourceRoots: ["src"],
+      referenceRoots: ["src"],
+      ...world({ "src/x.ts": "export class Orphan {}\nconst y = new Orphan();\n" }),
+    });
+    expect(found).toEqual([{ file: "src/x.ts", symbol: "Orphan", internalUses: 2 }]);
+  });
+
+  it("flags an orphan export enum with no other reference", () => {
+    const found = findDeadExports({
+      sourceRoots: ["src"],
+      referenceRoots: ["src"],
+      ...world({ "src/x.ts": "export enum Kind { A }\n" }),
+    });
+    expect(found.map((v) => v.symbol)).toEqual(["Kind"]);
+  });
+
+  it("does not flag a class referenced from another file (external > 0 early-break)", () => {
+    const found = findDeadExports({
+      sourceRoots: ["src"],
+      referenceRoots: ["src"],
+      ...world({
+        "src/x.ts": "export class Used {}\n",
+        "src/y.ts": "new Used();\n",
+      }),
+    });
+    expect(found).toEqual([]);
+  });
+
+  it("REGRESSION (#10047): export abstract class is matched — abstract must not defeat the anchor", () => {
+    const found = findDeadExports({
+      sourceRoots: ["src"],
+      referenceRoots: ["src"],
+      ...world({ "src/x.ts": "export abstract class Base {}\n" }),
+    });
+    expect(found.map((v) => v.symbol)).toEqual(["Base"]);
+  });
+
+  it("does NOT match a non-exported class Foo {}", () => {
+    const found = findDeadExports({
+      sourceRoots: ["src"],
+      referenceRoots: ["src"],
+      ...world({ "src/x.ts": "class Foo {}\nvoid Foo;\n" }),
+    });
+    expect(found).toEqual([]);
+  });
+
+  it("still does NOT match export type / export interface", () => {
+    const found = findDeadExports({
+      sourceRoots: ["src"],
+      referenceRoots: ["src"],
+      ...world({ "src/a.ts": "export type T = 1;\nexport interface I { x: 1 }\n" }),
+    });
+    expect(found).toEqual([]);
+  });
+
+  it("export const enum Kind is matched as Kind (const enum before bare const in the alternation)", () => {
+    const found = findDeadExports({
+      sourceRoots: ["src"],
+      referenceRoots: ["src"],
+      ...world({ "src/x.ts": "export const enum Kind { A }\n" }),
+    });
+    expect(found.map((v) => v.symbol)).toEqual(["Kind"]);
+  });
+
+  it("class with internalUses > 1 still reports the drop-export hint path", () => {
+    const found = findDeadExports({
+      sourceRoots: ["src"],
+      referenceRoots: ["src"],
+      ...world({ "src/x.ts": "export class Inside {}\nconst z = new Inside();\n" }),
+    });
+    expect(found.find((v) => v.symbol === "Inside")?.internalUses).toBeGreaterThan(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Extend EXPORTED_RUNTIME_SYMBOL to match export class / bstract class / enum / const enum.
- Update the scope JSDoc; no ALLOWED_EXPORTS changes.
- Unit coverage for orphan class/enum, abstract class, external reference, and const enum.

Closes #10047

## Test plan
- [x] 
pm run dead-exports:check exits 0
- [x] Injected-file assertions for Orphan class, Kind enum, Used cross-file, abstract class, const enum
