### PR TITLE
fix(ci): unbreak main — drop the unused MCP_SERVER_NAME export

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -839,8 +839,9 @@ export function isMcpAdminEnabled(env: Env): boolean {
 
 /** The MCP `serverInfo.name` this server reports, and the `$mcp_server_name` its analytics carry.
  *  One constant so the handshake a client sees and the dashboards an operator reads can never
- *  disagree about what this server is called. */
-export const MCP_SERVER_NAME = "loopover";
+ *  disagree about what this server is called. Module-local: both readers (the handshake's serverInfo and
+ *  the analytics property builder) live in this file, and #10177 exported it without a consumer outside it. */
+const MCP_SERVER_NAME = "loopover";
 
 export class LoopoverMcp {
   private accessScopePromise: Promise<ControlPanelAccessScope> | null = null;


### PR DESCRIPTION
Closes #10194

`dead-exports:check` — part of `test:ci` — is red on a clean `main`:

```
check-dead-exports found 1 exported symbol(s) with no reference outside their own file:
  src/mcp/server.ts: MCP_SERVER_NAME (used internally — drop the `export` keyword)
```

**Every open PR inherits this**, so nothing can go green until it lands. Third instance of this class (#9944, #10109).

## Cause

#10177 added `export const MCP_SERVER_NAME = "loopover"` at `src/mcp/server.ts:843`. Both readers are in that same file — `serverInfo.name` (line 863) and the analytics property builder (line 679).

Checked for a cross-package reader before removing it: `CHAT_GROUNDING_MCP_SERVER_NAME` in `packages/loopover-engine` is a **separate** symbol, not this one re-exported.

## Change

Drop the `export`. The constant, both call sites, and its rationale (one constant so the handshake a client sees and the dashboards an operator reads cannot disagree) are all unchanged — it is simply module-local.

## Verification

`typecheck` clean · `dead-exports:check` green · **1,339 MCP tests pass**.

## Follow-up worth considering

Three times now a merged PR has left `main` red on this checker, each time blocking the queue until someone noticed. #10146's escalation covers a *workflow* red across consecutive runs, but this is a different signal: the PR was green when it merged. Worth understanding why a merge can turn this red when the PR wasn't — noted in the issue.