### PR TITLE
fix(observability): report the miner's real input/output token split to PostHog

### DIFF
--- a/packages/loopover-engine/src/miner/agent-sdk-driver.ts
+++ b/packages/loopover-engine/src/miner/agent-sdk-driver.ts
@@ -16,6 +16,7 @@ import type {
   CodingAgentDriver,
   CodingAgentDriverResult,
   CodingAgentDriverTask,
+  CodingAgentTokenUsage,
 } from "./coding-agent-driver.js";
 
 /**
@@ -91,13 +92,23 @@ function finiteNonNegativeNumber(value: unknown): number | undefined {
  *  as `total_cost_usd`. `NonNullableUsage`'s `input_tokens`/`output_tokens` are themselves non-nullable numbers
  *  once `usage` exists, but this driver reads `resultMessage` as a loosely-typed record (like every other field
  *  read here), so both are re-validated defensively (finite + non-negative, #5827) rather than trusted from an
- *  untyped source. Returns undefined (never a fabricated 0) when `usage` is absent or malformed. */
-function tokensFromResultMessage(resultMessage: Record<string, unknown> | null): number | undefined {
+ *  untyped source. Returns an EMPTY usage (never a fabricated 0) when `usage` is absent or malformed.
+ *
+ *  #10198: returns the split alongside the blended total rather than only the sum. Both sides were already read
+ *  here and then added together, discarding the parts -- which left the miner with nothing to put in PostHog's
+ *  own `$ai_input_tokens`/`$ai_output_tokens`, the properties its cost views read. Each field is omitted rather
+ *  than zeroed when the provider did not report it: a fabricated 0 is indistinguishable from a real one in an
+ *  aggregate. */
+function tokensFromResultMessage(resultMessage: Record<string, unknown> | null): CodingAgentTokenUsage {
   const usage = asRecord(resultMessage?.usage);
   const inputTokens = finiteNonNegativeNumber(usage?.input_tokens);
   const outputTokens = finiteNonNegativeNumber(usage?.output_tokens);
-  if (inputTokens === undefined && outputTokens === undefined) return undefined;
-  return (inputTokens ?? 0) + (outputTokens ?? 0);
+  if (inputTokens === undefined && outputTokens === undefined) return {};
+  return {
+    tokensUsed: (inputTokens ?? 0) + (outputTokens ?? 0),
+    ...(inputTokens === undefined ? {} : { inputTokens }),
+    ...(outputTokens === undefined ? {} : { outputTokens }),
+  };
 }
 
 async function listWorktreeChangedFiles(cwd: string): Promise<string[]> {
@@ -197,7 +208,7 @@ export function createAgentSdkCodingAgentDriver(
       // `total_cost_usd: number` unconditionally -- present whenever a result message arrived at all, success
       // or not (the session was billed either way), absent only when the stream produced no result message.
       const costUsd = finiteNonNegativeNumber(resultMessage?.total_cost_usd);
-      const tokensUsed = tokensFromResultMessage(resultMessage);
+      const tokenUsage = tokensFromResultMessage(resultMessage);
       const resultText =
         typeof resultMessage?.result === "string" ? redactSecrets(resultMessage.result) : "";
       const transcript = redactSecrets(
@@ -224,7 +235,7 @@ export function createAgentSdkCodingAgentDriver(
           transcript,
           turnsUsed,
           costUsd,
-          tokensUsed,
+          ...tokenUsage,
           error: `agent_sdk_${subtype === "success" ? "errored" : subtype}`,
         };
       }
@@ -241,7 +252,7 @@ export function createAgentSdkCodingAgentDriver(
           transcript,
           turnsUsed,
           costUsd,
-          tokensUsed,
+          ...tokenUsage,
           error: `agent_sdk_changed_files_unavailable: ${detail}`,
         };
       }
@@ -254,7 +265,7 @@ export function createAgentSdkCodingAgentDriver(
         transcript,
         turnsUsed,
         costUsd,
-        tokensUsed,
+        ...tokenUsage,
       };
     },
   };

--- a/packages/loopover-engine/src/miner/cli-subprocess-driver.ts
+++ b/packages/loopover-engine/src/miner/cli-subprocess-driver.ts
@@ -2,6 +2,7 @@ import type {
   CodingAgentDriver,
   CodingAgentDriverResult,
   CodingAgentDriverTask,
+  CodingAgentTokenUsage,
 } from "./coding-agent-driver.js";
 import { buildAllowlistedEnv, redactSecrets } from "../subprocess-env.js";
 
