### PR TITLE
refactor(advisory): give addPullRequestFindings named signals instead of a 12-argument tail

### DIFF
--- a/packages/loopover-engine/src/advisory/gate-advisory.ts
+++ b/packages/loopover-engine/src/advisory/gate-advisory.ts
@@ -229,7 +229,14 @@ export function buildPullRequestAdvisory(
       action: "Re-deliver the webhook or wait for the next sync.",
     });
   } else {
-    addPullRequestFindings(repo, pr, findings, context.otherOpenPullRequests ?? [], Boolean(context.requireLinkedIssue), Boolean(context.duplicateWinnerEnabled), context.linkedIssueAuthorLogins ?? [], Boolean(context.confirmedNoOpenLinkedIssue), context.supersededBy);
+    addPullRequestFindings(repo, pr, findings, {
+      otherOpenPullRequests: context.otherOpenPullRequests ?? [],
+      requireLinkedIssue: Boolean(context.requireLinkedIssue),
+      duplicateWinnerEnabled: Boolean(context.duplicateWinnerEnabled),
+      linkedIssueAuthorLogins: context.linkedIssueAuthorLogins ?? [],
+      confirmedNoOpenLinkedIssue: Boolean(context.confirmedNoOpenLinkedIssue),
+      supersededBy: context.supersededBy,
+    });
   }
   return advisory("pull_request", targetKey, repoFullName, findings, "Pull request advisory generated.", pr?.number, undefined, pr?.headSha ?? undefined);
 }
@@ -295,18 +302,23 @@ function hasDuplicateOverlapCorroboration(pr: PullRequestRecord, otherPr: PullRe
   return Boolean(theirsFiles && theirsFiles.length > 0);
 }
 
