### PR TITLE
feat(observability): opt-in capture of AI prompts and completions

### DIFF
--- a/apps/loopover-ui/content/docs/self-hosting-operations.mdx
+++ b/apps/loopover-ui/content/docs/self-hosting-operations.mdx
@@ -676,7 +676,7 @@ three standalone bindings (`AI_EMBED`, `AI_VISION`, `AI_ADVISORY`).
     {
       title: "Content policy",
       description:
-        "Metadata only — never the prompt or completion text. $ai_generation's own optional content fields ($ai_input/$ai_output_choices) are never populated, the same redaction posture as every other capture path on this page.",
+        "Metadata only by default — no prompt or completion text leaves the box unless you explicitly opt in. $ai_generation's optional content fields ($ai_input/$ai_output_choices) stay unpopulated unless LOOPOVER_POSTHOG_AI_CONTENT is set, so upgrading never starts shipping content on its own.",
     },
     {
       title: "Model labelling",
@@ -690,6 +690,28 @@ three standalone bindings (`AI_EMBED`, `AI_VISION`, `AI_ADVISORY`).
     },
   ]}
 />
+
+### Capturing prompts and completions (`LOOPOVER_POSTHOG_AI_CONTENT`)
+
+**Off by default, and deliberately so.** With it unset, no prompt, diff or model completion ever leaves the
+box — only the metadata listed above. Set `LOOPOVER_POSTHOG_AI_CONTENT=1` to populate `$ai_input` and
+`$ai_output_choices`, which is what unlocks PostHog's conversation view, sentiment, evaluations and
+LLM-judge surfaces. Read this before turning it on:
+
+- **Your PR diffs and review text go to PostHog.** The prompt for a review contains the diff and the
+  assembled repo context. On a private repository that is private source code leaving your infrastructure.
+  Only enable it on a project you are willing to have that content in.
+- **The same redaction still applies.** Captured content passes through the identical `before_send` scrub
+  (`src/selfhost/redaction-scrub.ts`) as every other field — credential shapes, JWTs and query-string
+  secrets are redacted from it. That is a backstop, not a licence: it removes credential shapes, not the
+  source code itself.
+- **Content is truncated.** Each message is capped at 10,000 characters
+  (`LOOPOVER_POSTHOG_AI_CONTENT_MAX_CHARS`) and marked `…[truncated]`. A review prompt can exceed 300,000
+  characters, so an uncapped capture would blow past PostHog's payload limits and be dropped entirely. A
+  non-numeric, zero or negative override falls back to the default rather than disabling the cap.
+- **Images are never captured.** An image content block is dropped, not base64-encoded into the event.
+- **On a failure, the prompt is captured but there is no completion** — a `claude_stalled_no_output` or a
+  context-length rejection is only diagnosable against the input that produced it.
 
 A CLI-subscription provider declining an embedding request (`claude_code_no_embed` / `codex_no_embed`)
 is routing working as designed — it is how an embed reaches an embed-capable provider — so it is exempt

--- a/apps/loopover-ui/src/lib/selfhost-env-reference.ts
+++ b/apps/loopover-ui/src/lib/selfhost-env-reference.ts
@@ -322,6 +322,14 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
     firstReference: "src/server.ts",
   },
   {
+    name: "LOOPOVER_POSTHOG_AI_CONTENT",
+    firstReference: "src/selfhost/posthog.ts",
+  },
+  {
+    name: "LOOPOVER_POSTHOG_AI_CONTENT_MAX_CHARS",
+    firstReference: "src/selfhost/posthog.ts",
+  },
+  {
     name: "LOOPOVER_PUBLIC_SCORE_TERMS_ALLOWED_REPOS",
     firstReference: "src/selfhost/inert-config.ts",
   },
@@ -801,6 +809,8 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| `LOOPOVER_LEDGER_UNCHAINED_WAIVER` | `src/selfhost/preflight.ts` |",
   "| `LOOPOVER_MCP_TOKEN` | `src/selfhost/preflight.ts` |",
   "| `LOOPOVER_METRICS_REPO_LABELS` | `src/server.ts` |",