@@ -206,10 +207,18 @@ function extractCliUsage(stdout: string): CliUsage {
 /** Real token count (input + output) from `extractCliUsage`'s CliUsage, when either is present -- prefers an
  *  explicit `totalTokens` key if the CLI reported one directly (never double-counted against input+output),
  *  otherwise sums input+output. Undefined (never a fabricated 0) when neither is present. */
-function totalTokensFromUsage(usage: CliUsage): number | undefined {
-  if (usage.totalTokens !== undefined) return usage.totalTokens;
-  if (usage.inputTokens === undefined && usage.outputTokens === undefined) return undefined;
-  return (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0);
+/** #10198: carries the input/output split through alongside the blended total. The CLI reports the two sides
+ *  separately and this used to return only their sum, so the miner could not populate PostHog's own
+ *  `$ai_input_tokens`/`$ai_output_tokens`. A CLI that reports ONLY `totalTokens` still yields just the blended
+ *  figure -- the split stays absent rather than being invented from it. */
+function totalTokensFromUsage(usage: CliUsage): CodingAgentTokenUsage {
+  const split = {
+    ...(usage.inputTokens === undefined ? {} : { inputTokens: usage.inputTokens }),
+    ...(usage.outputTokens === undefined ? {} : { outputTokens: usage.outputTokens }),
+  };
+  if (usage.totalTokens !== undefined) return { tokensUsed: usage.totalTokens, ...split };
+  if (usage.inputTokens === undefined && usage.outputTokens === undefined) return {};
+  return { tokensUsed: (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0), ...split };
 }
 
 /** Claude Code's `--output-format json` sometimes exits non-zero while still emitting a structured
@@ -282,10 +291,9 @@ export function createCliSubprocessCodingAgentDriver(options: CliSubprocessDrive
       // below report spend symmetrically with the success path and with agent-sdk-driver.ts, preventing
       // attempt-metering budget-ceiling undercounting (#8871). extractCliUsage tolerates unparseable/empty stdout.
       const usage = extractCliUsage(spawned.stdout);
-      const tokensUsed = totalTokensFromUsage(usage);
       const usageFields = {
         ...(usage.costUsd !== undefined ? { costUsd: usage.costUsd } : {}),
-        ...(tokensUsed !== undefined ? { tokensUsed } : {}),
+        ...totalTokensFromUsage(usage),
       };
 
       if (spawned.timedOut && spawned.stalledNoOutput) {

--- a/packages/loopover-engine/src/miner/coding-agent-driver.ts
+++ b/packages/loopover-engine/src/miner/coding-agent-driver.ts
@@ -27,8 +27,19 @@ export type CodingAgentDriverResult = {
    *  zero) when the provider never got far enough, or reports no token signal at all -- never fabricated,
    *  mirroring `costUsd`'s own convention. */
   tokensUsed?: number | undefined;
+  /** The input/output split behind `tokensUsed`, when the provider reports the two sides separately (#10198).
+   *  Both drivers already read them individually and then summed them away, which left the miner unable to
+   *  populate PostHog's own `$ai_input_tokens`/`$ai_output_tokens` -- the properties its cost views read --
+   *  so miner spend was invisible there. Same never-fabricated convention as the two fields above: a provider
+   *  that reports only a blended total leaves these absent, and the blended `tokensUsed` still stands alone. */
+  inputTokens?: number | undefined;
+  outputTokens?: number | undefined;
   error?: string | undefined;
 };
+
+/** The token fields a driver contributes to its result (#10198) -- spread into the result at each return site
+ *  so a driver can never report a split that disagrees with its own blended total. */
+export type CodingAgentTokenUsage = Pick<CodingAgentDriverResult, "tokensUsed" | "inputTokens" | "outputTokens">;
 
 export interface CodingAgentDriver {
   run(task: CodingAgentDriverTask): Promise<CodingAgentDriverResult>;

--- a/packages/loopover-engine/test/agent-sdk-driver.test.ts
+++ b/packages/loopover-engine/test/agent-sdk-driver.test.ts
@@ -397,3 +397,79 @@ test("constructs with no options, defaulting to the real SDK query loop without 
   const driver = createAgentSdkCodingAgentDriver();
   assert.equal(typeof driver.run, "function");
 });
+
+// #10198: the driver used to sum input/output tokens and DISCARD the two sides. The miner's PostHog capture
+// therefore had nothing to put in `$ai_input_tokens`/`$ai_output_tokens` -- the properties PostHog's own cost
+// views read -- so every miner generation registered there as 0 input and 0 output tokens.
+test("reports the input/output split alongside the blended total (#10198)", async () => {
+  const driver = driverWith({
+    query: queryYielding([
+      {
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        num_turns: 2,
+        result: "done",
+        usage: { input_tokens: 1000, output_tokens: 234 },
+      },
+    ]),
+  });
+
+  const result = await driver.run(task);
+
+  assert.equal(result.tokensUsed, 1234);
+  assert.equal(result.inputTokens, 1000);
+  assert.equal(result.outputTokens, 234);
+});
+
+test("the split rides the failure results too, exactly like tokensUsed and costUsd (#10198)", async () => {
+  const driver = driverWith({
+    query: queryYielding([
+      {
+        type: "result",
+        subtype: "error_max_turns",
+        is_error: true,
+        num_turns: 6,
+        total_cost_usd: 0.05,
+        usage: { input_tokens: 500, output_tokens: 100 },
+      },
+    ]),
+  });
+
+  const result = await driver.run(task);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.inputTokens, 500);
+  assert.equal(result.outputTokens, 100);
+});
+
+test("a side the provider did not report stays ABSENT rather than being zeroed (#10198)", async () => {
+  // A fabricated 0 is indistinguishable from a real 0 once aggregated, so an out-of-contract or missing side
+  // must not become one -- the blended total still counts only what was real.
+  const onlyInput = driverWith({
+    query: queryYielding([
+      { type: "result", subtype: "success", is_error: false, num_turns: 2, result: "done", usage: { input_tokens: 100 } },
+    ]),
+  });
+  const onlyInputResult = await onlyInput.run(task);
+  assert.equal(onlyInputResult.tokensUsed, 100);
+  assert.equal(onlyInputResult.inputTokens, 100);
+  assert.equal(onlyInputResult.outputTokens, undefined);
+
+  const badOutput = driverWith({
+    query: queryYielding([
+      { type: "result", subtype: "success", is_error: false, num_turns: 2, result: "done", usage: { input_tokens: 100, output_tokens: -5 } },
+    ]),
+  });
+  const badOutputResult = await badOutput.run(task);
+  assert.equal(badOutputResult.tokensUsed, 100);
+  assert.equal(badOutputResult.outputTokens, undefined);
+
+  const noUsage = driverWith({
+    query: queryYielding([{ type: "result", subtype: "success", is_error: false, num_turns: 2, result: "done" }]),
+  });
+  const noUsageResult = await noUsage.run(task);
+  assert.equal(noUsageResult.tokensUsed, undefined);
+  assert.equal(noUsageResult.inputTokens, undefined);
+  assert.equal(noUsageResult.outputTokens, undefined);
+});

