### PR TITLE
fix(queue): thread ignoredCheckRuns into the live CI aggregate, not just its cache key

### DIFF
--- a/src/queue/ci-resolution.ts
+++ b/src/queue/ci-resolution.ts
@@ -245,6 +245,11 @@ function fetchLiveCiAggregateWithRequiredContexts(
         // would keep serving a stale aggregate computed against the old advisory list.
         requiredContextsKey: `${resolvedRequiredContextsKeyPart(requiredContexts)}|adv:${advisoryCheckRunsKeyPart(args.advisoryCheckRuns)}|ign:${ignoredCheckRunsKeyPart(args.ignoredCheckRuns)}`,
         advisoryCheckRuns: args.advisoryCheckRuns,
+        // #10018: thread the ignore list into the aggregate itself, not just its cache key — it was folded
+        // into `requiredContextsKey` above but dropped from the arg object, so `cachedFetchLiveCiAggregate`'s
+        // `ignoredCheckRuns` was always undefined and a maintainer-declared ignored check never actually
+        // dropped out of the live CI aggregate the maintenance planner reads. Mirrors advisoryCheckRuns above.
+        ignoredCheckRuns: args.ignoredCheckRuns,
         forceRefresh: args.forceRefresh,
         requiredContextsResolved: resolved,
         admissionKey: args.admissionKey,
@@ -282,6 +287,7 @@ export function cachedLiveCiAggregate(
       token: args.token,
       expectedCiContexts: args.expectedCiContexts,
       advisoryCheckRuns: args.advisoryCheckRuns,
+      ignoredCheckRuns: args.ignoredCheckRuns, // #10018: forward the ignore list, mirroring advisoryCheckRuns
       forceRefresh: false,
       admissionKey: args.admissionKey,
     }),
@@ -318,6 +324,7 @@ export function refreshLiveCiAggregate(
       token: args.token,
       expectedCiContexts: args.expectedCiContexts,
       advisoryCheckRuns: args.advisoryCheckRuns,
+      ignoredCheckRuns: args.ignoredCheckRuns, // #10018: forward the ignore list, mirroring advisoryCheckRuns
       forceRefresh: true,
       admissionKey: args.admissionKey,
     }),

--- a/test/unit/ci-resolution.test.ts
+++ b/test/unit/ci-resolution.test.ts
@@ -4,8 +4,10 @@ import {
   cachedLiveCiAggregate,
   cachedRequiredStatusContexts,
   observeRequiredContextsLookup,
+  refreshLiveCiAggregate,
   refreshLiveMergeState,
   REQUIRED_CONTEXTS_UNRESOLVED_METRIC,
+  reuseOrRefreshLiveCiAggregate,
   setMergeStateUnknownRetryDelayMsForTest,
 } from "../../src/queue/ci-resolution";
 import type { LiveGithubFacts } from "../../src/queue/processors";
@@ -132,6 +134,66 @@ describe("cachedLiveCiAggregate request-scoped memoization (#4498)", () => {
     await cachedLiveCiAggregate(env, { ...base, advisoryCheckRuns: twoEntry });
     await cachedLiveCiAggregate(env, { ...base, advisoryCheckRuns: [...twoEntry].reverse() });
     expect(liveCiSpy).toHaveBeenCalledTimes(3); // +1 only, the reversed list reused the key
+  });
+});
+
+describe("ignoredCheckRuns is threaded into the live CI aggregate, not just its cache key (#10018)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+  const IGNORED = [{ name: "Contributor trust", appSlug: "example-security-app" }];
+  const okAggregate = {
+    ciState: "passed" as const,
+    hasPending: false,
+    hasVisiblePending: false,
+    hasMissingRequiredContext: false,
+    failingDetails: [],
+    nonRequiredFailingDetails: [],
+    advisoryHoldDetails: [],
+    ignoredCheckDetails: [],
+    ciCompletenessWarning: null,
+  };
+  // Distinct headSha per call so the request-scoped memo never serves one test's aggregate to another.
+  const base = (headSha: string) => ({
+    repoFullName: "owner/repo",
+    facts: emptyFacts(),
+    prNumber: 7,
+    headSha,
+    baseRef: null,
+    token: "tok",
+    expectedCiContexts: null,
+    advisoryCheckRuns: null,
+  });
+  // fetchLiveCiAggregatePreferGraphQl's 8th positional argument (index 7) is ignoredCheckRuns.
+  const eighthArg = (spy: ReturnType<typeof vi.spyOn>) => spy.mock.calls[0]?.[7];
+
+  it("cachedLiveCiAggregate forwards the ignore list as the 8th positional argument", async () => {
+    const env = createTestEnv();
+    const spy = vi.spyOn(backfillModule, "fetchLiveCiAggregatePreferGraphQl").mockResolvedValue(okAggregate);
+    await cachedLiveCiAggregate(env, { ...base("sha-cached"), ignoredCheckRuns: IGNORED });
+    expect(eighthArg(spy)).toEqual(IGNORED);
+  });
+
+  it("refreshLiveCiAggregate forwards the ignore list as the 8th positional argument", async () => {
+    const env = createTestEnv();
+    const spy = vi.spyOn(backfillModule, "fetchLiveCiAggregatePreferGraphQl").mockResolvedValue(okAggregate);
+    await refreshLiveCiAggregate(env, { ...base("sha-refresh"), ignoredCheckRuns: IGNORED });
+    expect(eighthArg(spy)).toEqual(IGNORED);
+  });
+
+  it("reuseOrRefreshLiveCiAggregate (the positional-arg entry point) forwards the ignore list", async () => {
+    const env = createTestEnv();
+    const spy = vi.spyOn(backfillModule, "fetchLiveCiAggregatePreferGraphQl").mockResolvedValue(okAggregate);
+    // reuseOrRefreshLiveCiAggregate is positional: ignoredCheckRuns is its 11th arg (after advisoryCheckRuns).
+    await reuseOrRefreshLiveCiAggregate(env, "owner/repo", emptyFacts(), 7, "abc123", null, "tok", null, undefined, null, IGNORED);
+    expect(eighthArg(spy)).toEqual(IGNORED);
+  });
+
+  it("REGRESSION #10018: an unconfigured repo (ignoredCheckRuns null) still passes null/undefined through — byte-identical", async () => {
+    const env = createTestEnv();
+    const spy = vi.spyOn(backfillModule, "fetchLiveCiAggregatePreferGraphQl").mockResolvedValue(okAggregate);
+    await cachedLiveCiAggregate(env, { ...base("sha-null"), ignoredCheckRuns: null });
+    expect(eighthArg(spy) ?? null).toBeNull(); // no ignore list configured ⇒ the arg is null/undefined
   });
 });
 


