### PR TITLE
mcp(stdio): restore the CurrentBranchInput narrowing on the eight local-branch tools

### DIFF
--- a/packages/loopover-contract/src/tools/local-branch.ts
+++ b/packages/loopover-contract/src/tools/local-branch.ts
@@ -239,7 +239,15 @@ export const reviewPrBeforePushTool = defineTool({
   output: PreflightCurrentBranchOutput,
 });
 
+/** What the STDIO server serves: resolves login/repo from session and reads branch metadata from the checkout. */
+export const StdioLocalBranchAnalysisInput = CurrentBranchInput;
+
 export const DraftPrBodyInput = LocalBranchAnalysisInput.extend({
+  format: z.enum(["json", "markdown"]).optional(),
+});
+
+/** What the STDIO server serves for draft_pr_body: the branch narrowing plus optional format. */
+export const StdioDraftPrBodyInput = CurrentBranchInput.extend({
   format: z.enum(["json", "markdown"]).optional(),
 });
 export const draftPrBodyTool = defineTool({

--- a/packages/loopover-mcp/bin/loopover-mcp.ts
+++ b/packages/loopover-mcp/bin/loopover-mcp.ts
@@ -141,6 +141,8 @@ import {
   LocalStatusStructuredInput,
   MarkNotificationsReadInput,
   StdioMarkNotificationsReadInput,
+  StdioLocalBranchAnalysisInput,
+  StdioDraftPrBodyInput,
   MonitorOpenPrsInput,
   OpenPrInput,
   PlanRepoIssuesInput,
@@ -1670,6 +1672,7 @@ registerStdioTool(
       workspaceIntelligence: publicSafeWorkspaceIntelligence(result.analysis.workspaceIntelligence),
     });
   },
+  { input: StdioLocalBranchAnalysisInput },
 );
 
 registerStdioTool(
@@ -1689,6 +1692,7 @@ registerStdioTool(
       recommendedRerunCondition: result.analysis.recommendedRerunCondition,
     });
   },
+  { input: StdioLocalBranchAnalysisInput },
 );
 
 registerStdioTool(
@@ -1697,6 +1701,7 @@ registerStdioTool(
     const result = await analyzeCurrentBranch(await withClientWorkspaceRoots(input));
     return toolResult("LoopOver local next-action ranking.", { local: result.local, nextActions: result.analysis.nextActions, rewardRisk: result.analysis.rewardRisk, recommendedRerunCondition: result.analysis.recommendedRerunCondition });
   },
+  { input: StdioLocalBranchAnalysisInput },
 );
 
 registerStdioTool(
@@ -1713,6 +1718,7 @@ registerStdioTool(
       recommendedRerunCondition: result.analysis.recommendedRerunCondition,
     });
   },
+  { input: StdioLocalBranchAnalysisInput },
 );
 
 registerStdioTool(
@@ -1723,6 +1729,7 @@ registerStdioTool(
     const { localScorerStatus: _localScorerStatus, ...body } = payload;
     return toolResult("LoopOver remediation plan.", await apiPost("/v1/local/remediation-plan", body));
   },
+  { input: StdioLocalBranchAnalysisInput },
 );
 
 registerStdioTool(
@@ -1731,6 +1738,7 @@ registerStdioTool(
     const result = await analyzeCurrentBranch(await withClientWorkspaceRoots(input));
     return toolResult("LoopOver public-safe PR packet.", { local: result.local, prPacket: result.analysis.prPacket });
   },
+  { input: StdioLocalBranchAnalysisInput },
 );
 
 // #6741: CLI stdio mirror of loopover_draft_pr_body — same analyzeCurrentBranch fetch as prepare_pr_packet,
@@ -1755,6 +1763,7 @@ registerStdioTool(
       draft,
     );
   },