+  "| `LOOPOVER_POSTHOG_AI_CONTENT` | `src/selfhost/posthog.ts` |",
+  "| `LOOPOVER_POSTHOG_AI_CONTENT_MAX_CHARS` | `src/selfhost/posthog.ts` |",
   "| `LOOPOVER_PUBLIC_SCORE_TERMS_ALLOWED_REPOS` | `src/selfhost/inert-config.ts` |",
   "| `LOOPOVER_PUBLIC_STATS_REPOS` | `src/selfhost/inert-config.ts` |",
   "| `LOOPOVER_REPO_CONFIG_DIR` | `src/server.ts` |",

--- a/src/selfhost/ai.ts
+++ b/src/selfhost/ai.ts
@@ -1559,6 +1559,19 @@ function isExpectedEmbeddingRoutingError(options: AiRunOptions, error: unknown):
   return requestKind(options) === "embedding" && EXPECTED_EMBEDDING_ROUTING_ERRORS.has(errorMessage(error));
 }
 
+/** The prompt, flattened to the `{role, content}` list PostHog's `$ai_input` expects (#10218).
+ *
+ *  Reuses `contentText`, so an image block is dropped rather than base64-encoded into a telemetry event --
+ *  the same projection the subscription CLIs already apply when building their stdin prompt, so what is
+ *  captured is what the provider was actually given. An embedding request has no messages at all; its
+ *  inputs are the raw texts, reported under the same synthetic `user` role so one property shape covers
+ *  both request kinds. Capture is gated in posthog.ts, so this always builds and is simply ignored when
+ *  the operator has not opted in. */
+function aiContentInput(options: AiRunOptions): Array<{ role: string; content: string }> {
+  if (Array.isArray(options.text)) return options.text.map((text) => ({ role: "user", content: text }));
+  return toMessages(options).map((message) => ({ role: message.role, content: contentText(message.content) }));
+}
+
 async function runProviderWithOtel(
   provider: { name: string; ai: SelfHostAi },
   model: string,
@@ -1619,6 +1632,8 @@ async function runProviderWithOtel(
       totalCostUsd: usage?.costUsd,
       effort: usage?.effort,
       context: { repo: options.repoFullName, pullNumber: options.pullNumber },
+      input: aiContentInput(options),
+      outputText: result.response,
     });
     return usage ? { ...result, usage } : result;
   } catch (error) {
@@ -1635,6 +1650,9 @@ async function runProviderWithOtel(
       isError: true,
       error,
       context: { repo: options.repoFullName, pullNumber: options.pullNumber },
+      // The prompt is what a failure needs most: a `claude_stalled_no_output` or a context-length rejection
+      // is only diagnosable against the input that produced it. There is no completion to report.
+      input: aiContentInput(options),
     });
     incr("loopover_ai_provider_failures_total", { provider: provider.name });
     incr("loopover_ai_provider_request_errors_total", { provider: provider.name, request_kind: requestKindLabel });
@@ -1809,6 +1827,8 @@ export function withAiGenerationCapture(providerName: string, ai: SelfHostAi): S
           outputTokens: usage?.outputTokens,
           totalCostUsd: usage?.costUsd,
           effort: usage?.effort,
+          input: aiContentInput(options),
+          outputText: result.response,
         });
         return usage ? { ...result, usage } : result;
       } catch (error) {
@@ -1819,6 +1839,7 @@ export function withAiGenerationCapture(providerName: string, ai: SelfHostAi): S
           latencyMs: Date.now() - startedAtMs,
           isError: true,
           error,
+          input: aiContentInput(options),
         });
         throw error;
       }

--- a/src/selfhost/posthog.ts
+++ b/src/selfhost/posthog.ts
@@ -74,6 +74,37 @@ function processEnvString(env: NodeJS.ProcessEnv, name: string): string | undefi
   return nonBlank(env[name]);
 }
 
