### PR TITLE
fix(observability): count the prompt-cache tiers as input tokens for the CLI providers

### DIFF
--- a/src/selfhost/ai.ts
+++ b/src/selfhost/ai.ts
@@ -796,7 +796,29 @@ export function providerNameFromBaseUrl(baseUrl: string | undefined): "ollama" |
   return "openai-compatible";
 }
 
+// ALIASES of one value -- different providers' names for the same number, so `maxNumber` (below) is the right
+// combinator. The uncached portion of the prompt only; see the two cache tiers directly below.
 const INPUT_TOKEN_KEYS = ["input_tokens", "inputTokens", "prompt_tokens", "promptTokens"] as const;
+/** #10235: Anthropic (and therefore Claude Code) splits one prompt across THREE counters -- `input_tokens`
+ *  carries only the portion that was neither read from nor written to the prompt cache. With caching active,
+ *  which it is for every review the CLI runs, essentially the whole prompt lands in these two instead.
+ *
+ *  Measured on edge-nl-01 before this fix: `claude-code` recorded a total of 2048 input tokens across 1000
+ *  calls -- an average of exactly 2.0, against 1051 output tokens per call and $225 of real spend. An average
+ *  of 2.0 over a thousand calls is not a measurement, it is a constant, and every derived figure
+ *  (cost-per-token, input:output ratio, `loopover_ai_input_tokens_total`) was wrong by ~3 orders of magnitude.
+ *
+ *  These are genuine input tokens: the model processed them, and they are billed (cache reads at a reduced
+ *  rate). Each tier is its OWN alias group because the three are ADDITIVE COMPONENTS of one prompt, not names
+ *  for one value -- they must be summed with each other and max'd only within a group. Folding them into
+ *  INPUT_TOKEN_KEYS would take the maximum of the three and silently under-report again, just less severely.
+ *
+ *  Deliberately NOT applied to `coerceByokUsage` (src/services/ai-review.ts): that path documents its own
+ *  reason for skipping these keys -- `callAiProvider` never sends `cache_control`, so the provider never
+ *  populates them there -- and it feeds BYOK_MODEL_PRICING_USD_PER_MTOK, where a cache read bills at a
+ *  different rate than fresh input. The divergence between the two paths is intentional. */
+const CACHE_READ_INPUT_TOKEN_KEYS = ["cache_read_input_tokens", "cacheReadInputTokens"] as const;
+const CACHE_CREATION_INPUT_TOKEN_KEYS = ["cache_creation_input_tokens", "cacheCreationInputTokens"] as const;
 const OUTPUT_TOKEN_KEYS = ["output_tokens", "outputTokens", "completion_tokens", "completionTokens"] as const;
 const TOTAL_TOKEN_KEYS = ["total_tokens", "totalTokens"] as const;
 const COST_KEYS = ["total_cost_usd", "totalCostUsd", "cost_usd", "costUsd"] as const;
@@ -819,6 +841,24 @@ function maxNumber(record: Record<string, unknown>, keys: readonly string[]): nu
   return out;
 }
 