+  { input: StdioDraftPrBodyInput },
 );
 
 registerStdioTool(
@@ -1823,6 +1832,7 @@ registerStdioTool(
 registerStdioTool(
   "loopover_agent_prepare_pr_packet",
   async (input: z.infer<typeof CurrentBranchInput>) => toolResult("LoopOver base-agent public-safe PR packet.", await agentPreparePrPacket(await withClientWorkspaceRoots(input))),
+  { input: StdioLocalBranchAnalysisInput },
 );
 
 // Only this tool declares an outputSchema today; every other tool returns text + unschematized

--- a/test/unit/contract-registry.test.ts
+++ b/test/unit/contract-registry.test.ts
@@ -37,6 +37,12 @@ import { CLAIM_STATUSES as MINER_CLAIM_STATUSES } from "../../packages/loopover-
 import { RUN_STATES as LIVE_MINER_RUN_STATES } from "../../packages/loopover-miner/lib/run-state";
 import { LocalStatusStructuredInput } from "@loopover/contract/tools";
 import { GetRepoContextInput } from "@loopover/contract/tools";
+import {
+  DraftPrBodyInput,
+  LocalBranchAnalysisInput,
+  StdioDraftPrBodyInput,
+  StdioLocalBranchAnalysisInput,
+} from "@loopover/contract/tools";
 import { PREFLIGHT_LIMITS as ENGINE_PREFLIGHT_LIMITS } from "../../packages/loopover-engine/src/signals/preflight-limits";
 import { PUBLIC_SURFACE_SKIP_REASONS as SERVER_PUBLIC_SURFACE_SKIP_REASONS } from "../../src/signals/settings-preview";
 import { AUTONOMY_LEVELS as ENGINE_AUTONOMY_LEVELS, AGENT_ACTION_CLASSES as ENGINE_AGENT_ACTION_CLASSES } from "../../packages/loopover-engine/src/settings/autonomy";
@@ -96,6 +102,57 @@ describe("contract tool registry", () => {
     expect(contract!.input.safeParse({ owner: "o", repo: "", title: "t" }).success).toBe(false);
     expect(contract!.input.safeParse({ owner: "o", repo: "r", title: "" }).success).toBe(false);
     expect(contract!.input.safeParse({ owner: "o", repo: "r", title: "t" }).success).toBe(true);
+  });
+
+  it("declares stdio local-branch narrowings derived from LocalBranchAnalysisInput (#10034)", () => {
+    const contractRequired = new Set(
+      ((z.toJSONSchema(LocalBranchAnalysisInput, { target: "draft-2020-12" }) as { required?: string[] }).required ?? []),
+    );
+    const eightTools = [
+      "loopover_preflight_current_branch",
+      "loopover_preview_current_branch_score",
+      "loopover_rank_local_next_actions",
+      "loopover_explain_local_blockers",
+      "loopover_remediation_plan",
+      "loopover_prepare_pr_packet",
+      "loopover_draft_pr_body",
+      "loopover_agent_prepare_pr_packet",
+    ] as const;
+    const narrowingByTool: Record<(typeof eightTools)[number], z.ZodObject> = {
+      loopover_preflight_current_branch: StdioLocalBranchAnalysisInput,
+      loopover_preview_current_branch_score: StdioLocalBranchAnalysisInput,
+      loopover_rank_local_next_actions: StdioLocalBranchAnalysisInput,
+      loopover_explain_local_blockers: StdioLocalBranchAnalysisInput,
+      loopover_remediation_plan: StdioLocalBranchAnalysisInput,
+      loopover_prepare_pr_packet: StdioLocalBranchAnalysisInput,
+      loopover_draft_pr_body: StdioDraftPrBodyInput,
+      loopover_agent_prepare_pr_packet: StdioLocalBranchAnalysisInput,
+    };
+    for (const toolName of eightTools) {
+      const contract = getToolContract(toolName);
+      expect(contract, toolName).toBeDefined();
+      const contractSchema = z.toJSONSchema(contract!.input, { target: "draft-2020-12" }) as {
+        properties?: Record<string, unknown>;
+        required?: string[];
+      };
+      const narrowing = narrowingByTool[toolName];
+      const narrowingSchema = z.toJSONSchema(narrowing, { target: "draft-2020-12" }) as {
+        properties?: Record<string, unknown>;
+        required?: string[];
+      };
+      const narrowingRequired = narrowingSchema.required ?? [];
+      expect(narrowingRequired, toolName).not.toContain("login");
+      expect(narrowingRequired, toolName).not.toContain("repoFullName");
+      for (const required of narrowingRequired) {
+        expect(contractRequired, `${toolName}.${required}`).toContain(required);
+      }
+      for (const property of Object.keys(narrowingSchema.properties ?? {})) {
+        expect(contractSchema.properties ?? {}, `${toolName}.${property}`).toHaveProperty(property);
+      }
+    }
+    expect(DraftPrBodyInput.safeParse({ login: "a", repoFullName: "o/r", format: "json" }).success).toBe(true);
+    expect(StdioDraftPrBodyInput.safeParse({ format: "markdown" }).success).toBe(true);
+    expect(StdioDraftPrBodyInput.safeParse({}).success).toBe(true);
   });
 });
 