--- a/packages/loopover-miner/lib/coding-agent-construction.ts
+++ b/packages/loopover-miner/lib/coding-agent-construction.ts
@@ -78,9 +78,9 @@ export function createRealCliSubprocessSpawn(): CliSubprocessSpawnFn {
  *  vendor client -- the same "no cross-package import" boundary this file's own header already documents
  *  for its spawn implementation): this is the miner CLI's own host-bound construction site, exactly where
  *  `src/selfhost/`'s equivalent ORB-side wrapper (`withAiGenerationCapture`, ai.ts) lives relative to its
- *  own chain. `CodingAgentDriverResult` carries a single blended `costUsd`/`tokensUsed` (no input/output
- *  split, unlike ORB's `AiUsage`) -- captureMinerPostHogAiGeneration is deliberately built for that exact
- *  shape, never fabricating a split its source data doesn't have. A driver failure is reported via
+ *  own chain. `CodingAgentDriverResult` carries the blended `costUsd`/`tokensUsed` plus the input/output
+ *  split when the provider reported one (#10198); all of it is forwarded verbatim, and a driver that knows
+ *  no split simply leaves those fields absent rather than having one fabricated. A driver failure is reported via
  *  `result.ok === false` (the real, observed contract every shipped driver follows -- none of them throw
  *  for an ordinary task failure), with a genuine thrown exception handled defensively on top. */
 export function withCodingAgentAiGenerationCapture(providerName: string, model: string, driver: CodingAgentDriver): CodingAgentDriver {
@@ -95,6 +95,8 @@ export function withCodingAgentAiGenerationCapture(providerName: string, model: 
           latencyMs: Date.now() - startedAtMs,
           isError: !result.ok,
           totalTokens: result.tokensUsed,
+          inputTokens: result.inputTokens,
+          outputTokens: result.outputTokens,
           totalCostUsd: result.costUsd,
           error: result.ok ? undefined : result.error,
         });

--- a/packages/loopover-miner/lib/posthog.ts
+++ b/packages/loopover-miner/lib/posthog.ts
@@ -114,20 +114,24 @@ export function captureMinerPostHogEvent(event: string, properties: Record<strin
   }
 }
 
-/** One AMS coding-agent driver attempt (#8296 AMS follow-up, epic #8286 track 3). All three driver types
- *  (claude-cli/codex-cli/agent-sdk, packages/loopover-engine's CodingAgentDriver) report a single blended
- *  `costUsd`/`tokensUsed` -- unlike ORB's self-host `AiUsage`, there is no input/output split available at
- *  this layer, so this deliberately does NOT populate `$ai_input_tokens`/`$ai_output_tokens` with a
- *  fabricated split (they stay 0, honestly representing "no split known"); the real total rides in the
- *  plain `tokens_used` property instead. `$ai_total_cost_usd` IS one of PostHog's own recognized
- *  `$ai_generation` properties and needs no split, so it's populated directly when known. No field here
- *  ever carries prompt/diff/transcript content -- metadata only, same policy as the ORB side. */
+/** One AMS coding-agent driver attempt (#8296 AMS follow-up, epic #8286 track 3).
+ *
+ *  #10198: `inputTokens`/`outputTokens` are the REAL split, now that `CodingAgentDriverResult` carries it.
+ *  Both engine drivers already read the two sides from their provider and then summed them away, so this
+ *  event could only report a blended `tokens_used` -- a property PostHog's own cost views do not read, which
+ *  made every miner generation register as 0 input and 0 output tokens there. The split is still never
+ *  FABRICATED: a provider that reports only a blended total leaves both absent, and the blended figure keeps
+ *  riding in `tokens_used` on its own. `$ai_total_cost_usd` is one of PostHog's recognized properties and
+ *  needs no split, so it is populated directly when known. No field here ever carries prompt/diff/transcript
+ *  content -- metadata only, same policy as the ORB side. */
 export type MinerAiGenerationEvent = {
   provider: string;
   model: string;
   latencyMs: number;
   isError: boolean;
   totalTokens?: number | undefined;
+  inputTokens?: number | undefined;
+  outputTokens?: number | undefined;
   totalCostUsd?: number | undefined;
   error?: unknown;
 };
@@ -143,8 +147,11 @@ export function captureMinerPostHogAiGeneration(event: MinerAiGenerationEvent): 
     // PostHog's own $ai_generation schema reports latency in SECONDS, not ms.
     $ai_latency: event.latencyMs / 1000,
     $ai_http_status: event.isError ? 500 : 200,
-    $ai_input_tokens: 0,
-    $ai_output_tokens: 0,
+    // #10198: the provider's real split when it reported one. 0 remains the honest fallback for a provider
+    // that only ever reports a blended total -- it means "no split known", and `tokens_used` below still
+    // carries the figure that IS known.
+    $ai_input_tokens: Number.isFinite(event.inputTokens) ? event.inputTokens : 0,
+    $ai_output_tokens: Number.isFinite(event.outputTokens) ? event.outputTokens : 0,
     $ai_is_error: event.isError,
   };
   if (Number.isFinite(event.totalTokens)) properties.tokens_used = event.totalTokens;