+/**
+ * The full prompt size for one usage envelope: the uncached portion plus both cache tiers (#10235).
+ *
+ * Returns undefined only when the envelope reports NO input counter at all, so a provider that never emits
+ * these keys is completely unaffected and an absent count is never turned into a fabricated 0 (#10207's rule).
+ * A tier that is present but zero contributes a real zero, which is why absence is tested per tier rather than
+ * falsiness.
+ */
+function totalInputTokens(entry: Record<string, unknown>): number | undefined {
+  const tiers = [
+    maxNumber(entry, INPUT_TOKEN_KEYS),
+    maxNumber(entry, CACHE_READ_INPUT_TOKEN_KEYS),
+    maxNumber(entry, CACHE_CREATION_INPUT_TOKEN_KEYS),
+  ];
+  if (tiers.every((tier) => tier === undefined)) return undefined;
+  return tiers.reduce<number>((sum, tier) => sum + (tier ?? 0), 0);
+}
+
 function mergeUsage(out: CliUsage, record: Record<string, unknown>): void {
   const nested = [
     record,
@@ -829,7 +869,7 @@ function mergeUsage(out: CliUsage, record: Record<string, unknown>): void {
     asRecord(record.usageMetadata),
   ].filter((entry): entry is Record<string, unknown> => Boolean(entry));
   for (const entry of nested) {
-    const inputTokens = maxNumber(entry, INPUT_TOKEN_KEYS);
+    const inputTokens = totalInputTokens(entry);
     if (inputTokens !== undefined) out.inputTokens = Math.max(out.inputTokens ?? 0, inputTokens);
     const outputTokens = maxNumber(entry, OUTPUT_TOKEN_KEYS);
     if (outputTokens !== undefined) out.outputTokens = Math.max(out.outputTokens ?? 0, outputTokens);

--- a/src/services/ai-review.ts
+++ b/src/services/ai-review.ts
@@ -2009,7 +2009,11 @@ function priceByokUsageUsd(
  *  the already-camelCase envelope `coerceAiUsage` reads from `env.AI.run()`. Anthropic's `usage` can also
  *  carry `cache_creation_input_tokens`/`cache_read_input_tokens`, priced differently than `input_tokens` —
  *  intentionally not read here, since `callAiProvider` never sends `cache_control`, so Anthropic never
- *  populates them on this path. Private to this file, but not private in effect: `ai-slop.ts`'s BYOK branch
+ *  populates them on this path. #10235: the CLI-subprocess path (`mergeUsage`, src/selfhost/ai.ts) now DOES
+ *  sum those two tiers, because Claude Code caches internally and was therefore reporting ~2 input tokens per
+ *  call. That divergence is deliberate, not drift: reading them here would be dead code today, and if
+ *  `cache_control` is ever introduced it would mis-price, since the sum below feeds
+ *  BYOK_MODEL_PRICING_USD_PER_MTOK at the fresh-input rate while a cache read bills at a reduced one. Private to this file, but not private in effect: `ai-slop.ts`'s BYOK branch
  *  depends on this normalization too, indirectly, via `callAiProvider`'s returned `usage` field — if this
  *  ever moves, update both call sites. */
 function coerceByokUsage(

--- a/test/unit/selfhost-ai.test.ts
+++ b/test/unit/selfhost-ai.test.ts
@@ -1618,6 +1618,36 @@ describe("branch coverage — defaults + edge inputs", () => {
       ),
     ).toEqual({ inputTokens: 12, outputTokens: 6, totalTokens: 18, costUsd: 0.09, model: "gpt-5" });
   });
+
+  it("REGRESSION (#10235): sums the prompt-cache tiers into inputTokens, instead of reporting the uncached remainder", () => {
+    // The real Claude Code result frame. `input_tokens` carries ONLY what was neither read from nor written to
+    // the prompt cache, so with caching active -- which it is on every review -- it degenerates to a handful of
+    // tokens. Measured on the Orb before this fix: 2048 input tokens across 1000 claude-code calls, an average
+    // of exactly 2.0, against 1051 output tokens per call and $225 of real spend.
+    expect(
+      extractCliUsage(
+        JSON.stringify({
+          type: "result",
+          usage: { input_tokens: 2, cache_read_input_tokens: 41_820, cache_creation_input_tokens: 1_140, output_tokens: 1051 },
+          model: "claude-sonnet-5",
+        }),
+      ),
+    ).toEqual({ inputTokens: 42_962, outputTokens: 1051, model: "claude-sonnet-5" });
+  });
+
+  it("sums the cache tiers only when present, leaving every other provider untouched (#10235)", () => {
+    // codex and the OpenAI-compatible providers emit no cache keys at all: their figure must be byte-identical
+    // to before, which is what makes this safe to apply at the shared extraction point.
+    expect(extractCliUsage(JSON.stringify({ usage: { input_tokens: 20, output_tokens: 7 } }))).toEqual({ inputTokens: 20, outputTokens: 7 });
+    // A cache tier alone, with no uncached remainder reported, still yields the real prompt size.
+    expect(extractCliUsage(JSON.stringify({ usage: { cache_read_input_tokens: 900 } }))).toEqual({ inputTokens: 900 });
+    // camelCase aliases resolve the same way the other key groups already do.
+    expect(extractCliUsage(JSON.stringify({ usage: { inputTokens: 5, cacheReadInputTokens: 10, cacheCreationInputTokens: 20 } }))).toEqual({ inputTokens: 35 });
+    // A genuinely reported 0 in one tier contributes a real 0 rather than dropping the whole reading.
+    expect(extractCliUsage(JSON.stringify({ usage: { input_tokens: 0, cache_read_input_tokens: 700, cache_creation_input_tokens: 0 } }))).toEqual({ inputTokens: 700 });
+    // No input counter of any kind stays ABSENT -- never a fabricated 0 (#10207).
+    expect(extractCliUsage(JSON.stringify({ usage: { output_tokens: 4 } }))).toEqual({ outputTokens: 4 });
+  });
   it("claudeErrorStatus: subtype + unknown fallbacks", () => {
     expect(claudeErrorStatus(JSON.stringify({ is_error: true, subtype: "sub" }))).toBe("sub");
     expect(claudeErrorStatus(JSON.stringify({ is_error: true }))).toBe("unknown");


### PR DESCRIPTION
## Summary

**Every `claude-code` call recorded exactly ~2 input tokens.** Measured on edge-nl-01 over 48h:

| provider | calls | input total | input avg | output total | output avg | cost |
|---|---|---|---|---|---|---|
| `claude-code` | 1000 | 2048 | **2.0** | 1,051,346 | 1051.3 | **$225.06** |

An average of 2.0 across a thousand calls is not a measurement, it is a constant. The output side is healthy and the dollar cost is real, so the event was arriving and being parsed — the input figure specifically carried nothing.

## Cause

Anthropic — and therefore Claude Code — splits one prompt across **three** counters. `input_tokens` carries only the portion that was neither read from nor written to the prompt cache; the rest lands in `cache_read_input_tokens` and `cache_creation_input_tokens`. `INPUT_TOKEN_KEYS` (`src/selfhost/ai.ts`) read only the first group:

```ts
const INPUT_TOKEN_KEYS = ["input_tokens", "inputTokens", "prompt_tokens", "promptTokens"] as const;
```

With caching active — which it is on every review the CLI runs, since the system prompt and tool definitions are stable — that degenerates to the handful of genuinely-new tokens per call. Nothing was malformed and nothing was being dropped defensively: the extractor read a real field that does not mean what its name suggests under caching.

## Fix, and the trap inside it

The two cache tiers are counted as input tokens, because they are: the model processed them, and they are billed (cache reads at a reduced rate).

**Each tier gets its own alias group, and the groups are SUMMED — not appended to `INPUT_TOKEN_KEYS`.** `maxNumber` takes the maximum across a key list, which is correct for aliases (`input_tokens` and `prompt_tokens` are two names for one number) but wrong here, because the three are **additive components** of a single prompt. Folding them into one list would take the max of the three and silently under-report again, just less severely — the same failure wearing a smaller number.

Absence stays absence: an envelope reporting no input counter at all yields `undefined`, never a fabricated `0` (#10207's rule), while a tier that is present but zero contributes a real zero.

## Blast radius

- Providers that emit no cache keys — `codex` and the OpenAI-compatible bindings — are **byte-identical** to before. That is what makes this safe to apply at the shared extraction point rather than per-provider, and it is pinned by a test.
- `loopover_ai_input_tokens_total` is corrected by the same change, since it reads the same `usage.inputTokens`. The Prometheus/Grafana view was wrong in the same direction.

## What is deliberately NOT changed

`coerceByokUsage` (`src/services/ai-review.ts`) — the BYOK API path — already considered these exact two keys and declined them:

> *"intentionally not read here, since `callAiProvider` never sends `cache_control`, so Anthropic never populates them on this path."*

That reasoning still holds, and reading them there would be worse than dead code: it feeds `BYOK_MODEL_PRICING_USD_PER_MTOK`, where a cache read bills at a **different rate** than fresh input, so if `cache_control` is ever introduced it would mis-price. The two paths naming the same keys but disagreeing on whether to read them is correct, not drift — its comment now says so explicitly, so the next reader sees an intentional divergence rather than an oversight.

Closes #10235

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed**
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

Detail:

- Full suite against current `main`: **26,623 passed, 0 failed**.
- Patch coverage verified **line-by-line against lcov**, every changed hunk: **all changed lines and branches covered**, no exceptions.
- **Mutation-tested**: reverting `totalInputTokens` to the old `maxNumber(entry, INPUT_TOKEN_KEYS)` fails both new tests.
- The regression test uses the **real Claude Code result frame** (`input_tokens: 2` alongside `cache_read_input_tokens: 41820` / `cache_creation_input_tokens: 1140`), reproducing the exact ~2 observed in production.
- Boundary cases pinned separately: no cache keys at all (unchanged), a cache tier with no uncached remainder, camelCase aliases, a genuinely-reported 0 in one tier, and no input counter of any kind (stays absent).
- Drift sweep green: `selfhost:env-reference:check`, `docs:drift-check`, `coverage-boltons:check`, `dead-exports:check`, `manifest:drift-check`.
- Unchecked boxes cover surfaces this diff does not touch. `npm audit` reports only pre-existing advisories transitive under `release-please`; this PR changes no dependencies.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

Token counts only — no prompt, diff, transcript or completion content is read or emitted by this path, and the metadata-only policy on `$ai_generation` is unchanged.

## UI Evidence

Not applicable — no visible UI, frontend, docs, or extension change.

## Notes

Historical `ai_usage_events` rows keep their wrong figure; this corrects the reading going forward rather than backfilling. Worth knowing when comparing across the cutover: `claude-code` input tokens will jump by roughly three orders of magnitude, and that jump is the fix landing, not a change in usage. Cost is unaffected — `$ai_total_cost_usd` was always read from the provider's own `total_cost_usd` and was never derived from these counters.