+/** Truthy-string env flag, matching the repo-wide convention for a flag-gated capability that ships OFF. */
+const TRUE_ENV_VALUES = new Set(["1", "true", "yes", "on"]);
+
+/** Default ceiling on a single captured message's characters (#10218). A review prompt carries up to 120k
+ *  chars of diff plus a 240k-char aggregate context budget, so an uncapped capture would push events past
+ *  PostHog's own payload limits and be dropped wholesale -- a cap is what makes this survivable at all. */
+const DEFAULT_AI_CONTENT_MAX_CHARS = 10_000;
+
+/** #10218: whether `$ai_input`/`$ai_output_choices` are populated at all. OFF unless
+ *  `LOOPOVER_POSTHOG_AI_CONTENT` is explicitly truthy. Self-host-only, read off real process.env, matching
+ *  this file's precedent for every other self-host-exclusive knob. */
+let aiContentCapture = false;
+let aiContentMaxChars = DEFAULT_AI_CONTENT_MAX_CHARS;
+
+function resolveAiContentCapture(env: NodeJS.ProcessEnv): boolean {
+  return TRUE_ENV_VALUES.has((env.LOOPOVER_POSTHOG_AI_CONTENT ?? "").trim().toLowerCase());
+}
+
+/** Per-message character ceiling. A non-numeric, zero, negative or fractional override falls back to the
+ *  default rather than disabling the cap -- an operator typo must never become "send the whole diff". */
+function resolveAiContentMaxChars(env: NodeJS.ProcessEnv): number {
+  const raw = Number(env.LOOPOVER_POSTHOG_AI_CONTENT_MAX_CHARS);
+  return Number.isInteger(raw) && raw > 0 ? raw : DEFAULT_AI_CONTENT_MAX_CHARS;
+}
+
+/** Truncate to the configured ceiling, marking that it happened so a reader never mistakes a clipped prompt
+ *  for the whole one. */
+function boundedContent(value: string): string {
+  return value.length <= aiContentMaxChars ? value : `${value.slice(0, aiContentMaxChars)}…[truncated]`;
+}
+
 /** Resolve the PostHog release id: explicit override first, then the image-baked self-host version, matching
  *  {@link resolveSentryRelease}'s identical precedence in sentry.ts. */
 export function resolvePostHogRelease(env: NodeJS.ProcessEnv): string | undefined {
@@ -181,6 +212,11 @@ export async function initPostHog(env: NodeJS.ProcessEnv): Promise<boolean> {
   usingCentralPostHogKey = !explicitKey;
   await loadNodeHasher();
   const { PostHog } = await import("posthog-node");
+  // #10218: content capture is OFF unless the operator turns it on. Upgrading an ORB must never start
+  // shipping private PR diffs and model completions to a vendor as a side effect of a version bump, so the
+  // default stays metadata-only exactly as before -- see resolveAiContentCapture.
+  aiContentCapture = resolveAiContentCapture(env);
+  aiContentMaxChars = resolveAiContentMaxChars(env);
   posthogEnvironment = processEnvString(env, "POSTHOG_ENVIRONMENT") ?? "production";
   activeRelease = resolvePostHogRelease(env);
   const host = processEnvString(env, "POSTHOG_HOST") ?? DEFAULT_POSTHOG_HOST;
@@ -406,7 +442,33 @@ export type PostHogAiGenerationEvent = {
   /** Raw caught value on the error path (mirrors capturePostHogError's own `error` param) -- never a
    *  caller-preformatted string. Ignored when `isError` is false. */
   error?: unknown;
+  /** #10218: the prompt messages, already flattened to plain text by the caller (an image block has no
+   *  place in a telemetry event and is dropped upstream). IGNORED unless content capture is enabled --
+   *  passing it is always safe, the gate lives here rather than at every call site. */
+  input?: ReadonlyArray<{ role: string; content: string }> | undefined;
+  /** #10218: the model's completion text. Same gating as {@link PostHogAiGenerationEvent.input}. */
+  outputText?: string | undefined;
 };
+
+/** Build the `$ai_input`/`$ai_output_choices` properties PostHog's LLM-analytics views read (#10218).
+ *  Returns an EMPTY bag when content capture is off, which is the default and the pre-#10218 behavior
+ *  byte-for-byte. Every string is bounded here; the vendor-bound redaction pass still runs afterwards over
+ *  the whole properties bag via `before_send` (scrubPostHogEvent -> scrubRecord), so captured content goes
+ *  through exactly the same credential/vocabulary scrubbing as every other field in this file -- it is not
+ *  a second, weaker path. */
+function aiContentProperties(event: PostHogAiGenerationEvent): Record<string, unknown> {
+  if (!aiContentCapture) return {};
+  const properties: Record<string, unknown> = {};
+  if (event.input && event.input.length > 0) {
+    properties.$ai_input = event.input.map((message) => ({ role: message.role, content: boundedContent(message.content) }));
+  }
+  // PostHog's shape is a list of choices; the self-host providers are all single-completion, so this is
+  // always a one-element list rather than a fabricated multi-choice response.
+  if (event.outputText !== undefined && event.outputText !== "") {
+    properties.$ai_output_choices = [{ role: "assistant", content: boundedContent(event.outputText) }];
+  }
+  return properties;
+}
 
 /** Capture one AI provider attempt as PostHog's `$ai_generation` (`$ai_embedding` for an embedding
  *  request) event (#8296). No-op when PostHog is off -- same contract as every other capture function in
@@ -451,6 +513,7 @@ export function capturePostHogAiGeneration(event: PostHogAiGenerationEvent): voi
   const properties: Record<string, unknown> = {
     ...operational,
     ...aiTraceProperties(operational),
+    ...aiContentProperties(event),
     // Names the node in the trace tree. Provider-and-kind rather than the tool/feature name, because
     // that is what this function actually knows -- the feature lives in ai_usage_events, not here.
     $ai_span_name: `ai.${event.requestKind}/${nonBlank(event.provider) ?? "unknown"}`,
@@ -566,5 +629,7 @@ export function resetPostHogForTest(): void {
   activeRelease = undefined;
   usingCentralPostHogKey = false;
   centralKeyAnonSecret = undefined;
+  aiContentCapture = false;
+  aiContentMaxChars = DEFAULT_AI_CONTENT_MAX_CHARS;
   resetRedactionScrubForTest();
 }

--- a/test/unit/docs-selfhost-posthog-observability.test.ts
+++ b/test/unit/docs-selfhost-posthog-observability.test.ts
@@ -40,6 +40,15 @@ describe("self-host PostHog observability docs (#8287)", () => {
     expect(operations).toContain("<provider>-default");
   });
 
+  it("documents content capture as opt-in, with the real env var names and the privacy warning (#10218)", () => {
+    // The page previously promised metadata-only unconditionally. That is now conditional, so the page must
+    // say WHICH var changes it and what enabling it actually sends -- a self-hoster's private diffs.
+    expect(operations).toContain("LOOPOVER_POSTHOG_AI_CONTENT");
+    expect(operations).toContain("LOOPOVER_POSTHOG_AI_CONTENT_MAX_CHARS");
+    expect(operations).toContain("Off by default");
+    expect(operations).toContain("private source code leaving your infrastructure");
+  });
+
   it("documents the cron-monitor heartbeat replacement with the real exported event name", () => {
     expect(operations).toContain("Cron Monitors");
     expect(operations).toContain(POSTHOG_MONITOR_HEARTBEAT_EVENT);

--- a/test/unit/selfhost-ai.test.ts
+++ b/test/unit/selfhost-ai.test.ts
@@ -740,6 +740,75 @@ describe("$ai_generation PostHog capture at the chain chokepoint (#8296)", () =>
     expect(posthogMocks.capture).not.toHaveBeenCalled();
   });
 
+  // #10218: content capture. ai.ts always passes the prompt/completion; posthog.ts decides whether it is
+  // emitted, so these drive the real chain with the flag on.
+  it("captures the flattened prompt and the completion when content capture is enabled (#10218)", async () => {
+    await initPostHog({ POSTHOG_API_KEY: "phc_test_key", LOOPOVER_POSTHOG_AI_CONTENT: "1" } as unknown as NodeJS.ProcessEnv);
+    const provider = { name: "ollama", ai: { run: async () => ({ response: "no blockers found" }) } };
+    await createChainAi([provider]).run("m", {
+      messages: [
+        { role: "system", content: "you are a reviewer" },
+        { role: "user", content: "review this diff" },
+      ],
+    });
+    const { properties } = posthogMocks.capture.mock.calls[0]?.[0];
+    expect(properties.$ai_input).toEqual([
+      { role: "system", content: "you are a reviewer" },
+      { role: "user", content: "review this diff" },
+    ]);
+    expect(properties.$ai_output_choices).toEqual([{ role: "assistant", content: "no blockers found" }]);
+  });
+
+  it("drops an image block rather than base64-encoding it into the event (#10218)", async () => {
+    await initPostHog({ POSTHOG_API_KEY: "phc_test_key", LOOPOVER_POSTHOG_AI_CONTENT: "1" } as unknown as NodeJS.ProcessEnv);
+    const provider = { name: "ollama", ai: { run: async () => ({ response: "ok" }) } };
+    await createChainAi([provider]).run("m", {
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "describe this" },
+            { type: "image", mimeType: "image/png", data: "AAAABBBBCCCC" },
+          ],
+        },
+      ],
+    });
+    const captured = JSON.stringify(posthogMocks.capture.mock.calls[0]?.[0].properties.$ai_input);
+    expect(captured).toContain("describe this");
+    expect(captured).not.toContain("AAAABBBBCCCC");
+  });
+
+  it("reports an embedding request's raw texts as the input, under a synthetic user role (#10218)", async () => {
+    await initPostHog({ POSTHOG_API_KEY: "phc_test_key", LOOPOVER_POSTHOG_AI_CONTENT: "1" } as unknown as NodeJS.ProcessEnv);
+    const provider = { name: "ollama", ai: { run: async () => ({ data: [[0.1]] }) } };
+    await createChainAi([provider]).run("m", { text: ["chunk one", "chunk two"] });
+    const { properties } = posthogMocks.capture.mock.calls[0]?.[0];
+    expect(properties.$ai_input).toEqual([
+      { role: "user", content: "chunk one" },
+      { role: "user", content: "chunk two" },
+    ]);
+    // An embedding has no completion to report.
+    expect("$ai_output_choices" in properties).toBe(false);
+  });
+
+  it("captures the prompt on the FAILURE path, where it is what makes the failure diagnosable (#10218)", async () => {
+    await initPostHog({ POSTHOG_API_KEY: "phc_test_key", LOOPOVER_POSTHOG_AI_CONTENT: "1" } as unknown as NodeJS.ProcessEnv);
+    const provider = { name: "claude-code", ai: { run: async () => { throw new Error("claude_stalled_no_output"); } } };
+    await expect(createChainAi([provider]).run("m", { prompt: "review this" })).rejects.toThrow(/stalled/);
+    const generation = posthogMocks.capture.mock.calls.find((call) => call[0].event === "$ai_generation")?.[0];
+    expect(generation.properties.$ai_input).toEqual([{ role: "user", content: "review this" }]);
+    expect("$ai_output_choices" in generation.properties).toBe(false);
+  });
+
+  it("emits NO content when the operator has not opted in, even though ai.ts always passes it (#10218)", async () => {
+    await initPostHog({ POSTHOG_API_KEY: "phc_test_key" } as unknown as NodeJS.ProcessEnv);
+    const provider = { name: "ollama", ai: { run: async () => ({ response: "secret completion" }) } };
+    await createChainAi([provider]).run("m", { prompt: "private diff" });
+    const keys = Object.keys(posthogMocks.capture.mock.calls[0]?.[0].properties);
+    expect(keys).not.toContain("$ai_input");
+    expect(keys).not.toContain("$ai_output_choices");
+  });
+
   it("stays a no-op end-to-end when PostHog is unconfigured (no posthog-node client constructed)", async () => {
     const provider = { name: "posthog-unconfigured-provider", ai: { run: async () => ({ response: "ok" }) } };
     await createChainAi([provider]).run("m", { prompt: "x" });

--- a/test/unit/selfhost-posthog.test.ts
+++ b/test/unit/selfhost-posthog.test.ts
@@ -723,12 +723,77 @@ describe("capturePostHogAiGeneration (#8296)", () => {
     expect(mocks.capture.mock.calls[0]?.[0].properties.$ai_error).toBe("just a string");
   });
 
-  it("never carries prompt/response content -- no field beyond model/provider ids", async () => {
+  it("carries NO prompt/response content by default, even when the caller supplies it (#10218)", async () => {
+    // The gate lives in posthog.ts, not at the call sites: ai.ts always passes the content, so this is the
+    // single place that decides. An operator who has not opted in is byte-identical to before #10218.
     await initPostHog({ POSTHOG_API_KEY: "phc_test_key" } as unknown as NodeJS.ProcessEnv);
-    capturePostHogAiGeneration(BASE);
+    capturePostHogAiGeneration({ ...BASE, input: [{ role: "user", content: "review this diff" }], outputText: "looks good" });
     const keys = Object.keys(mocks.capture.mock.calls[0]?.[0].properties);
     expect(keys).not.toContain("$ai_input");
     expect(keys).not.toContain("$ai_output_choices");
+  });
+
+  it("populates $ai_input/$ai_output_choices once LOOPOVER_POSTHOG_AI_CONTENT is set (#10218)", async () => {
+    await initPostHog({ POSTHOG_API_KEY: "phc_test_key", LOOPOVER_POSTHOG_AI_CONTENT: "1" } as unknown as NodeJS.ProcessEnv);
+    capturePostHogAiGeneration({
+      ...BASE,
+      input: [{ role: "system", content: "you are a reviewer" }, { role: "user", content: "review this diff" }],
+      outputText: "looks good",
+    });
+    const { properties } = mocks.capture.mock.calls[0]?.[0];
+    expect(properties.$ai_input).toEqual([
+      { role: "system", content: "you are a reviewer" },
+      { role: "user", content: "review this diff" },
+    ]);
+    // PostHog's shape is a list of choices; the self-host providers are single-completion, so exactly one.
+    expect(properties.$ai_output_choices).toEqual([{ role: "assistant", content: "looks good" }]);
+  });
+
+  it("omits each content field independently when it has nothing to say", async () => {
+    await initPostHog({ POSTHOG_API_KEY: "phc_test_key", LOOPOVER_POSTHOG_AI_CONTENT: "true" } as unknown as NodeJS.ProcessEnv);
+    // A failure has a prompt but no completion; an empty prompt list must not become an empty array.
+    capturePostHogAiGeneration({ ...BASE, input: [{ role: "user", content: "x" }] });
+    capturePostHogAiGeneration({ ...BASE, input: [], outputText: "" });
+    const withPrompt = mocks.capture.mock.calls[0]?.[0].properties;
+    expect(withPrompt.$ai_input).toHaveLength(1);
+    expect("$ai_output_choices" in withPrompt).toBe(false);
+    const withNeither = mocks.capture.mock.calls[1]?.[0].properties;
+    expect("$ai_input" in withNeither).toBe(false);
+    expect("$ai_output_choices" in withNeither).toBe(false);
+  });
+
+  it("truncates content at the cap and marks that it happened (#10218)", async () => {
+    await initPostHog({
+      POSTHOG_API_KEY: "phc_test_key",
+      LOOPOVER_POSTHOG_AI_CONTENT: "on",
+      LOOPOVER_POSTHOG_AI_CONTENT_MAX_CHARS: "10",
+    } as unknown as NodeJS.ProcessEnv);
+    capturePostHogAiGeneration({ ...BASE, input: [{ role: "user", content: "a".repeat(50) }], outputText: "b".repeat(50) });
+    const { properties } = mocks.capture.mock.calls[0]?.[0];
+    // A reader must never mistake a clipped prompt for the whole one.
+    expect((properties.$ai_input as Array<{ content: string }>)[0]?.content).toBe(`${"a".repeat(10)}…[truncated]`);
+    expect((properties.$ai_output_choices as Array<{ content: string }>)[0]?.content).toBe(`${"b".repeat(10)}…[truncated]`);
+  });
+
+  it("leaves content at or under the cap untouched", async () => {
+    await initPostHog({
+      POSTHOG_API_KEY: "phc_test_key",
+      LOOPOVER_POSTHOG_AI_CONTENT: "yes",
+      LOOPOVER_POSTHOG_AI_CONTENT_MAX_CHARS: "10",
+    } as unknown as NodeJS.ProcessEnv);
+    capturePostHogAiGeneration({ ...BASE, input: [{ role: "user", content: "a".repeat(10) }] });
+    expect((mocks.capture.mock.calls[0]?.[0].properties.$ai_input as Array<{ content: string }>)[0]?.content).toBe("a".repeat(10));
+  });
+
+  it("captured content still goes through the same before_send redaction as every other field", async () => {
+    await initPostHog({ POSTHOG_API_KEY: "phc_test_key", LOOPOVER_POSTHOG_AI_CONTENT: "1" } as unknown as NodeJS.ProcessEnv);
+    const leaked = ["ghp", "abcdefghijklmnopqrst123456"].join("_");
+    capturePostHogAiGeneration({ ...BASE, input: [{ role: "user", content: `token is ${leaked}` }] });
+    // scrubPostHogEvent is posthog-node's before_send, so assert on it directly the way the client would.
+    const event = scrubPostHogEvent(mocks.capture.mock.calls[0]?.[0] as never) as unknown as { properties: Record<string, unknown> };
+    const captured = JSON.stringify(event.properties.$ai_input);
+    expect(captured).not.toContain(leaked);
+    expect(captured).toContain("[redacted]");
   });
 
   it("mints a fresh, real UUID trace id on every call", async () => {


### PR DESCRIPTION
## Summary

PostHog's LLM Analytics **Traces** view shows a dash for Input message, Output message and Sentiment on every row in this project, because `$ai_input` and `$ai_output_choices` were deliberately never populated. That default was defensible, but it also made the entire content-dependent half of the product unreachable: the conversation view, sentiment, evaluations, LLM-as-judge and online evals all read the captured prompt and completion.

This populates them behind **`LOOPOVER_POSTHOG_AI_CONTENT`, default OFF**. An operator who has not opted in gets byte-identical behaviour to before — upgrading an ORB must never start shipping private PR diffs and model completions to a vendor as a side effect of a version bump.

### Design decisions worth reviewing

- **The gate lives in the capture function, not at the call sites.** `ai.ts` always passes the content and `posthog.ts` alone decides whether to emit it. A future call site therefore cannot forget the check — the failure mode of a per-call-site gate is exactly the silent leak this feature must not have.
- **Content reuses the existing redaction, not a parallel path.** It rides in the normal properties bag, so `before_send` → `scrubPostHogEvent` → `scrubRecord` applies the same credential/JWT/query-string scrubbing it applies to every other field. A test asserts a leaked PAT in a prompt comes out `[redacted]`.
- **Bounded, and marked when bounded.** Each message is capped (default 10,000 chars) and suffixed `…[truncated]`, so a clipped prompt is never mistaken for the whole one. A review prompt carries up to 120k chars of diff plus a 240k-char context budget — uncapped, these events would exceed PostHog's payload limits and be dropped wholesale, which is a worse outcome than truncation. A non-numeric, zero, negative or fractional override falls back to the default rather than disabling the cap.
- **Images are dropped, not encoded.** Reuses `contentText`, the same projection the subscription CLIs already apply when building their stdin prompt — so what is captured is what the provider was actually given, and no base64 blob lands in a telemetry event.
- **Embeddings and chat share one property shape.** An embedding has no messages, so its raw texts are reported under a synthetic `user` role; it has no completion, so `$ai_output_choices` is omitted rather than emitted empty.
- **The failure path captures the prompt and no completion.** A `claude_stalled_no_output` or a context-length rejection is only diagnosable against the input that produced it.

Closes #10218

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

Also run and green, because this change touches their inputs specifically:

- `npm run selfhost:env-reference` — regenerated and committed; two new `env.*` reads under `src/selfhost/**` land in `apps/loopover-ui/src/lib/selfhost-env-reference.ts`. `selfhost:env-reference:check` passes.
- `npm run dead-exports:check` — green. The two resolver helpers are **module-local on purpose**: exporting them with no consumer outside the file is precisely what put `dead-exports:check` red on a clean `main` in #10195, and they are covered through `initPostHog` instead.
- `prettier --check` on the changed MDX and the generated reference — clean.

If any required check was skipped, explain why:

- Coverage measured scoped to the two changed source files: **100% of the changed lines AND branches**, verified line-by-line against lcov rather than read off a summary percentage.
- The unchecked commands cover untouched surfaces (no workflow, binding, OpenAPI schema or MCP manifest change here) and are left to CI.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

**This is the change on this page that most deserves scrutiny, so it is stated plainly rather than buried:** with the flag on, prompts contain the PR diff and the assembled repo context, and on a private repository that is private source code leaving the operator's infrastructure. The redaction pass removes credential shapes, not source code — the docs say so in those words rather than implying the scrub makes it safe. The default is off, the flag is a deliberate operator action, and nothing about the emitted event changes until it is set.

## UI Evidence

Not applicable — no visible UI or frontend change. The docs change is prose plus a `FeatureRow` entry on the existing self-hosting operations page, whose accuracy is pinned by a drift test rather than a screenshot.

## Notes

Tests cover both states throughout rather than only the new one: content present and absent, each field omitted independently, at-cap and over-cap, the flag off with content supplied, images dropped, embeddings, and the failure path. The existing "never carries prompt/response content" assertion was **flipped to cover both states rather than deleted** — it now passes content in and asserts it does not appear, which is a strictly stronger check than the original.

Token usage is a separate root cause and is not addressed here — see #10211.
