### PR TITLE
fix(orb): do not un-install repos from a page-capped installation-repositories crawl

### DIFF
--- a/src/orb/installed-repos-sync.ts
+++ b/src/orb/installed-repos-sync.ts
@@ -27,8 +27,12 @@ export type InstalledReposSyncResult =
 /** Fetch every repo currently accessible to this brokered installation via GitHub's own
  *  `GET /installation/repositories`, paginated. Uses the broker token directly -- its response already carries
  *  the bound installationId, so no separate token mint is needed for this call. */
-async function fetchAllInstallationRepos(token: string, fetchImpl: typeof fetch): Promise<GitHubRepositoryPayload[]> {
+export async function fetchAllInstallationRepos(token: string, fetchImpl: typeof fetch): Promise<{ repos: GitHubRepositoryPayload[]; truncated: boolean }> {
   const repos: GitHubRepositoryPayload[] = [];
+  // #10033: TRUE only when the loop exhausts MAX_INSTALLATION_REPOS_PAGES with a still-full last page -- a
+  // short page means the list is complete, but a full final page means there is an untraversed tail. The caller
+  // must not treat a truncated list as negative evidence and un-install the repos it never saw.
+  let truncated = false;
   for (let page = 1; page <= MAX_INSTALLATION_REPOS_PAGES; page += 1) {
     const res = await fetchImpl(`https://api.github.com/installation/repositories?per_page=${GITHUB_INSTALLATION_REPOS_PAGE_SIZE}&page=${page}`, {
       headers: githubHeaders({ token }),
@@ -39,8 +43,9 @@ async function fetchAllInstallationRepos(token: string, fetchImpl: typeof fetch)
     const batch = body.repositories ?? [];
     repos.push(...batch);
     if (batch.length < GITHUB_INSTALLATION_REPOS_PAGE_SIZE) break;
+    if (page === MAX_INSTALLATION_REPOS_PAGES) truncated = true;
   }
-  return repos;
+  return { repos, truncated };
 }
 
 /**
@@ -65,9 +70,18 @@ export async function syncBrokeredInstalledRepos(
   if (!isOrbBrokerMode(env)) return { status: "skipped" };
   try {
     const { token, installationId } = await fetchBrokeredInstallationToken(env, fetchImpl);
-    const repos = await fetchAllInstallationRepos(token, fetchImpl);
+    const { repos, truncated } = await fetchAllInstallationRepos(token, fetchImpl);
+    // A partial list is valid POSITIVE evidence: still upsert every repo we DID fetch as installed.
     for (const repo of repos) {
       await upsertRepositoryFromGitHub(env, repo, installationId);
+    }
+    if (truncated) {
+      // #10033: a page-capped crawl is not valid NEGATIVE evidence -- reconciling against it would flip every
+      // installed repo in the untraversed tail to isInstalled: false and take them silently dark. Skip the
+      // destructive reconcile entirely, but still report `synced` (the sync did useful upsert work; the cron
+      // must not read this as an outage) with removedCount 0, and log so an operator sees the suppression.
+      console.error(JSON.stringify({ level: "error", event: "installed_repos_sync_truncated", installationId, repoCount: repos.length }));
+      return { status: "synced", installationId, repoCount: repos.length, removedCount: 0 };
     }
     const freshFullNames = new Set(repos.map((repo) => repo.full_name));
     const previouslyInstalled = await listInstalledRepoFullNamesForInstallation(env, installationId);

--- a/test/unit/orb-installed-repos-sync.test.ts
+++ b/test/unit/orb-installed-repos-sync.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as repositories from "../../src/db/repositories";
 import { getRepository } from "../../src/db/repositories";
-import { syncBrokeredInstalledRepos } from "../../src/orb/installed-repos-sync";
+import { fetchAllInstallationRepos, syncBrokeredInstalledRepos } from "../../src/orb/installed-repos-sync";
 import { createTestEnv } from "../helpers/d1";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 type Call = { url: string; init?: RequestInit | undefined };
 
@@ -104,5 +109,58 @@ describe("syncBrokeredInstalledRepos", () => {
     const { fetchImpl } = routedFetch({ tokenResponse: tokenResponse(42), pages: [Response.json({})] });
     const result = await syncBrokeredInstalledRepos(env, fetchImpl);
     expect(result).toEqual({ status: "synced", installationId: 42, repoCount: 0, removedCount: 0 });
+  });
+
+  // #10033: fetchAllInstallationRepos must report truncation so the caller does not treat a page-capped list
+  // as negative evidence and un-install the untraversed tail.
+  const fullPage = (start: number) => Response.json({ repositories: Array.from({ length: 100 }, (_, i) => repoPayload(`owner/repo-${start + i}`)) });
+
+  it("#10033: fetchAllInstallationRepos reports truncated=true only when the page cap is hit with a full last page", async () => {
+    // 50 full pages → the cap is exhausted while a full page is still pending → truncated, 5000 repos.
+    const capped = routedFetch({ tokenResponse: tokenResponse(42), pages: Array.from({ length: 50 }, (_, p) => fullPage(p * 100)) });
+    await expect(fetchAllInstallationRepos("tok", capped.fetchImpl)).resolves.toMatchObject({ truncated: true, repos: expect.any(Array) });
+    expect((await fetchAllInstallationRepos("tok", routedFetch({ tokenResponse: tokenResponse(42), pages: Array.from({ length: 50 }, (_, p) => fullPage(p * 100)) }).fetchImpl)).repos).toHaveLength(5000);
+
+    // 100 then 40 (short page) → complete, 140 repos.
+    const short = routedFetch({ tokenResponse: tokenResponse(42), pages: [fullPage(0), Response.json({ repositories: Array.from({ length: 40 }, (_, i) => repoPayload(`owner/tail-${i}`)) })] });
+    await expect(fetchAllInstallationRepos("tok", short.fetchImpl)).resolves.toMatchObject({ truncated: false });
+
+    // Exactly 100 then 0 (empty page) → complete, 100 repos.
+    const emptyTail = routedFetch({ tokenResponse: tokenResponse(42), pages: [fullPage(0), Response.json({ repositories: [] })] });
+    const res = await fetchAllInstallationRepos("tok", emptyTail.fetchImpl);
+    expect(res).toMatchObject({ truncated: false });
+    expect(res.repos).toHaveLength(100);
+  });
+
+  it("#10033: a truncated crawl calls markRepositoriesRemovedFromInstallation ZERO times but still upserts every fetched repo", async () => {
+    const env = createTestEnv({ ORB_ENROLLMENT_SECRET: "orbsec_x" });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const removeSpy = vi.spyOn(repositories, "markRepositoriesRemovedFromInstallation");
+    const upsertSpy = vi.spyOn(repositories, "upsertRepositoryFromGitHub");
+    const capped = routedFetch({ tokenResponse: tokenResponse(42), pages: Array.from({ length: 50 }, (_, p) => fullPage(p * 100)) });
+    await syncBrokeredInstalledRepos(env, capped.fetchImpl);
+    expect(removeSpy).not.toHaveBeenCalled();
+    expect(upsertSpy).toHaveBeenCalledTimes(5000);
+  });
+
+  it("#10033 REGRESSION: a page-capped installation-repositories crawl must not un-install the untraversed tail", async () => {
+    const env = createTestEnv({ ORB_ENROLLMENT_SECRET: "orbsec_x" });
+    // First a COMPLETE sync installs a repo that a later truncated crawl will not surface.
+    const first = routedFetch({ tokenResponse: tokenResponse(42), pages: [Response.json({ repositories: [repoPayload("owner/in-the-tail")] })] });
+    await syncBrokeredInstalledRepos(env, first.fetchImpl);
+    await expect(getRepository(env, "owner/in-the-tail")).resolves.toMatchObject({ isInstalled: true });
+
+    // Now a TRUNCATED crawl (50 full pages, none of them the tail repo): the reconcile must be suppressed.
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const capped = routedFetch({ tokenResponse: tokenResponse(42), pages: Array.from({ length: 50 }, (_, p) => fullPage(p * 100)) });
+    const result = await syncBrokeredInstalledRepos(env, capped.fetchImpl);
+
+    expect(result).toEqual({ status: "synced", installationId: 42, repoCount: 5000, removedCount: 0 });
+    // The tail repo the truncated crawl never saw stays installed — NOT flipped to isInstalled: false.
+    await expect(getRepository(env, "owner/in-the-tail")).resolves.toMatchObject({ isInstalled: true, installationId: 42 });
+    // One structured error line records the suppressed reconcile.
+    const truncWarns = errorSpy.mock.calls.map((c) => String(c[0])).filter((m) => m.includes("installed_repos_sync_truncated"));
+    expect(truncWarns).toHaveLength(1);
+    expect(truncWarns[0]).toContain("\"repoCount\":5000");
   });
 });


### PR DESCRIPTION
## What & why

`syncBrokeredInstalledRepos` treats the list from `fetchAllInstallationRepos` as the complete, authoritative repo set and reconciles **destructively** against it — every locally-installed repo not in the fresh list is flipped to `isInstalled: false` with its `installationId` cleared.

But `fetchAllInstallationRepos` has two exits the caller can't tell apart:

```ts
repos.push(...batch);
if (batch.length < GITHUB_INSTALLATION_REPOS_PAGE_SIZE) break;  // short page → list COMPLETE
// …or the loop simply runs out of pages: page cap hit with a full page still pending → list TRUNCATED
```

On truncation the reconcile ran anyway: every locally-installed repo beyond item 5,000 (50 pages × 100) is absent from `freshFullNames`, so `markRepositoriesRemovedFromInstallation` un-installs it. Per this file's header, **every core feature is gated on `isInstalled`**, so those repos go silently dark — and nothing self-heals.

This is the only one of the four paginated GitHub crawls in the codebase that performs a **destructive write** off a possibly-truncated read, and the only one with no capped/inconclusive signal (`listMigrationFilenamesAtRef` returns `null`, `fetchPullRequestFiles` warns and holds, `fetchPagedSegment` records a `"capped"` status).

## The fix

- `fetchAllInstallationRepos` now returns `{ repos, truncated }`, where `truncated` is `true` **exactly** when the loop exhausts `MAX_INSTALLATION_REPOS_PAGES` with a full last page, and `false` on a short-page exit.
- `syncBrokeredInstalledRepos` skips `markRepositoriesRemovedFromInstallation` entirely when truncated — a partial list is valid **positive** evidence (still `upsert`s every fetched repo) but not valid **negative** evidence. Mirrors `listMigrationFilenamesAtRef`'s "a bound-hit is inconclusive" posture.
- A truncated sync still returns `{ status: "synced", …, removedCount: 0 }` (the cron must not read it as an outage) and emits one structured `console.error` (`event: "installed_repos_sync_truncated"`, with `installationId` and `repoCount`) so an operator sees the suppressed reconcile.

**Unchanged:** `MAX_INSTALLATION_REPOS_PAGES` (50), `GITHUB_INSTALLATION_REPOS_PAGE_SIZE` (100), the `isOrbBrokerMode` → `skipped` early return, the thrown-error → `failed` path, the `InstalledReposSyncResult` union members, and the **complete-crawl** upsert-and-reconcile behaviour including `removedCount`.

## Tests (`test/unit/orb-installed-repos-sync.test.ts`)

- `fetchAllInstallationRepos` reports `truncated: true` (5,000 repos) for 50 full pages; `truncated: false` for 100-then-40 (140 repos) and 100-then-0 (100 repos).
- A truncated crawl calls `markRepositoriesRemovedFromInstallation` **zero** times (spied) but `upsertRepositoryFromGitHub` once per fetched repo (5,000).
- The truncated result is `{ status: "synced", installationId, repoCount: 5000, removedCount: 0 }` with one structured `console.error`.
- **REGRESSION:** a repo installed by an earlier complete sync, absent from a later truncated crawl, stays `isInstalled: true` — not un-installed.
- The existing complete-crawl removal test (a repo GitHub stops returning IS un-installed, `removedCount: 1`) is preserved unchanged.
- All new assertions **fail on `main`**.

## Validation

- Diff coverage on `src/orb/installed-repos-sync.ts` is **100%** line and branch (both arms of the new truncation branch, plus the preserved `!res.ok` / `isOrbBrokerMode` paths).
- `npm run typecheck` clean; `npm run engine-parity:drift-check` passes (host-only file, not a twin); `npm run dead-exports:check` clean; the suite (11 tests) green.
- `git diff --check` clean; no schema/migration/generated-artifact change.

Closes #10033
