### PR TITLE
fix(miner): cap check-runs page follows so poll cannot spin forever

### DIFF
--- a/packages/loopover-miner/lib/ci-poller.ts
+++ b/packages/loopover-miner/lib/ci-poller.ts
@@ -5,6 +5,10 @@ const defaultMinIntervalMs = 60_000;
 const defaultMaxIntervalMs = 5 * 60_000;
 const defaultMaxAttempts = 1;
 const defaultRequestTimeoutMs = 10_000;
+// Follow the check-runs Link header past the first page so a head with >100 checks isn't silently
+// truncated; cap the follow loop so a pathological Link chain can't run away (#10007). Default 10
+// pages × per_page=100 = 1000 checks — well above any realistic PR check-run count.
+const defaultMaxPages = 10;
 const githubApiVersion = "2022-11-28";
 
 export type CheckRunConclusion = "pending" | "success" | "failure" | "neutral";
@@ -33,6 +37,8 @@ export type PollCheckRunsOptions = {
   minIntervalMs?: number;
   maxIntervalMs?: number;
   requestTimeoutMs?: number;
+  /** Cap on check-runs page follows (#10007); defaults to `defaultMaxPages`. */
+  maxPages?: number;
   sleepFn?: (delayMs: number) => Promise<unknown>;
 };
 
@@ -44,6 +50,7 @@ type NormalizedPollOptions = {
   minIntervalMs: number;
   maxIntervalMs: number;
   requestTimeoutMs: number;
+  maxPages: number;
   sleepFn: (delayMs: number) => Promise<unknown>;
 };
 
@@ -81,6 +88,8 @@ function normalizeOptions(options: PollCheckRunsOptions = {}): NormalizedPollOpt
     minIntervalMs: normalizePositiveInt(options.minIntervalMs, defaultMinIntervalMs, 1, 60 * 60_000),
     maxIntervalMs: normalizePositiveInt(options.maxIntervalMs, defaultMaxIntervalMs, 1, 60 * 60_000),
     requestTimeoutMs: normalizePositiveInt(options.requestTimeoutMs, defaultRequestTimeoutMs, 1, 60_000),
+    // Same clamp shape as opportunity-fanout's maxPages (#4831 / #10007).
+    maxPages: normalizePositiveInt(options.maxPages, defaultMaxPages, 1, 100),
     sleepFn:
       options.sleepFn ??
       ((delayMs: number) => new Promise((resolve) => setTimeout(resolve, delayMs))),
