### PR TITLE
fix(services): enqueue notify-deliver for the approval-queue staged-action and reminder badges

### DIFF
--- a/src/services/agent-action-executor.ts
+++ b/src/services/agent-action-executor.ts
@@ -1465,7 +1465,7 @@ async function stageForApproval(env: Env, ctx: AgentActionExecutionContext, acti
   if (!created) return false;
   /* v8 ignore next -- a repo full name always has an owner segment; the empty fallback is purely defensive. */
   const recipientLogin = ctx.repoFullName.split("/")[0] ?? "";
-  await insertNotificationDeliveryIfAbsent(env, {
+  const { created: deliveryCreated, delivery } = await insertNotificationDeliveryIfAbsent(env, {
     dedupKey: `agent.pending_action:${ctx.repoFullName}#${ctx.pullNumber}:${action.actionClass}`,
     channel: "badge",
     recipientLogin,
@@ -1477,5 +1477,20 @@ async function stageForApproval(env: Env, ctx: AgentActionExecutionContext, acti
     deeplink: `https://github.com/${ctx.repoFullName}/pull/${ctx.pullNumber}`,
     actorLogin: AGENT_ACTOR,
   });
+  // #10025: enqueue the notify-deliver job that promotes this pending row to delivered — without it the badge
+  // sits invisible in notification_deliveries until the stranded-delivery sweep rescues it 10+ minutes later.
+  // Mirrors evaluateAndEnqueueNotificationDeliveries' `created && status === "pending"` guard: a dedup hit
+  // (already sent) or a rate-limit-suppressed non-pending row enqueues nothing. Best-effort: a failed send
+  // must not abort staging (still returns true), only log.
+  // The `status === "pending"` arm mirrors evaluateAndEnqueueNotificationDeliveries' guard and honours the
+  // "send nothing for a suppressed row" contract, but this insert never passes a status, so the delivery is
+  // always pending here -- the false arm is unreachable from THIS caller (rate-limit suppression lives in
+  // evaluateNotificationEvent, a different helper), hence the ignore. `created` false IS reachable (a dedup).
+  /* v8 ignore next -- `delivery.status === "pending"` is always true from this caller; the guard is the shared contract */
+  if (deliveryCreated && delivery.status === "pending") {
+    await env.JOBS.send({ type: "notify-deliver", requestedBy: "agent-approval", deliveryId: delivery.id }).catch((error: unknown) => {
+      console.warn(JSON.stringify({ event: "approval_notification_enqueue_failed", deliveryId: delivery.id, repoFullName: ctx.repoFullName, pullNumber: ctx.pullNumber, message: errorMessage(error).slice(0, 200) }));
+    });
+  }
   return true;
 }

--- a/src/services/agent-approval-queue.ts
+++ b/src/services/agent-approval-queue.ts
@@ -24,6 +24,7 @@ import { resolvePerRepoContributorCapMatch } from "../queue/processors";
 import { isBelowAccountAgeThreshold } from "../queue/account-age-throttle";
 import { isAutoCloseExempt } from "../settings/auto-close-exempt";
 import { isPerTenantAdmin } from "../auth/security";
+import { errorMessage } from "../utils/json";
 import type { AgentPendingActionParams, AgentPendingActionRecord } from "../types";
 
 export type ApprovalDecision = "accept" | "reject";
@@ -614,7 +615,7 @@ export async function sweepStaleApprovalQueue(env: Env, nowMs: number = Date.now
     const recipientLogin = row.repoFullName.split("/")[0] ?? "";
     if (plan.kind === "remind") {
       const ageDays = plan.bucket;
-      const { created } = await insertNotificationDeliveryIfAbsent(env, {
+      const inserted = await insertNotificationDeliveryIfAbsent(env, {
         // The bucket index is what makes this fire again at all: the dedup key changes once per interval, so
         // the ~2-minute sweep cadence collapses to exactly one badge per interval with no extra persisted state.
         dedupKey: `agent.pending_action.reminder:${row.repoFullName}#${row.pullNumber}:${row.actionClass}:${plan.bucket}`,
@@ -627,8 +628,21 @@ export async function sweepStaleApprovalQueue(env: Env, nowMs: number = Date.now
         body: `${row.reason ?? "A staged action"} — accept to execute it, or reject to cancel. It expires after ${Math.round(APPROVAL_EXPIRY_MS / (24 * 60 * 60 * 1000))} days.`,
         deeplink: `https://github.com/${row.repoFullName}/pull/${row.pullNumber}`,
         actorLogin: "loopover",
-      }).catch(() => ({ created: false }));
-      if (created) reminded += 1;
+      }).catch(() => null);
+      if (inserted?.created) {
+        reminded += 1;
+        // #10025: enqueue the notify-deliver job so the reminder badge — the #9032 escape hatch for a
+        // maintainer who missed the first badge — actually reaches the feed, instead of waiting 10+ minutes
+        // for the stranded-delivery sweep. Best-effort: a failed send still counts the reminder and continues.
+        // As in stageForApproval: this insert never passes a status, so the delivery is always pending here --
+        // the false arm is unreachable from this caller. The check mirrors the shared enqueue contract.
+        /* v8 ignore next -- `inserted.delivery.status === "pending"` is always true from this caller */
+        if (inserted.delivery.status === "pending") {
+          await env.JOBS.send({ type: "notify-deliver", requestedBy: "agent-approval", deliveryId: inserted.delivery.id }).catch((error: unknown) => {
+            console.warn(JSON.stringify({ event: "approval_notification_enqueue_failed", deliveryId: inserted.delivery.id, repoFullName: row.repoFullName, pullNumber: row.pullNumber, message: errorMessage(error).slice(0, 200) }));
+          });
+        }
+      }
       continue;
     }
     // Atomic pending→expired, so a maintainer accepting at the exact moment the sweep expires the row still

--- a/src/types.ts
+++ b/src/types.ts
@@ -222,7 +222,9 @@ export type JobMessage =
     }
   | {
       type: "notify-deliver";
-      requestedBy: "notify-evaluate" | "test";
+      // #10025: the approval-queue's staged-action + reminder badges enqueue their own notify-deliver jobs so
+      // they reach the feed without waiting on the stranded-delivery sweep.
+      requestedBy: "notify-evaluate" | "test" | "agent-approval";
       deliveryId: string;
     }
   | {

--- a/test/unit/agent-approval-queue.test.ts
+++ b/test/unit/agent-approval-queue.test.ts
@@ -84,6 +84,7 @@ import {
   upsertRepositorySettings,
 } from "../../src/db/repositories";
 import { AGENT_LABEL_NEEDS_REVIEW, type PlannedAgentAction } from "../../src/settings/agent-actions";
+import { buildNotificationFeed, deliverNotification } from "../../src/notifications/service";
 import { createTestEnv } from "../helpers/d1";
 
 function ctx(over: Partial<AgentActionExecutionContext> = {}): AgentActionExecutionContext {
@@ -150,6 +151,49 @@ describe("agent approval queue (#779)", () => {
     expect(await listPendingAgentActions(env, { repoFullName: "owner/repo" })).toHaveLength(1);
     const deliveries = (await listNotificationDeliveriesForRecipient(env, "owner")).filter((d) => d.eventType === "agent.pending_action");
     expect(deliveries).toHaveLength(1);
+  });
+
+  // #10025: capture the notify-deliver jobs the staging path enqueues.
+  const withJobsCapture = (env: Env): Array<{ type: string; deliveryId?: string }> => {
+    const sent: Array<{ type: string; deliveryId?: string }> = [];
+    (env as unknown as { JOBS: { send: (msg: unknown) => Promise<void> } }).JOBS = { send: async (msg) => void sent.push(msg as { type: string; deliveryId?: string }) };
+    return sent;
+  };
+
+  it("#10025: staging enqueues exactly one notify-deliver job for the created badge; a second staging enqueues none", async () => {
+    const env = createTestEnv({});
+    const sent = withJobsCapture(env);
+    await executeAgentMaintenanceActions(env, ctx(), [mergeApproval]);
+    const notifyJobs = sent.filter((m) => m.type === "notify-deliver");
+    expect(notifyJobs).toHaveLength(1);
+    const delivery = (await listNotificationDeliveriesForRecipient(env, "owner")).find((d) => d.eventType === "agent.pending_action" && d.pullNumber === 7);
+    expect(notifyJobs[0]?.deliveryId).toBe(delivery?.id);
+
+    // A second staging hits the dedup (created:false) → enqueues nothing more.
+    await executeAgentMaintenanceActions(env, ctx(), [mergeApproval]);
+    expect(sent.filter((m) => m.type === "notify-deliver")).toHaveLength(1);
+  });
+
+  it("#10025: a rejected notify-deliver send is caught, warns, and staging still returns queued", async () => {
+    const env = createTestEnv({});
+    (env as unknown as { JOBS: { send: (msg: unknown) => Promise<void> } }).JOBS = { send: async () => { throw new Error("queue down"); } };
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const outcomes = await executeAgentMaintenanceActions(env, ctx(), [mergeApproval]);
+    expect(outcomes[0]?.outcome).toBe("queued"); // the send failure did not abort staging
+    expect(warn.mock.calls.map((c) => String(c[0])).some((m) => m.includes("approval_notification_enqueue_failed"))).toBe(true);
+    warn.mockRestore();
+  });
+
+  it("#10025 REGRESSION: after staging + delivering the enqueued job, the recipient's feed contains the staged-action item", async () => {
+    const env = createTestEnv({});
+    const sent = withJobsCapture(env);
+    await executeAgentMaintenanceActions(env, ctx(), [mergeApproval]);
+    const deliveryId = sent.find((m) => m.type === "notify-deliver")?.deliveryId;
+    expect(deliveryId).toBeDefined();
+    // Run the job that promotes the pending row to delivered.
+    await deliverNotification(env, deliveryId!);
+    const feed = buildNotificationFeed("owner", await listNotificationDeliveriesForRecipient(env, "owner"));
+    expect(feed.notifications.some((item) => item.eventType === "agent.pending_action" && item.pullNumber === 7)).toBe(true);
   });
 
   it("createPendingAgentActionIfAbsent reports created vs already-staged", async () => {

--- a/test/unit/approval-queue-staleness.test.ts
+++ b/test/unit/approval-queue-staleness.test.ts
@@ -87,6 +87,35 @@ describe("sweepStaleApprovalQueue (#9032)", () => {
     expect(deliveries.every((delivery) => delivery.recipientLogin === "alice")).toBe(true);
   });
 
+  it("#10025: a row aged past the reminder interval enqueues exactly one notify-deliver; a second sweep in the same bucket enqueues none", async () => {
+    const env = createTestEnv();
+    const sent: Array<{ type: string; deliveryId?: string }> = [];
+    (env as unknown as { JOBS: { send: (msg: unknown) => Promise<void> } }).JOBS = { send: async (msg) => void sent.push(msg as { type: string; deliveryId?: string }) };
+    const id = await stage(env, 3);
+    const stagedAt = Date.parse((await getPendingAgentAction(env, id))!.createdAt);
+
+    await sweepStaleApprovalQueue(env, stagedAt + APPROVAL_REMINDER_INTERVAL_MS);
+    const notifyJobs = sent.filter((m) => m.type === "notify-deliver");
+    expect(notifyJobs).toHaveLength(1);
+    const reminder = (await listNotificationDeliveriesForRecipient(env, "alice", { limit: 50 })).find((d) => d.title.includes("Still waiting"));
+    expect(notifyJobs[0]?.deliveryId).toBe(reminder?.id);
+
+    // A second sweep inside the SAME reminder bucket hits the dedup (created:false) → no further enqueue.
+    await sweepStaleApprovalQueue(env, stagedAt + APPROVAL_REMINDER_INTERVAL_MS + 60_000);
+    expect(sent.filter((m) => m.type === "notify-deliver")).toHaveLength(1);
+  });
+
+  it("#10025: a rejected notify-deliver send is caught, warns, and the sweep still counts the reminder", async () => {
+    const env = createTestEnv();
+    (env as unknown as { JOBS: { send: (msg: unknown) => Promise<void> } }).JOBS = { send: async () => { throw new Error("queue down"); } };
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const id = await stage(env, 4);
+    const stagedAt = Date.parse((await getPendingAgentAction(env, id))!.createdAt);
+    expect(await sweepStaleApprovalQueue(env, stagedAt + APPROVAL_REMINDER_INTERVAL_MS)).toEqual({ reminded: 1, expired: 0 });
+    expect(warn.mock.calls.map((c) => String(c[0])).some((m) => m.includes("approval_notification_enqueue_failed"))).toBe(true);
+    warn.mockRestore();
+  });
+
   it("still writes a readable reminder for a row staged without a reason", async () => {
     const env = createTestEnv();
     const { action } = await createPendingAgentActionIfAbsent(env, {


### PR DESCRIPTION
## What & why

A `notification_deliveries` row is only visible in the recipient's feed once something promotes it out of `pending` — and the only thing that does is a `notify-deliver` queue job. Every insert in `src/notifications/service.ts` is paired with an enqueue (`evaluateAndEnqueueNotificationDeliveries`, the `notify-evaluate` handler). **The approval queue's two inserts were not:**

- `stageForApproval` (`agent-action-executor.ts`) — the badge a maintainer gets when an `auto_with_approval` action is staged.
- `sweepStaleApprovalQueue` (`agent-approval-queue.ts`) — the #9032 reminder badge, the entire point of the escape hatch.

Neither passed a `status`, so both rows were created at `"pending"`, and neither sent a `notify-deliver` job. Both badges therefore sat invisible in `notification_deliveries`. The only thing that eventually delivered them was `sweepStrandedNotificationDeliveries`, whose own doc frames it as a rescue for a *failed* enqueue and which deliberately waits `STRANDED_NOTIFICATION_GRACE_MS` (10 min). So these notifications were structurally dependent on an unrelated self-heal, delayed 10+ minutes, and would vanish entirely if that sweep were ever scoped — directly contradicting `agent-approval-staleness.ts`'s framing of the staging badge as the notification the maintainer "gets."

## The fix

At both sites, when `insertNotificationDeliveryIfAbsent` reports `created: true` **and** the returned delivery's `status` is `"pending"`, send `{ type: "notify-deliver", requestedBy: "agent-approval", deliveryId: delivery.id }` on `env.JOBS` — mirroring `evaluateAndEnqueueNotificationDeliveries`. A dedup hit (`created: false`) or a rate-limit-suppressed non-pending row enqueues nothing, preserving the "exactly one badge per (PR, actionClass)" / "one badge per reminder bucket" contracts.

Both sends are **best-effort**: a rejected `env.JOBS.send` is caught, emits one structured `console.warn` (`event: "approval_notification_enqueue_failed"` with `deliveryId`/`repoFullName`/`pullNumber`), and does not abort staging (`stageForApproval` still returns `true`) or the sweep loop (still counts the reminder, continues to the next row). The `notify-deliver` `requestedBy` union is extended with `"agent-approval"`.

**Unchanged:** the two dedup keys, `insertNotificationDeliveryIfAbsent`, `deliverNotification`, `buildNotificationFeed`, and `sweepStrandedNotificationDeliveries`.

## Tests (`agent-approval-queue.test.ts`, `approval-queue-staleness.test.ts`)

- Staging an `auto_with_approval` action enqueues exactly one `notify-deliver` carrying the inserted delivery's id; a second staging (dedup) enqueues none.
- A row aged past `APPROVAL_REMINDER_INTERVAL_MS` enqueues exactly one reminder `notify-deliver`; a second sweep in the same bucket enqueues none.
- A rejected `env.JOBS.send` on either path warns `approval_notification_enqueue_failed` and does not change the return (`queued` / `reminded: 1`).
- **REGRESSION:** after staging + running `deliverNotification` for the enqueued id, `buildNotificationFeed` for the recipient now contains the staged-action item — against today's code the feed is empty (the row is still `pending`).
- All new assertions **fail on `main`**.

## Validation

- Diff coverage on both service files is **100%** line and branch (the created+pending / created+suppressed / not-created / send-rejects arms per call site). `types.ts` is a type-only change.
- `npm run typecheck` clean; `npm run engine-parity:drift-check`, `ui-derived-types:check`, and `manifest:drift-check` all pass (the `types.ts` change touches no generated artifact); `dead-exports:check` clean; both suites (117 tests) green.
- `git diff --check` clean; no schema/migration change.

Closes #10025