--- a/test/unit/mcp-cli-current-branch-input.test.ts
+++ b/test/unit/mcp-cli-current-branch-input.test.ts
@@ -1,0 +1,89 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { closeFixtureServer, startFixtureServer } from "./support/mcp-cli-harness";
+
+const EIGHT_CURRENT_BRANCH_TOOLS = [
+  "loopover_preflight_current_branch",
+  "loopover_preview_current_branch_score",
+  "loopover_rank_local_next_actions",
+  "loopover_explain_local_blockers",
+  "loopover_remediation_plan",
+  "loopover_prepare_pr_packet",
+  "loopover_draft_pr_body",
+  "loopover_agent_prepare_pr_packet",
+] as const;
+
+type BinModule = {
+  server: { connect: (transport: unknown) => Promise<void> };
+};
+
+let tempDir = "";
+let loaded: BinModule;
+
+beforeAll(async () => {
+  tempDir = mkdtempSync(join(tmpdir(), "loopover-current-branch-input-"));
+  const apiUrl = await startFixtureServer();
+  process.env.LOOPOVER_API_URL = apiUrl;
+  process.env.LOOPOVER_API_TOKEN = "in-process-token";
+  process.env.LOOPOVER_API_TIMEOUT_MS = "2000";
+  process.env.LOOPOVER_CONFIG_DIR = tempDir;
+  process.env.LOOPOVER_SKIP_NPM_VERSION_CHECK = "1";
+  process.env.LOOPOVER_LOGIN = "JSONbored";
+  loaded = (await import("../../packages/loopover-mcp/bin/loopover-mcp")) as unknown as BinModule;
+}, 120_000);
+
+afterAll(async () => {
+  await closeFixtureServer();
+  if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+  delete process.env.LOOPOVER_API_URL;
+  delete process.env.LOOPOVER_API_TOKEN;
+  delete process.env.LOOPOVER_CONFIG_DIR;
+  delete process.env.LOOPOVER_SKIP_NPM_VERSION_CHECK;
+  delete process.env.LOOPOVER_LOGIN;
+});
+
+async function connectClient(): Promise<Client> {
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await loaded.server.connect(serverTransport);
+  const client = new Client({ name: "current-branch-input-test", version: "0.1.0" }, { capabilities: {} });
+  await client.connect(clientTransport);
+  return client;
+}
+
+describe("REGRESSION: the stdio branch tools must not demand a login the CLI resolves itself", () => {
+  it("advertises no required login or repoFullName on the eight current-branch tools", async () => {
+    const client = await connectClient();
+    try {
+      const { tools } = await client.listTools();
+      for (const toolName of EIGHT_CURRENT_BRANCH_TOOLS) {
+        const tool = tools.find((entry) => entry.name === toolName);
+        expect(tool, toolName).toBeDefined();
+        const required = (tool!.inputSchema as { required?: string[] }).required ?? [];
+        expect(required, toolName).not.toContain("login");
+        expect(required, toolName).not.toContain("repoFullName");
+      }
+    } finally {
+      await client.close().catch(() => undefined);
+    }
+  });
+
+  it("accepts an empty argument object without schema rejection for login or repoFullName", async () => {
+    const client = await connectClient();
+    try {
+      for (const toolName of EIGHT_CURRENT_BRANCH_TOOLS) {
+        const result = await client.callTool({ name: toolName, arguments: {} });
+        const serialized = JSON.stringify(result);
+        expect(serialized, toolName).not.toMatch(/required property ['"]login['"]/i);
+        expect(serialized, toolName).not.toMatch(/required property ['"]repoFullName['"]/i);
+        expect(serialized, toolName).not.toMatch(/-32602.*login/i);
+        expect(serialized, toolName).not.toMatch(/-32602.*repoFullName/i);
+      }
+    } finally {
+      await client.close().catch(() => undefined);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`packages/loopover-contract/src/tools/local-branch.ts:106` widens the current-branch family's contract
input, and makes two previously-optional fields **required**:

```ts
export const LocalBranchAnalysisInput = CurrentBranchInput.extend({
  login: z.string().min(1).max(SCENARIO_LIMITS.branchRefChars),
  repoFullName: z.string().min(3).max(SCENARIO_LIMITS.repoFullNameChars),
  baseSha: z.string().min(1).optional(),
  ...
```

The doc directly above it, at `packages/loopover-contract/src/tools/local-branch.ts:101`, states the
intended split:

```
 * The contract is the wider surface, per the rule a server narrows FROM: the remote accepts this whole
 * shape because a caller may supply the metadata itself, and the stdio server narrows to `CurrentBranchInput`
 * because it reads the shas, the diff and the scorer probe off the local checkout instead of taking them
 * from the caller -- serving less, and saying so, rather than advertising a field it ignores.
```

**The stdio server never got that narrowing.** `registerStdioTool`
(`packages/loopover-mcp/bin/loopover-mcp.ts:897`) advertises and enforces
`overrides?.input ?? contract.input` at line 923, and none of the eight tools whose contract input is
`LocalBranchAnalysisInput` passes an override. Only five overrides exist in the whole file
(`loopover-mcp.ts:1604`, `:1618`, `:1630`, `:1780`, `:1893`), and none of them is one of these:

| tool | contract entry | stdio registration | handler's declared arg type |
| --- | --- | --- | --- |
| `loopover_preflight_current_branch` | `local-branch.ts:142` | `loopover-mcp.ts:1661` | `z.infer<typeof CurrentBranchInput>` |
| `loopover_preview_current_branch_score` | `local-branch.ts:155` | `loopover-mcp.ts:1679` | `z.infer<typeof CurrentBranchInput>` |
| `loopover_rank_local_next_actions` | `local-branch.ts:168` | `loopover-mcp.ts:1693` | `z.infer<typeof CurrentBranchInput>` |
| `loopover_explain_local_blockers` | `local-branch.ts:181` | `loopover-mcp.ts:1701` | `z.infer<typeof CurrentBranchInput>` |
| `loopover_remediation_plan` | `local-branch.ts:194` | `loopover-mcp.ts:1717` | `z.infer<typeof CurrentBranchInput>` |
| `loopover_prepare_pr_packet` | `local-branch.ts:207` | `loopover-mcp.ts:1727` | `z.infer<typeof CurrentBranchInput>` |
| `loopover_draft_pr_body` | `local-branch.ts:251` (`DraftPrBodyInput = LocalBranchAnalysisInput.extend(...)`) | `loopover-mcp.ts:1738` | `z.infer<typeof DraftPrBodyInput>` |
| `loopover_agent_prepare_pr_packet` | `local-branch.ts:222` | `loopover-mcp.ts:1822` | `z.infer<typeof CurrentBranchInput>` |

This is a behaviour regression, not a latent inconsistency. Before the widening,
`preflightCurrentBranchTool.input` was `CurrentBranchInput` — verifiable with
`git show c3b9a9b1f^:packages/loopover-contract/src/tools/local-branch.ts` (line 99: `input: CurrentBranchInput`).
`CurrentBranchInput` (`local-branch.ts:70`) makes both fields optional precisely because
"both servers resolve it themselves -- the stdio server from its persisted session (or `LOOPOVER_LOGIN`)".

What breaks in practice: `loopover_preflight_current_branch` with `{}` — the ordinary "check the branch
I am on" call, and the one the CLI's own guidance recommends at `loopover-mcp.ts:432` and `:453` — is now
rejected by the MCP SDK with a `-32602` for missing `login` and `repoFullName`, on a server whose handler
resolves both from the checkout and the active session and does not need either.

Nothing catches it. `checkInputNarrowing`
(`scripts/lib/validate-mcp/invariants.ts`) only fails when the ADVERTISED input requires something the
contract does not — here advertised and contract are the same object, so it passes. And
`test/contract/validate-mcp.test.ts:100` synthesizes smoke arguments *from the advertised schema*, so the
validator dutifully supplies `login` and `repoFullName` and the call succeeds.

## Deliverables

- [ ] A narrowing exported from `packages/loopover-contract/src/tools/local-branch.ts`, derived from
      `LocalBranchAnalysisInput`, whose JSON Schema `required` array contains neither `login` nor
      `repoFullName`, and a `loopover_draft_pr_body` variant of it that still declares `format`.
- [ ] All eight `registerStdioTool` call sites in `packages/loopover-mcp/bin/loopover-mcp.ts`
      (lines 1661, 1679, 1693, 1701, 1717, 1727, 1738, 1822) pass that narrowing as the `{ input }` override.
- [ ] A test in `test/unit/contract-registry.test.ts` asserting that, for each of the eight tool names,
      the narrowing's `required` array is a subset of `LocalBranchAnalysisInput`'s and excludes `login`
      and `repoFullName`, and that every property the narrowing declares also exists on the contract
      entry's input (so `checkInputNarrowing` still passes).
- [ ] A regression test at `test/unit/mcp-cli-current-branch-input.test.ts` (new file) that connects an
      in-process client to the stdio `server` export (the `InMemoryTransport` pattern already used in
      `test/contract/validate-mcp.test.ts:150`), reads `tools/list`, and asserts that the advertised
      `inputSchema.required` for all eight tool names contains neither `login` nor `repoFullName` —
      named for this bug (`REGRESSION: the stdio branch tools must not demand a login the CLI resolves itself`).

All Deliverables above are required in a single PR. A PR that satisfies only some of them — for
example fixing `loopover_preflight_current_branch` alone and leaving the other seven, or adding the
narrowing to the contract without wiring it into the registrations — does not resolve this issue.

## Test plan

This repo enforces 99%+ Codecov patch coverage, **branch-counted**. `vitest.config.ts`'s
`coverage.include` covers `packages/loopover-contract/src/**/*.ts` (line 108) and
`packages/loopover-mcp/bin/**/*.ts` (line 120), so **both touched paths are measured and gated**.
The narrowing declarations are plain schema constants with no branches; `registerStdioTool`'s
`overrides?.input ?? contract.input` (`loopover-mcp.ts:923`) is an existing `??` whose BOTH arms must be
exercised — the eight new override call sites cover the left arm, and at least one existing
override-free registration must still be asserted to cover the right arm.

Fixes #10034