### PR TITLE
fix(selfhost): stop the redaction scrubber nulling every AI token count

### DIFF
--- a/src/selfhost/redaction-scrub.ts
+++ b/src/selfhost/redaction-scrub.ts
@@ -232,7 +232,14 @@ export function scrubRecord(obj: unknown, depth: number): void {
       delete rec[key];
       continue;
     }
-    if (shouldRedactKey(key)) {
+    // #10211: a secret-shaped KEY holding a NUMBER is a counter, not a credential. Every secret this module
+    // exists to catch -- a token, an API key, a password, a cookie, a DSN, a bearer header -- is a string;
+    // there is no numeric form of one to leak. Redacting numbers anyway silently destroyed real telemetry:
+    // SECRET_KEY matches /token/i, so PostHog's own `$ai_input_tokens`/`$ai_output_tokens` were rewritten to
+    // the "[redacted]" STRING, which PostHog then coerced to null on its numerically-typed properties. The
+    // result was that not one AI call in the project ever carried a token count, while cost came through
+    // untouched (`$ai_total_cost_usd` has no secret-shaped word in it).
+    if (shouldRedactKey(key) && typeof rec[key] !== "number") {
       rec[key] = REDACTED;
       continue;
     }

--- a/test/unit/selfhost-redaction-scrub.test.ts
+++ b/test/unit/selfhost-redaction-scrub.test.ts
@@ -87,3 +87,56 @@ describe("scrubRecord — end-to-end via the structured-identifier keys (#9142)"
     expect(properties.detail).toContain("private context");
   });
 });
+
+describe("scrubRecord — a secret-shaped key holding a NUMBER is a counter, not a credential (#10211)", () => {
+  it("REGRESSION: PostHog's own token-count properties survive the scrub", () => {
+    // SECRET_KEY matches /token/i, so these were rewritten to the "[redacted]" STRING and PostHog then
+    // coerced that to null on its numerically-typed properties -- not one AI call in the live project
+    // ever carried a token count, while $ai_total_cost_usd came through untouched.
+    const properties: Record<string, unknown> = {
+      $ai_input_tokens: 1200,
+      $ai_output_tokens: 300,
+      $ai_total_cost_usd: 0.44,
+      tokens_used: 1500,
+    };
+    scrubRecord(properties, 0);
+    expect(properties.$ai_input_tokens).toBe(1200);
+    expect(properties.$ai_output_tokens).toBe(300);
+    expect(properties.$ai_total_cost_usd).toBe(0.44);
+    expect(properties.tokens_used).toBe(1500);
+  });
+
+  it("a zero count is preserved rather than read as absent", () => {
+    const properties: Record<string, unknown> = { $ai_input_tokens: 0 };
+    scrubRecord(properties, 0);
+    expect(properties.$ai_input_tokens).toBe(0);
+  });
+
+  it("still redacts a secret-shaped key holding a STRING, which is the only shape a real credential takes", () => {
+    const properties: Record<string, unknown> = {
+      api_token: ["ghp", "abcdefghijklmnopqrst123456"].join("_"),
+      password: "hunter2",
+      authorization: "Bearer abc.def.ghi",
+      session_cookie: "sid=abc123",
+    };
+    scrubRecord(properties, 0);
+    expect(properties.api_token).toBe(REDACTED);
+    expect(properties.password).toBe(REDACTED);
+    expect(properties.authorization).toBe(REDACTED);
+    expect(properties.session_cookie).toBe(REDACTED);
+  });
+
+  it("still redacts a secret-shaped key holding a non-numeric, non-string value", () => {
+    // An object or array under a secret-shaped key is not a counter, so the number carve-out must not
+    // widen into "anything that is not a string".
+    const properties: Record<string, unknown> = {
+      credentials: { token: "abc" },
+      api_keys: ["one", "two"],
+      secret_flag: true,
+    };
+    scrubRecord(properties, 0);
+    expect(properties.credentials).toBe(REDACTED);
+    expect(properties.api_keys).toBe(REDACTED);
+    expect(properties.secret_flag).toBe(REDACTED);
+  });
+});


### PR DESCRIPTION
## Summary

**Not one AI call in the project has ever carried a token count.** The privacy scrubber was eating them.

`SECRET_KEY` matches `/token/i`, and `scrubRecord` — wired as posthog-node's `before_send` — redacts on **key** match. So PostHog's own `$ai_input_tokens` and `$ai_output_tokens` were rewritten to the `"[redacted]"` *string*, which PostHog then coerced to `null` on its numerically-typed properties. Confirmed on a real live event:

```json
{"$ai_input_tokens":null,"$ai_output_tokens":null,"$ai_latency":10.308,
 "$ai_model":"claude-sonnet-5","$ai_provider":"claude-code",
 "$ai_total_cost_usd":0.44771210000000006, ...}
```

`$ai_total_cost_usd` survives because it has no secret-shaped word in it. The token fields do not.

### Impact

`posthog.ai_events.input_tokens` / `output_tokens` / `total_tokens` are NULL for **every** model over the retention window — including `claude-sonnet-5` at 2,321 calls and $498.43 of real spend. PostHog's LLM cost views break spend down by token usage, so the ORB shows dollars but no tokens/call, no input-vs-output ratio, and no cost-per-token. `$ai_input_cost_usd` / `$ai_output_cost_usd`, which PostHog derives from tokens, could not be computed at all.

It would also have silently defeated the miner-side token split landed in #10199: those events pass through the same scrubber.

### Fix

A secret-shaped key holding a **number** is a counter, not a credential. Every secret this module exists to catch — a token, an API key, a password, a cookie, a DSN, a bearer header — is a string; there is no numeric form of one to leak. Numbers are skipped; a string, object, array or boolean under the same key is still redacted exactly as before.

Deliberately general rather than an allowlist of the two `$ai_*` keys. An allowlist goes stale the moment PostHog adds `$ai_cache_read_input_tokens` or the code adds another counter — and it would fail the same silent way this bug did.

Closes #10211

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Every redaction-related suite was run and is green: `selfhost-redaction-scrub`, `selfhost-posthog`, `redaction`, `prompt-packet-redaction` (264 tests). Coverage measured scoped to the changed file: **100% of the changed lines and branches**, verified line-by-line against lcov rather than read off a summary.
- The regression tests were confirmed to **fail** with the fix reverted and pass with it.
- The unchecked commands cover untouched surfaces (no workflow, binding, schema, MCP manifest or UI change here) and are left to CI.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

**This narrows a redaction rule, so it deserves the scrutiny.** The carve-out is numbers only, and three of the four new tests exist specifically to pin the boundary: a string under `api_token` / `password` / `authorization` / `session_cookie` is still redacted, and so is an object, an array, or a boolean under a secret-shaped key. The number case cannot carry a credential — a bearer token, PAT, JWT, DSN, cookie or password has no numeric representation. Value-based scrubbing (`SECRET_VALUE`, the JWT and query-string paths) is untouched and still applies to every string regardless of its key.

## UI Evidence

Not applicable — no visible UI, frontend, docs, or extension change.

## Notes

Found while investigating why PostHog's LLM Analytics **Token usage** column was empty for every trace. The same investigation confirmed the ORB is emitting the events correctly — cost, latency, model, provider, repo and trace id all arrive intact — so this was the only thing standing between the project and real token metrics.