--- a/test/unit/cli-subprocess-driver.test.ts
+++ b/test/unit/cli-subprocess-driver.test.ts
@@ -529,6 +529,52 @@ describe("createCliSubprocessCodingAgentDriver (#4266)", () => {
   });
 
   describe("REGRESSION: real token-usage extraction, ported from src/selfhost/ai.ts's extractCliUsage (#5653)", () => {
+    // #10198: the driver read both sides and returned only their sum, so the miner's PostHog capture had
+    // nothing for `$ai_input_tokens`/`$ai_output_tokens` -- the properties PostHog's own cost views read.
+    it("reports the input/output split alongside the blended total (#10198)", async () => {
+      const { spawn } = fakeSpawn({
+        stdout: JSON.stringify({ type: "result", subtype: "success", result: "done", input_tokens: 1000, output_tokens: 234 }),
+        code: 0,
+      });
+      const driver = createCliSubprocessCodingAgentDriver({ command: "claude", spawn });
+      const result = await driver.run(TASK);
+      expect(result.tokensUsed).toBe(1234);
+      expect(result.inputTokens).toBe(1000);
+      expect(result.outputTokens).toBe(234);
+    });
+
+    it("keeps an explicit total_tokens as the blended figure WITHOUT inventing a split from it (#10198)", async () => {
+      // A CLI that reports only a total genuinely has no split to report; deriving one would be a fabrication.
+      const { spawn } = fakeSpawn({ stdout: JSON.stringify({ total_tokens: 999 }), code: 0 });
+      const driver = createCliSubprocessCodingAgentDriver({ command: "claude", spawn });
+      const result = await driver.run(TASK);
+      expect(result.tokensUsed).toBe(999);
+      expect(result.inputTokens).toBeUndefined();
+      expect(result.outputTokens).toBeUndefined();
+    });
+
+    it("carries the split through when total_tokens AND the two sides are all reported (#10198)", async () => {
+      const { spawn } = fakeSpawn({
+        stdout: JSON.stringify({ input_tokens: 100, output_tokens: 50, total_tokens: 999 }),
+        code: 0,
+      });
+      const driver = createCliSubprocessCodingAgentDriver({ command: "claude", spawn });
+      const result = await driver.run(TASK);
+      // The CLI's own total still wins over the sum -- unchanged from before the split existed.
+      expect(result.tokensUsed).toBe(999);
+      expect(result.inputTokens).toBe(100);
+      expect(result.outputTokens).toBe(50);
+    });
+
+    it("leaves a side ABSENT rather than zeroed when the CLI reported only one of them (#10198)", async () => {
+      const { spawn } = fakeSpawn({ stdout: JSON.stringify({ input_tokens: 42 }), code: 0 });
+      const driver = createCliSubprocessCodingAgentDriver({ command: "claude", spawn });
+      const result = await driver.run(TASK);
+      expect(result.tokensUsed).toBe(42);
+      expect(result.inputTokens).toBe(42);
+      expect(result.outputTokens).toBeUndefined();
+    });
+
     it("sums claude's top-level input_tokens + output_tokens from its single JSON result on success", async () => {
       const { spawn } = fakeSpawn({
         stdout: JSON.stringify({ type: "result", subtype: "success", result: "done", input_tokens: 1000, output_tokens: 234 }),

--- a/test/unit/miner-coding-agent-construction.test.ts
+++ b/test/unit/miner-coding-agent-construction.test.ts
@@ -211,12 +211,12 @@ describe("withCodingAgentAiGenerationCapture (#8296 AMS follow-up)", () => {
     expect(posthogMock.capture).not.toHaveBeenCalled();
   });
 
-  it("captures a successful attempt's cost/tokens as a combined figure (no fabricated input/output split)", async () => {
+  it("forwards the driver's cost, blended tokens AND input/output split to the capture (#10198)", async () => {
     await initMinerPostHog({ LOOPOVER_MINER_POSTHOG_API_KEY: "phc_test_key" });
     const driver = withCodingAgentAiGenerationCapture(
       "claude-cli",
       "claude-sonnet-5",
-      driverReturning({ ok: true, changedFiles: ["a.ts"], summary: "done", transcript: "", costUsd: 0.12, tokensUsed: 4000 }),
+      driverReturning({ ok: true, changedFiles: ["a.ts"], summary: "done", transcript: "", costUsd: 0.12, tokensUsed: 4000, inputTokens: 3200, outputTokens: 800 }),
     );
     await driver.run(task);
     expect(posthogMock.capture).toHaveBeenCalledTimes(1);
@@ -225,7 +225,23 @@ describe("withCodingAgentAiGenerationCapture (#8296 AMS follow-up)", () => {
     expect(properties.$ai_model).toBe("claude-sonnet-5");
     expect(properties.$ai_is_error).toBe(false);
     expect(properties.tokens_used).toBe(4000);
+    expect(properties.$ai_input_tokens).toBe(3200);
+    expect(properties.$ai_output_tokens).toBe(800);
     expect(properties.$ai_total_cost_usd).toBe(0.12);
+  });
+
+  it("leaves the split at 0 for a driver that reports only a blended total (#10198)", async () => {
+    await initMinerPostHog({ LOOPOVER_MINER_POSTHOG_API_KEY: "phc_test_key" });
+    const driver = withCodingAgentAiGenerationCapture(
+      "codex-cli",
+      "gpt-5-codex",
+      driverReturning({ ok: true, changedFiles: [], summary: "done", transcript: "", tokensUsed: 4000 }),
+    );
+    await driver.run(task);
+    const { properties } = posthogMock.capture.mock.calls[0]?.[0];
+    expect(properties.tokens_used).toBe(4000);
+    expect(properties.$ai_input_tokens).toBe(0);
+    expect(properties.$ai_output_tokens).toBe(0);
   });
 
   it("captures result.ok:false as a failure, using the driver's own error string -- no exception thrown", async () => {

--- a/test/unit/miner-posthog.test.ts
+++ b/test/unit/miner-posthog.test.ts
@@ -155,9 +155,9 @@ describe("loopover-miner opt-in PostHog (#8292, epic #8286)", () => {
       expect(posthogMock.capture).not.toHaveBeenCalled();
     });
 
-    it("captures a well-formed $ai_generation event with a combined tokens_used property (no fabricated input/output split)", async () => {
+    it("captures a well-formed $ai_generation event, keeping the blended tokens_used alongside the real split", async () => {
       await initMinerPostHog({ LOOPOVER_MINER_POSTHOG_API_KEY: "phc_test_key" });
-      captureMinerPostHogAiGeneration({ ...BASE, totalTokens: 1500, totalCostUsd: 0.05 });
+      captureMinerPostHogAiGeneration({ ...BASE, totalTokens: 1500, inputTokens: 1200, outputTokens: 300, totalCostUsd: 0.05 });
       expect(posthogMock.capture).toHaveBeenCalledTimes(1);
       const call = posthogMock.capture.mock.calls[0]?.[0];
       expect(call.event).toBe("$ai_generation");
@@ -166,13 +166,30 @@ describe("loopover-miner opt-in PostHog (#8292, epic #8286)", () => {
       expect(call.properties.$ai_provider).toBe("claude-cli");
       expect(call.properties.$ai_latency).toBe(2.5);
       expect(call.properties.$ai_http_status).toBe(200);
-      expect(call.properties.$ai_input_tokens).toBe(0);
-      expect(call.properties.$ai_output_tokens).toBe(0);
+      // #10198: these are the properties PostHog's own cost views read. They were hardcoded to 0, so the
+      // miner's whole spend was invisible there while the real figure sat in the non-standard tokens_used.
+      expect(call.properties.$ai_input_tokens).toBe(1200);
+      expect(call.properties.$ai_output_tokens).toBe(300);
       expect(call.properties.tokens_used).toBe(1500);
       expect(call.properties.$ai_total_cost_usd).toBe(0.05);
       expect(call.properties.$ai_is_error).toBe(false);
       expect("$ai_input" in call.properties).toBe(false);
       expect("$ai_output_choices" in call.properties).toBe(false);
+    });
+
+    it("falls back to 0 for a side the driver could not report, without losing the blended total (#10198)", async () => {
+      // A provider that reports only a blended total genuinely has no split; 0 here means "no split known",
+      // and tokens_used still carries the figure that IS known.
+      await initMinerPostHog({ LOOPOVER_MINER_POSTHOG_API_KEY: "phc_test_key" });
+      captureMinerPostHogAiGeneration({ ...BASE, totalTokens: 999 });
+      captureMinerPostHogAiGeneration({ ...BASE, totalTokens: 999, inputTokens: 800, outputTokens: Number.NaN });
+      const blended = posthogMock.capture.mock.calls[0]?.[0].properties;
+      expect(blended.$ai_input_tokens).toBe(0);
+      expect(blended.$ai_output_tokens).toBe(0);
+      expect(blended.tokens_used).toBe(999);
+      const partial = posthogMock.capture.mock.calls[1]?.[0].properties;
+      expect(partial.$ai_input_tokens).toBe(800);
+      expect(partial.$ai_output_tokens).toBe(0);
     });
 
     it("omits tokens_used/$ai_total_cost_usd when neither is supplied or finite", async () => {


### PR DESCRIPTION
## Summary

The miner reported **0 input tokens and 0 output tokens** on every `$ai_generation`, so PostHog's own LLM cost views were blind to AMS spend entirely. The real figure was emitted, but under a non-standard `tokens_used` property those views do not read.

`captureMinerPostHogAiGeneration` hardcoded the two properties, and its doc comment justified that as honest — *"there is no input/output split available at this layer"*. That was true **of that layer**, but the layer below threw the split away: both engine drivers read the two sides and returned only their sum.

- `agent-sdk-driver.ts` read `usage.input_tokens` / `usage.output_tokens`, then returned `(inputTokens ?? 0) + (outputTokens ?? 0)`.
- `cli-subprocess-driver.ts` did the same with `usage.inputTokens` / `usage.outputTokens`.

So the fix is not to relabel anything — it is to stop discarding data that was already in hand. `CodingAgentDriverResult` now carries `inputTokens`/`outputTokens` alongside the existing blended `tokensUsed`, both drivers populate them from values they already read, and the miner reports them.

The never-fabricate convention `costUsd` and `tokensUsed` already follow is preserved throughout:

- A CLI that reports only `total_tokens` genuinely has no split; it leaves both sides absent and the blended figure keeps riding in `tokens_used`. Deriving a split from a total would be an invention.
- A side that is missing, or out-of-contract (negative / `NaN` / `Infinity`), stays absent rather than becoming a `0` — once aggregated, a fabricated 0 is indistinguishable from a real one.
- `0` therefore survives as the miner-side fallback only where it means "no split known".

Each driver's token fields are produced by a single expression and spread into every return site, so a driver cannot report a split that disagrees with its own blended total.

Closes #10198

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [x] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- `npm run build:miner` and the `@loopover/engine` workspace suite (942 tests) were both run and are green; the engine package was rebuilt before every test run so the `dist/`-importing engine tests exercised the new code rather than a stale build.
- Coverage was measured scoped to the five changed files rather than via a full `test:coverage` run: **100% of the changed lines AND branches** in all five, verified line-by-line against the lcov report rather than read off a summary percentage. Engine behaviour is covered from `packages/loopover-engine/test/**` as well as the root suite, so the engine upload credits it independently.
- The unchecked commands cover untouched surfaces (no workflow, worker binding, OpenAPI schema, or UI file changes here) and are left to CI.

### Tests added

Two existing tests asserted the hardcoded zeros and the "no fabricated split" rationale; both were updated to the corrected expectation rather than deleted, since the rationale itself is what changed.

- Engine (`packages/loopover-engine/test/agent-sdk-driver.test.ts`): the split alongside the blended total; the split riding the **failure** results too, exactly like `tokensUsed`/`costUsd` (the session was billed either way); and a side left absent rather than zeroed when it is missing, out-of-contract, or when `usage` is absent entirely.
- CLI driver: the split reported alongside the total; an explicit `total_tokens` kept as the blended figure **without** inventing a split from it; `total_tokens` plus both sides all reported together (the CLI's own total still wins over the sum, unchanged); and a single reported side left absent on the other.
- Miner: the real split reaching `$ai_input_tokens`/`$ai_output_tokens`, and the 0-fallback for a driver that only knows a blended total, including a partially-reported case.
- `withCodingAgentAiGenerationCapture`: forwards cost, blended tokens and the split verbatim, and leaves the split at 0 for a driver that reports only a total.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

Token counts are metadata, not content: no prompt, diff, or transcript text is added to any event by this change, and the existing assertions that `$ai_input`/`$ai_output_choices` are never present still hold.

## UI Evidence

Not applicable — no visible UI, frontend, docs, or extension change.

## Notes

The blended `tokens_used` property is deliberately kept rather than replaced. It is the only figure available for a provider that reports no split, and dropping it would lose data for exactly the callers that have the least of it.

Two AMS surfaces remain uninstrumented and are out of scope here — `runChatGrounding` (`packages/loopover-engine/src/miner/chat-grounding.ts`) and the `runCodingAgentAttempt` path, which calls `createCodingAgentDriver` directly and so bypasses `constructProductionCodingAgentDriver`'s capture wrapper entirely. Both warrant their own issue and change.