### PR DESCRIPTION
## What & why

`gate.ignoredCheckRuns` (#9813) is supposed to exclude a maintainer-declared third-party check-run from CI resolution entirely — "never gates, never pends, never holds." The reducer honours it and `fetchLiveCiAggregatePreferGraphQl` accepts it as its 8th positional argument. But `src/queue/ci-resolution.ts` folded it into the durable **cache key** at all three hand-offs while **dropping it from the arg object** passed downstream:

```ts
requiredContextsKey: `…|ign:${ignoredCheckRunsKeyPart(args.ignoredCheckRuns)}`,  // in the key…
advisoryCheckRuns: args.advisoryCheckRuns,
// …but no `ignoredCheckRuns:` here — so cachedFetchLiveCiAggregate's ignoredCheckRuns is always undefined
```

TypeScript can't catch it: the property is optional at every hop. So `args.ignoredCheckRuns` inside `cachedFetchLiveCiAggregate` (its only consumer) is **always `undefined`**. Consequences, all on the live maintenance path:

- `ciAggregate.ignoredCheckDetails` is always `[]`, so `ignoredCheckNonPassing` is always empty and `unstableExplainedByIgnoredChecks` is always `false`. The #9810 follow-up that stops an ignored check from holding a PR at `mergeable_state: "unstable"` **can never fire in production**.
- An ignored check still counts toward `ciState`/`hasPending` in the planner's aggregate, while the executor's and approval-queue's own re-checks pass the list through correctly — so planner and executor can disagree about the same PR's CI state.

## The fix

Forward `args.ignoredCheckRuns` at all three call sites — `fetchLiveCiAggregateWithRequiredContexts`, `cachedLiveCiAggregate`, and `refreshLiveCiAggregate` — mirroring how `advisoryCheckRuns` is already threaded through the same three hops. One added property per call site, nothing else.

**Unchanged:** signatures stay optional so positional callers (`reuseOrRefreshLiveCiAggregate` at `processors.ts:3322`) are byte-identical; the `requiredContextsKey` composition (already includes the ignore-list fingerprint) and the `advisoryCheckRuns` threading are unchanged; nothing outside `ci-resolution.ts` is modified.

## Tests (`test/unit/ci-resolution.test.ts`)

- Via a spy on `fetchLiveCiAggregatePreferGraphQl`, its **8th positional argument** equals the exact ignore array `[{ name: "Contributor trust", appSlug: "example-security-app" }]` for `cachedLiveCiAggregate`, `refreshLiveCiAggregate`, and the positional entry point `reuseOrRefreshLiveCiAggregate` — today it is `undefined`.
- **REGRESSION:** an unconfigured repo (`ignoredCheckRuns: null`) still passes `null`/`undefined` through, so an un-opted-in repo stays byte-identical.
- The three forwarding assertions **fail on `main`**.

## Validation

- Diff coverage on `src/queue/ci-resolution.ts` is **100%** line and branch (each of the three touched call sites executed; the populated and absent `ignoredCheckRunsKeyPart` arms both exercised).
- `npm run typecheck` clean; `npm run engine-parity:drift-check` passes (not a twin); `npm run dead-exports:check` clean; the suite (15 tests) green.
- `git diff --check` clean; no schema/migration/generated-artifact change.

Closes #10018
