### PR TITLE
fix(backfill): stop recording a resume cursor the sampled segment can never consume

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -1712,6 +1712,11 @@ async function fetchPagedSegment<T>(
   expectedCount: number | undefined,
   persistPage: (payloads: T[], scanStartedAt: string) => Promise<number>,
   options: {
+    /** Marks a segment as a BOUNDED RECENT-WINDOW SAMPLE rather than an exhaustive crawl: when the page budget
+     *  runs out with more pages upstream, the run settles as `sampled` instead of `running`, and records no
+     *  continuation cursor because none can be consumed (#10209 — see the fuller note at the `sampled` branch).
+     *  The name is historical and reads as "walks deeper each run"; it does not. Coverage grows only by
+     *  accretion as the underlying `sort=updated` window slides. */
     progressiveHistory?: boolean;
     countPersisted?: () => Promise<number>;
     reconcileOnComplete?: (scanStartedAt: string) => Promise<number>;
@@ -1814,6 +1819,25 @@ async function fetchPagedSegment<T>(
   if (status === "complete") {
     if (hasMore && options.progressiveHistory) {
       status = "sampled";
+      // #10209: a `sampled` segment is NOT resumable, so a nextCursor recorded here is written and never read.
+      // Three independent gates make that so: this branch maps complete+hasMore to `sampled` rather than
+      // `running`; `canResumePreviousScan` accepts only running/partial/waiting_rate_limit, so both
+      // `previous.nextCursor` and an explicitly passed `cursor` are ignored and startPage falls back to 1; and
+      // the automatic resume re-send below is scoped to labels/open_issues/open_pull_requests, with the
+      // scheduled cron only ever dispatching light/full. Confirmed live on edge-nl-01: a `resume` run with an
+      // explicit cursor: "11" against a segment at next_cursor=11 re-crawled pages 1-10 and persisted nothing
+      // new, returning the same nextCursor: "11" it started with.
+      //
+      // Clearing it makes the stored row describe what this segment actually IS -- a bounded window over the
+      // most-recently-updated closed PRs, re-crawled from page 1 every run, whose coverage grows by accretion
+      // as the window slides (and is trimmed by the 30-day updated_at retention in src/db/retention.ts). That
+      // is a defensible design; recording a continuation position no scheduled or manual path can consume is
+      // not, because it invites a reader to conclude the crawl is advancing when it never can.
+      //
+      // `expectedCount` is deliberately KEPT: "this window holds N of the M closed PRs GitHub reports" is a
+      // true and useful coverage statement. It is only misleading when read as progress toward M, which is
+      // what the absent cursor now signals.
+      nextCursor = undefined;
     } else if (hasMore) {
       status = "running";
     } else {

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { clearInstallationTokenCacheForTest } from "../../src/github/app";
 import {
   getInstallationHealth,
+  getRepoSyncSegment,
   listCheckSummaries,
   listContributorRepoStats,
   listIssues,
@@ -4052,6 +4053,56 @@ describe("GitHub backfill", () => {
 
     expect(result).toMatchObject({ status: "sampled", fetchedCount: 10, expectedCount: 2000 });
     expect(await listRecentMergedPullRequests(env, "JSONbored/gittensory")).toHaveLength(10);
+
+    // REGRESSION (#10209): a `sampled` segment records NO continuation cursor. It is not resumable --
+    // canResumePreviousScan accepts only running/partial/waiting_rate_limit -- so a stored nextCursor would be
+    // written and never read, describing a continuation no scheduled or manual path can perform. expectedCount
+    // is deliberately still recorded: "10 of 2000" is a true coverage statement, just not a progress one.
+    expect(result.nextCursor ?? null).toBeNull();
+    const stored = await getRepoSyncSegment(env, "JSONbored/gittensory", "recent_merged_pull_requests");
+    expect(stored?.status).toBe("sampled");
+    expect(stored?.nextCursor ?? null).toBeNull();
+    expect(stored?.expectedCount).toBe(2000);
+  });
+
+  it("REGRESSION (#10209): a resume dispatched against a sampled segment restarts at page 1 rather than advancing", async () => {
+    // Pins the behaviour the absent cursor now advertises honestly. Verified live on edge-nl-01 before the
+    // change: a resume run with an explicit cursor: "11" against next_cursor=11 re-crawled pages 1-10 and
+    // persisted nothing new. The segment is a rolling most-recently-updated window, not a deepening crawl.
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+    await seedRegisteredRepo(env);
+    const pagesRequested: number[] = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url === "https://api.github.com/graphql") return githubTotalsResponse({ openIssues: 0, openPullRequests: 0, mergedPullRequests: 2000, closedPullRequests: 0, labels: 0 });
+      if (/\/pulls\/\d+\/files/.test(url)) return Response.json([]);
+      if (url.includes("/pulls?state=closed")) {
+        const page = Number(new URL(url).searchParams.get("page") ?? "1");
+        pagesRequested.push(page);
+        return Response.json(
+          [{ number: page, title: `Merged ${page}`, state: "closed", merged_at: "2026-05-20T00:00:00.000Z", user: { login: "oktofeesh1" }, labels: [], body: "" }],
+          { headers: { link: `<https://api.github.com/repositories/1/pulls?page=${page + 1}>; rel="next"` } },
+        );
+      }
+      return Response.json([]);
+    });
+
+    await backfillRepositorySegment(env, { repoFullName: "JSONbored/gittensory", segment: "recent_merged_pull_requests", mode: "full" });
+    pagesRequested.length = 0;
+
+    const resumed = await backfillRepositorySegment(env, {
+      repoFullName: "JSONbored/gittensory",
+      segment: "recent_merged_pull_requests",
+      mode: "resume",
+      cursor: "11",
+    });
+
+    // The explicitly-passed cursor is ignored: the crawl restarts from page 1, so nothing beyond the window
+    // is ever reachable and the run settles as `sampled` again with no cursor to hand back.
+    expect(pagesRequested[0]).toBe(1);
+    expect(pagesRequested).not.toContain(11);
+    expect(resumed).toMatchObject({ status: "sampled" });
+    expect(resumed.nextCursor ?? null).toBeNull();
   });
 
   it("hydrates PR files and reviews through GraphQL when public-token REST detail endpoints are hidden", async () => {


### PR DESCRIPTION
## Summary

`recent_merged_pull_requests` recorded a `nextCursor` that nothing could ever read.

It is the only segment using `progressiveHistory`, and the only one whose terminal status is `sampled`. Three independent gates make that status unresumable:

1. `complete && hasMore` maps to **`sampled`**, never `running` — so the status that would mean "more pages pending" is never produced for this segment.
2. `canResumePreviousScan` accepts only `running` / `partial` / `waiting_rate_limit`. **`sampled` is absent**, so both `previous.nextCursor` and an explicitly passed `cursor` are ignored and `startPage` falls back to 1.
3. The automatic `mode: "resume"` re-send is scoped to `labels` / `open_issues` / `open_pull_requests`, and the scheduled cron only dispatches `light` or `full`.

Confirmed on edge-nl-01 before the change — a `resume` run with an **explicit** `cursor: "11"` against a segment sitting at `next_cursor=11`:

```
{"status":"sampled","fetchedCount":1758,"expectedCount":3588,"nextCursor":"11"}
```

`fetchedCount` unchanged, `nextCursor` still `11`. It re-crawled pages 1–10 and persisted nothing new.

## Which option this takes, and why

#10209 offered two. This is **option 2**: accept the rolling-window design and remove the misleading bookkeeping, rather than making `sampled` resumable.

Option 1 would build machinery to satisfy a claim no caller makes. Every consumer reads through `listRecentMergedPullRequests`, which is `ORDER BY merged_at DESC LIMIT 200` — nothing asks for the deep history, so nothing would benefit from being able to walk it. The stored cursor's only effect today is to invite a reader to conclude the crawl is advancing when it structurally cannot.

What the segment actually is, now stated in the code: a bounded window over the most-recently-updated closed PRs, re-crawled from page 1 each run, whose coverage grows by accretion as the `sort=updated` window slides, and is trimmed by the 30-day `updated_at` retention in `src/db/retention.ts`. That is a defensible design. Recording a continuation position for it is not.

`expectedCount` is **deliberately kept**. "This window holds N of the M closed PRs GitHub reports" is a true and useful coverage statement; it only misleads when read as *progress toward M*, which is exactly what the now-absent cursor signals.

## No behaviour change to the crawl

`sampled` is not a fresh status (`isFreshSegmentStatus` is `complete` / `not_modified` only), so `conditionalRequestForSegment` already returned `undefined` for these rows regardless of the cursor. The 304 conditional-request fast path is untouched, and no page is fetched or skipped differently.

Closes #10209

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed**
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

Detail:

- Full suite: **26,597 passed, 0 failed**.
- The diff has exactly **one** executable changed line (`nextCursor = undefined`); everything else is comment. Verified against lcov line-by-line: that line has **3 hits**, and no changed line is uncovered.
- **Mutation-tested**: removing the assignment fails **both** new regression tests.
- Drift sweep green: `db:migrations:check`, `db:schema-drift:check`, `selfhost:env-reference:check`, `docs:drift-check`, `coverage-boltons:check`, `dead-exports:check`, `manifest:drift-check`.
- Unchecked boxes cover surfaces this diff does not touch (no workflow, MCP, UI, binding or schema change) and are left to CI. `npm audit` reports only pre-existing advisories transitive under `release-please`; this PR changes no dependencies.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

The `/v1/internal/jobs/backfill-repo-segment/run` response drops `nextCursor` for this segment, which is the point — it previously reported a continuation that did not exist. No other field changes shape.

## UI Evidence

Not applicable — no visible UI, frontend, docs, or extension change.

## Notes

The defect is **latent, not user-visible**, which is why #10209 was filed separately from #10203 rather than folded into it. It bounds how much history the table can ever hold and makes the cursor/`expectedCount` bookkeeping misleading to anyone reasoning about coverage — including the 2026-07-10 → 2026-07-23 hole #10193 opened, which no supported path can backfill. This PR does not change what is reachable; it stops the stored row claiming otherwise. Widening the window, if that is ever wanted, is a separate decision with a real GitHub-cost tradeoff.
