### PR TITLE
fix(mcp): read the initialize handshake before the transport consumes the body

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -665,7 +665,12 @@ export async function handleMcpRequest(c: AppContext): Promise<Response> {
   if (!identity) return c.json({ error: "unauthorized" }, 401);
 
   const telemetry = buildMcpClientTelemetry(c.req.raw.headers, { defaultClientName: "mcp" })!;
-  const usageMetadata = await describeMcpUsageRequest(c.req.raw, telemetry.metadata);
+  // ONE clone-and-parse of the JSON-RPC body, here, BEFORE createMcpHandler below consumes it (#10190).
+  // A second `request.clone()` after that point throws `TypeError: unusable` -- the Fetch spec forbids
+  // cloning a request whose body is already disturbed -- which is why the post-response handshake read this
+  // replaces turned every `initialize` into an unhandled 500.
+  const envelope = await readMcpRequestEnvelope(c.req.raw);
+  const usageMetadata = describeMcpUsageRequest(envelope, c.req.raw.method, telemetry.metadata);
   const startedAt = Date.now();
   const executionCtx = getExecutionContext(c);
   // #9525: the dispatch chokepoint's sink is built per request so its deferred work rides this
@@ -693,7 +698,7 @@ export async function handleMcpRequest(c: AppContext): Promise<Response> {
     // a rejected handshake never inflates the session/client counts.
     if (response.status < 400) {
       if (usageMetadata.rpcMethod === "initialize") {
-        recordMcpInitialize(c.env, defer, await readInitializeHandshake(c.req.raw), analyticsContext);
+        recordMcpInitialize(c.env, defer, readInitializeHandshake(envelope), analyticsContext);
       } else if (usageMetadata.rpcMethod === "tools/list") {
         // Names come from this server's own registration chokepoint, not the cross-server contract
         // registry, so the event reports what was actually advertised to THIS client.
@@ -765,20 +770,35 @@ function trimmedHeader(value: string | null): string | undefined {
  * client. Returns an empty handshake for a malformed or absent body: the fields are optional by
  * contract, and a session that connected is still worth counting.
  */
-async function readInitializeHandshake(request: Request): Promise<McpInitializeTelemetry> {
-  const body = await request.clone().json().catch(() => null);
-  if (!body || typeof body !== "object") return {};
-  const clientInfo = (body as { params?: { clientInfo?: { name?: unknown; version?: unknown } } }).params?.clientInfo;
+function readInitializeHandshake(envelope: McpRequestEnvelope | null): McpInitializeTelemetry {
+  const clientInfo = envelope?.params?.clientInfo;
   return {
     clientName: typeof clientInfo?.name === "string" ? clientInfo.name : undefined,
     clientVersion: typeof clientInfo?.version === "string" ? clientInfo.version : undefined,
   };
 }
 
-async function describeMcpUsageRequest(request: Request, telemetryMetadata: Record<string, unknown> | undefined): Promise<Record<string, unknown>> {
+/** The JSON-RPC envelope fields the telemetry paths read. Deliberately structural and permissive: this is an
+ *  unvalidated client body, and every consumer below re-checks the type of the field it uses. */
+type McpRequestEnvelope = {
+  method?: unknown;
+  params?: { name?: unknown; clientInfo?: { name?: unknown; version?: unknown } };
+};
+
+/** Clone-and-parse the request body exactly once, at the top of {@link handleMcpRequest} (#10190). Returns
+ *  null for an absent or malformed body -- the telemetry fields are all optional by contract, and a request
+ *  that is still worth counting must never be failed over its own instrumentation. */
+async function readMcpRequestEnvelope(request: Request): Promise<McpRequestEnvelope | null> {
   const body = await request.clone().json().catch(() => null);
-  if (!body || typeof body !== "object") return { transport: "http", method: request.method, ...telemetryMetadata };
-  const envelope = body as { method?: unknown; params?: { name?: unknown } };
+  return body && typeof body === "object" ? (body as McpRequestEnvelope) : null;
+}
+
+function describeMcpUsageRequest(
+  envelope: McpRequestEnvelope | null,
+  method: string,
+  telemetryMetadata: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  if (!envelope) return { transport: "http", method, ...telemetryMetadata };
   const rpcMethod = typeof envelope.method === "string" ? envelope.method : undefined;
   const toolName = envelope.params && typeof envelope.params.name === "string" ? envelope.params.name : undefined;
   return {

--- a/test/unit/mcp-server-telemetry.test.ts
+++ b/test/unit/mcp-server-telemetry.test.ts
@@ -273,4 +273,51 @@ describe("MCP server telemetry", () => {
     expect(response.status).toBe(200);
     await expect(response.clone().json()).resolves.toEqual({ ok: true, result: "unchanged" });
   });
+
+  // REGRESSION (#10190): the #10175 handshake read called `c.req.raw.clone()` AFTER createMcpHandler had
+  // consumed the body. The Fetch spec forbids cloning a request whose body is already disturbed, so it threw
+  // `TypeError: unusable`, handleMcpRequest's catch rethrew, and a correct 2xx MCP response was replaced by an
+  // unhandled 500 -- on every `initialize`, i.e. the first call of every MCP session. The telemetry key gate
+  // did not save it: the handshake read is an ARGUMENT to recordMcpInitialize, evaluated before its no-op check.
+  const runInitialize = async (params: unknown): Promise<Response> => {
+    vi.resetModules();
+    // A handler that CONSUMES the request body, exactly as the real MCP transport does -- the whole point of
+    // the regression. A handler that ignored the body would pass even with the bug reintroduced.
+    vi.doMock("agents/mcp", () => ({
+      createMcpHandler: () => async (request: Request) => {
+        await request.text();
+        return Response.json({ jsonrpc: "2.0", id: "init", result: { protocolVersion: "2024-11-05" } });
+      },
+    }));
+    const { handleMcpRequest } = await import("../../src/mcp/server");
+    const env = createTestEnv({ PRODUCT_USAGE_HASH_SALT: "mcp-initialize-clone-salt" });
+    const request = new Request("https://api.test/mcp", {
+      method: "POST",
+      headers: { authorization: `Bearer ${env.LOOPOVER_MCP_TOKEN}`, "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: "init", method: "initialize", ...(params === undefined ? {} : { params }) }),
+    });
+    return handleMcpRequest({
+      env,
+      executionCtx: { waitUntil() {}, passThroughOnException() {} },
+      req: { method: "POST", raw: request, header: (name: string) => request.headers.get(name) ?? undefined },
+      json: (body: unknown, status?: number) => Response.json(body, status === undefined ? undefined : { status }),
+    } as never);
+  };
+
+  it("REGRESSION (#10190): an initialize whose body the handler consumed still returns the handler's response, not a 500", async () => {
+    const response = await runInitialize({
+      protocolVersion: "2024-11-05",
+      capabilities: {},
+      clientInfo: { name: "claude-code", version: "2.1.0" },
+    });
+    expect(response.status).toBe(200);
+    await expect(response.clone().json()).resolves.toMatchObject({ result: { protocolVersion: "2024-11-05" } });
+  });
+
+  it("REGRESSION (#10190): an initialize with no params, and one whose clientInfo fields are not strings, still succeed", async () => {
+    // The handshake fields are optional by contract -- a client that omits them must not be failed over
+    // LoopOver's own instrumentation.
+    await expect(runInitialize(undefined)).resolves.toMatchObject({ status: 200 });
+    await expect(runInitialize({ clientInfo: { name: 42, version: null } })).resolves.toMatchObject({ status: 200 });
+  });
 });


### PR DESCRIPTION
## Summary

Every MCP `initialize` request has been returning **500** since #10175 landed. The handshake telemetry it added called `c.req.raw.clone()` *after* `createMcpHandler` had already consumed the request body:

- The Fetch spec forbids cloning a request whose body is disturbed, so `readInitializeHandshake` threw `TypeError: unusable`.
- `handleMcpRequest`'s catch block rethrows, so a correct 2xx MCP response was discarded and replaced by an `unhandled_route_error` → 500.
- The telemetry gate did not contain it. `recordMcpInitialize` no-ops without `POSTHOG_API_KEY`, but the handshake read is an **argument** to it and is evaluated first — the throw happened regardless of configuration.

`initialize` is the first call of every MCP session, so no client could complete a handshake. `tools/list` was unaffected (`recordMcpToolsList` reads the server's own registered tool names and never touches the body).

The fix parses the JSON-RPC envelope **once**, before the handler runs, and derives both the usage metadata and the `clientInfo` handshake from that single parse. `describeMcpUsageRequest` and `readInitializeHandshake` become pure functions over that envelope, so no clone can survive past the handler again.

Closes #10190

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Coverage was measured scoped to the changed file rather than via a full `test:coverage` run: **100% of the changed lines and branches** in `src/mcp/server.ts` are covered (verified against the lcov report for `test/unit/mcp-server-telemetry.test.ts` + `test/integration/api.test.ts`). The unchecked commands are untouched surfaces — this diff changes no workflow, worker binding, OpenAPI schema, MCP package manifest, or UI file — and are left to CI.
- Both new tests were confirmed to **fail** with the fix reverted (`TypeError: unusable`) and pass with it, so they pin the regression rather than merely passing.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — no visible UI, frontend, docs, or extension change. This is a server-side request-handling fix.

## Notes

The existing integration test `test/integration/api.test.ts > api routes > serves private MCP tool listing and tool calls` was already failing on `main` at its `expect(telemetryDownInitialize.status).toBe(200)` assertion; it passes again with this change. The two added unit tests cover the handshake path directly, including an `initialize` with no `params` and one whose `clientInfo` fields are not strings — both must still succeed, since those fields are optional by contract and a client must never be failed over LoopOver's own instrumentation.