-function addPullRequestFindings(
-  repo: RepositoryRecord | null,
-  pr: PullRequestRecord,
-  findings: AdvisoryFinding[],
-  otherOpenPullRequests: PullRequestRecord[],
-  requireLinkedIssue: boolean,
-  duplicateWinnerEnabled: boolean,
-  linkedIssueAuthorLogins: (string | null | undefined)[],
-  confirmedNoOpenLinkedIssue: boolean,
-  // #10168: present only when the caller proved a rival merged after this PR opened and closed its issue.
-  supersededBy?: { issueNumber: number; rivalPullNumber: number } | null | undefined,
-): void {
+/** #10210 (host-parity): the resolved per-PR signals {@link addPullRequestFindings} evaluates, as ONE object
+ *  rather than a positional tail. See the host copy (src/rules/advisory.ts) for the full rationale — in short,
+ *  the tail had to be threaded in identical ORDER through both twins on every addition, and transposing two
+ *  same-typed arguments compiled cleanly. Declared locally rather than shared with the host: keeping these two
+ *  files free of a common import is precisely what the divergence exists for (#4518/#4881). */
+type PullRequestFindingSignals = {
+  otherOpenPullRequests: PullRequestRecord[];
+  requireLinkedIssue: boolean;
+  duplicateWinnerEnabled: boolean;
+  linkedIssueAuthorLogins: (string | null | undefined)[];
+  confirmedNoOpenLinkedIssue: boolean;
+  /** #10168: present only when the caller proved a rival merged after this PR opened and closed its issue. */
+  supersededBy?: { issueNumber: number; rivalPullNumber: number } | null | undefined;
+};
+
+function addPullRequestFindings(repo: RepositoryRecord | null, pr: PullRequestRecord, findings: AdvisoryFinding[], signals: PullRequestFindingSignals): void {
+  const { otherOpenPullRequests, requireLinkedIssue, duplicateWinnerEnabled, linkedIssueAuthorLogins, confirmedNoOpenLinkedIssue, supersededBy } = signals;
   if (pr.state !== "open") {
     findings.push({
       code: "pr_not_open",

--- a/src/rules/advisory.ts
+++ b/src/rules/advisory.ts
@@ -448,20 +448,17 @@ export function buildPullRequestAdvisory(
       action: "Re-deliver the webhook or wait for the next sync.",
     });
   } else {
-    addPullRequestFindings(
-      repo,
-      pr,
-      findings,
-      context.otherOpenPullRequests ?? [],
-      Boolean(context.requireLinkedIssue),
-      Boolean(context.duplicateWinnerEnabled),
-      context.linkedIssueAuthorLogins ?? [],
-      Boolean(context.confirmedNoOpenLinkedIssue),
-      context.copycatGateMode,
-      context.copycatGateMinScore,
-      context.scopedLinkedIssueClaimedAt,
-      context.supersededBy,
-    );
+    addPullRequestFindings(repo, pr, findings, {
+      otherOpenPullRequests: context.otherOpenPullRequests ?? [],
+      requireLinkedIssue: Boolean(context.requireLinkedIssue),
+      duplicateWinnerEnabled: Boolean(context.duplicateWinnerEnabled),
+      linkedIssueAuthorLogins: context.linkedIssueAuthorLogins ?? [],
+      confirmedNoOpenLinkedIssue: Boolean(context.confirmedNoOpenLinkedIssue),
+      copycatGateMode: context.copycatGateMode,
+      copycatGateMinScore: context.copycatGateMinScore,
+      scopedLinkedIssueClaimedAt: context.scopedLinkedIssueClaimedAt,
+      supersededBy: context.supersededBy,
+    });
   }
   return advisory("pull_request", targetKey, repoFullName, findings, "Pull request advisory generated.", pr?.number, undefined, pr?.headSha ?? undefined);
 }
@@ -1049,27 +1046,49 @@ function hasDuplicateOverlapCorroboration(pr: PullRequestRecord, otherPr: PullRe
   return Boolean(theirsFiles && theirsFiles.length > 0);
 }
 
+/** #10210: the resolved per-PR signals {@link addPullRequestFindings} evaluates, as ONE object rather than a
+ *  positional tail. The tail had reached twelve arguments and had to be threaded in the identical ORDER
+ *  through this file and its deliberately-divergent engine twin
+ *  (packages/loopover-engine/src/advisory/gate-advisory.ts) on every addition -- a shape where transposing
+ *  two same-typed arguments compiles cleanly and silently changes the verdict. Named members make that
+ *  class of mistake unrepresentable, and cost nothing at the single call site, which already had a
+ *  `context` object to unpack. Declared locally, NOT shared with the twin: keeping the two files free of a
+ *  common import is the whole point of the divergence (#4518/#4881). */
+type PullRequestFindingSignals = {
+  otherOpenPullRequests: PullRequestRecord[];
+  requireLinkedIssue: boolean;
+  duplicateWinnerEnabled: boolean;
+  linkedIssueAuthorLogins: (string | null | undefined)[];
+  confirmedNoOpenLinkedIssue: boolean;
+  copycatGateMode: CopycatGateMode | null | undefined;
+  copycatGateMinScore: number | null | undefined;
+  /** #9160: pr's claim time, ALREADY SCOPED by the caller (queue/duplicate-detection.ts's
+   *  resolveScopedLinkedIssueClaimedAt) to only the issue(s) actually contested with an open sibling, instead
+   *  of pr.linkedIssueClaimedAt's blended-across-every-linked-issue value -- see that function's own doc
+   *  comment for why the blended column lets an unrelated, already-linked issue backdate a newly-added one's
+   *  claim. `undefined` (every non-DB caller, like decision-replay.ts) falls back to pr.linkedIssueClaimedAt. */
+  scopedLinkedIssueClaimedAt?: string | null | undefined;
+  /** #10168: present only when the caller proved a rival merged after this PR opened and closed its issue. */
+  supersededBy?: SupersededByRival | null | undefined;
+};
+
 function addPullRequestFindings(
   repo: RepositoryRecord | null,
   pr: PullRequestRecord,
   findings: AdvisoryFinding[],
-  otherOpenPullRequests: PullRequestRecord[],
-  requireLinkedIssue: boolean,
-  duplicateWinnerEnabled: boolean,
-  linkedIssueAuthorLogins: (string | null | undefined)[],
-  confirmedNoOpenLinkedIssue: boolean,
-  copycatGateMode: CopycatGateMode | null | undefined,
-  copycatGateMinScore: number | null | undefined,
-  // #9160: pr's claim time, ALREADY SCOPED by the caller (queue/duplicate-detection.ts's
-  // resolveScopedLinkedIssueClaimedAt) to only the issue(s) actually contested with an open sibling, instead of
-  // pr.linkedIssueClaimedAt's blended-across-every-linked-issue value -- see that function's own doc comment
-  // for why the blended column lets an unrelated, already-linked issue backdate a newly-added one's claim.
-  // `undefined` (every caller that hasn't been updated, and every non-DB caller like decision-replay.ts) falls
-  // back to pr.linkedIssueClaimedAt, byte-identical to before this existed.
-  scopedLinkedIssueClaimedAt?: string | null | undefined,
-  // #10168: present only when the caller proved a rival merged after this PR opened and closed its issue.
-  supersededBy?: SupersededByRival | null | undefined,
+  signals: PullRequestFindingSignals,
 ): void {
+  const {
+    otherOpenPullRequests,
+    requireLinkedIssue,
+    duplicateWinnerEnabled,
+    linkedIssueAuthorLogins,
+    confirmedNoOpenLinkedIssue,
+    copycatGateMode,
+    copycatGateMinScore,
+    scopedLinkedIssueClaimedAt,
+    supersededBy,
+  } = signals;
   if (pr.state !== "open") {
     findings.push({
       code: "pr_not_open",


### PR DESCRIPTION
## Summary

`addPullRequestFindings` exists **twice** — in `src/rules/advisory.ts` and its deliberately-divergent engine twin `packages/loopover-engine/src/advisory/gate-advisory.ts` — and both took the same **positional** tail. Every new signal had to be threaded in identical *order* through two files.

That is a shape where transposing two same-typed arguments **compiles cleanly and silently changes a verdict**. #10205 added the twelfth argument and paid the tax in both signatures and both call sites; the next signal would too.

Both copies now take one named object. Each declares its **own local type** rather than sharing one — keeping these two files free of a common import is precisely what the divergence exists for (#4518, keep-divergent recorded for #4881), so `@loopover/engine` still never reaches into the host's graph.

Selected as #10170's first target for a specific reason, not arbitrarily: it is the only entry on that list that must be edited in two places every time, so the fix removes a recurring class of drift rather than tidying one signature. Context and the corrected measurements are in [this comment on #10170](https://github.com/JSONbored/loopover/issues/10170#issuecomment-5142931251) — the audit's original ranking counted commas inside JSDoc, which inflated the numbers and mis-ranked the targets.

### Why you can trust it is behaviour-neutral

**Nothing else moved.** No finding added or removed, no message text touched, **no test edited**. The diff contains **zero** changed lines matching `findings.push` or a finding-code literal — only the signature, the destructure, and the single call site in each file.

The existing advisory suites on both sides, `test:engine-parity`, and `engine-parity:drift-check` all pass **unmodified**. That is the whole regression proof: if an assertion had needed editing, it would have meant behaviour changed, and the right response would have been to re-examine the refactor rather than adjust the test.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`).

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage`
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests — **not applicable by design**: this changes no behaviour, and the value of the change is that the pre-existing suites pass untouched.

Full `npx vitest run`: **1358 files, 26503 tests, 0 failures**. `@loopover/engine`: 945 pass. `test:engine-parity`: 15 pass. `engine-parity:drift-check`: 7 twin pairs agree at engine 3.20.0. Also green: `dead-source-files`, `dead-exports`, `import-specifiers`, `coverage-boltons`, `typecheck-coverage`, `docs:drift`, `cf-typegen`.

If any required check was skipped, explain why:

- Not run locally: `actionlint`, `test:workers`, `build:mcp`, `test:mcp-pack`, `ui:*`. This PR touches exactly two TypeScript files under `src/rules/` and `packages/loopover-engine/src/advisory/` — no workflow, worker-pool, MCP, OpenAPI, or UI file. CI runs them all.
- `npm audit` reports pre-existing advisories on `main`; this PR changes no dependency (no `package.json` / lockfile diff).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

No contributor-visible string changes at all — the findings this function emits are byte-identical.

## UI Evidence

Not applicable — no UI, frontend, docs, or extension files are touched.

## Notes

The first three arguments (`repo`, `pr`, `findings`) stay positional: they are the genuine subject of the call, and `findings` is the accumulator being appended to. Only the resolved-signal tail moved into the object.

Closes #10210