@@ -233,7 +242,8 @@ async function fetchCheckRuns(
   const checks: NormalizedCheckRun[] = [];
   let page = 1;
   let expectedTotalCount: number | null = null;
-  while (true) {
+  // #10007: page-count cap (not checks.length) so a looping endpoint that re-serves the same page can't spin forever.
+  while (page <= options.maxPages) {
     const { payload, response } = await githubGetJsonResponse(
       apiUrl(
         options.apiBaseUrl,
@@ -257,6 +267,8 @@ async function fetchCheckRuns(
     }
     page += 1;
   }
+  // Distinct from pagination_incomplete: the server kept advertising more pages past the hard cap.
+  throw new Error("github_check_runs_pagination_page_cap");
 }
 
 export async function pollCheckRuns(

--- a/test/unit/miner-ci-poller.test.ts
+++ b/test/unit/miner-ci-poller.test.ts
@@ -604,4 +604,140 @@ describe("miner CI check-run poller (#2323)", () => {
       vi.useRealTimers();
     }
   });
+
+  it('REGRESSION: a never-ending rel="next" chain stops at the page cap instead of looping forever (#10007)', async () => {
+    const fetchFn = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/pulls/18")) return prResponse("cap-sha");
+      if (url.includes("/check-runs")) {
+        // Always advertise another page with a non-empty body — the pre-fix while(true) never exits.
+        return checksResponse([checkRun("validate", "completed", "success")], {
+          totalCount: 10_000,
+          headers: {
+            link: `<${API}/repos/acme/widgets/commits/cap-sha/check-runs?per_page=100&page=999>; rel="next"`,
+          },
+        });
+      }
+      return jsonResponse({}, { status: 404 });
+    });
+
+    await expect(
+      pollCheckRuns("acme/widgets", 18, {
+        apiBaseUrl: API,
+        fetchFn,
+        maxPages: 3,
+        sleepFn: vi.fn(async () => {}),
+      }),
+    ).rejects.toThrow("github_check_runs_pagination_page_cap");
+
+    const checkRunCalls = fetchFn.mock.calls.filter((call) => String(call[0]).includes("/check-runs"));
+    expect(checkRunCalls).toHaveLength(3);
+  });
+
+  it("still returns every check run across a two-page response under the default maxPages (#10007)", async () => {
+    const fetchFn = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/pulls/19")) return prResponse("two-page-sha");
+      if (url.includes("&page=1")) {
+        return checksResponse([checkRun("a", "completed", "success")], {
+          totalCount: 2,
+          headers: {
+            link: `<${API}/repos/acme/widgets/commits/two-page-sha/check-runs?per_page=100&page=2>; rel="next"`,
+          },
+        });
+      }
+      if (url.includes("&page=2")) {
+        return checksResponse([checkRun("b", "completed", "failure")], { totalCount: 2 });
+      }
+      return jsonResponse({}, { status: 404 });
+    });
+
+    const result = await pollCheckRuns("acme/widgets", 19, {
+      apiBaseUrl: API,
+      fetchFn,
+      sleepFn: vi.fn(async () => {}),
+      // omit maxPages — default must still allow a normal two-page follow
+    });
+    expect(result.checks.map((check) => check.name)).toEqual(["a", "b"]);
+    expect(result.conclusion).toBe("failure");
+  });
+
+  it("still throws github_check_runs_pagination_incomplete on an empty mid-stream page (#10007)", async () => {
+    const fetchFn = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/pulls/20")) return prResponse("empty-page-sha");
+      if (url.includes("&page=1")) {
+        return checksResponse([checkRun("a", "completed", "success")], {
+          totalCount: 2,
+          headers: {
+            link: `<${API}/repos/acme/widgets/commits/empty-page-sha/check-runs?per_page=100&page=2>; rel="next"`,
+          },
+        });
+      }
+      if (url.includes("&page=2")) {
+        return checksResponse([], { totalCount: 2 });
+      }
+      return jsonResponse({}, { status: 404 });
+    });
+
+    await expect(
+      pollCheckRuns("acme/widgets", 20, {
+        apiBaseUrl: API,
+        fetchFn,
+        sleepFn: vi.fn(async () => {}),
+      }),
+    ).rejects.toThrow("github_check_runs_pagination_incomplete");
+  });
+
+  it("clamps maxPages to the floor of 1 and the ceiling of 100 (#10007)", async () => {
+    const endless = (sha: string) =>
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes("/pulls/")) return prResponse(sha);
+        if (url.includes("/check-runs")) {
+          return checksResponse([checkRun("validate", "completed", "success")], {
+            totalCount: 10_000,
+            headers: {
+              link: `<${API}/repos/acme/widgets/commits/${sha}/check-runs?per_page=100&page=999>; rel="next"`,
+            },
+          });
+        }
+        return jsonResponse({}, { status: 404 });
+      });
+
+    // Floor: non-finite / sub-1 values fall back or clamp to 1 → exactly one check-runs page before the cap error.
+    const floorFetch = endless("floor-sha");
+    await expect(
+      pollCheckRuns("acme/widgets", 21, {
+        apiBaseUrl: API,
+        fetchFn: floorFetch,
+        maxPages: 0,
+        sleepFn: vi.fn(async () => {}),
+      }),
+    ).rejects.toThrow("github_check_runs_pagination_page_cap");
+    expect(floorFetch.mock.calls.filter((call) => String(call[0]).includes("/check-runs"))).toHaveLength(1);
+
+    // Omitted maxPages uses the default (10): ten check-runs pages, then the cap error.
+    const defaultFetch = endless("default-sha");
+    await expect(
+      pollCheckRuns("acme/widgets", 22, {
+        apiBaseUrl: API,
+        fetchFn: defaultFetch,
+        sleepFn: vi.fn(async () => {}),
+      }),
+    ).rejects.toThrow("github_check_runs_pagination_page_cap");
+    expect(defaultFetch.mock.calls.filter((call) => String(call[0]).includes("/check-runs"))).toHaveLength(10);
+
+    // Ceiling: values above 100 clamp to 100.
+    const ceilingFetch = endless("ceiling-sha");
+    await expect(
+      pollCheckRuns("acme/widgets", 23, {
+        apiBaseUrl: API,
+        fetchFn: ceilingFetch,
+        maxPages: 10_000,
+        sleepFn: vi.fn(async () => {}),
+      }),
+    ).rejects.toThrow("github_check_runs_pagination_page_cap");
+    expect(ceilingFetch.mock.calls.filter((call) => String(call[0]).includes("/check-runs"))).toHaveLength(100);
+  });
 });


### PR DESCRIPTION
## Summary

- Add `maxPages` to `PollCheckRunsOptions`, normalized like the other poller bounds (default **10** → 1000 checks at `per_page=100`, clamped 1–100), mirroring `opportunity-fanout`'s page-follow cap.
- Replace `fetchCheckRuns`' unbounded `while (true)` with `while (page <= maxPages)`; exceeding the cap throws `github_check_runs_pagination_page_cap` so a pathological `rel="next"` chain cannot wedge `manage poll` / `loop`.
- Legitimate multi-page responses and `github_check_runs_pagination_incomplete` behavior are unchanged.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran focused coverage on `packages/loopover-miner/lib/ci-poller.ts` via `test/unit/miner-ci-poller.test.ts` + `test/unit/miner-ci-poller-failure-modes.test.ts` (100% lines / 100% branches on the file). Full `test:ci` / UI / MCP packs deferred to CI for this miner-lib-only change.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — no visible UI/frontend/docs changes.

## Notes

- Closes #10007
- Error at the page cap is deliberately distinct from `github_check_runs_pagination_incomplete` so operators can tell "server kept advertising more pages" from "empty page mid-stream".


Made with [Cursor](https://cursor.com)