### PR TITLE
refactor(ai-review): give both reviewer paths one shared options type instead of a positional tail

### DIFF
--- a/src/services/ai-review.ts
+++ b/src/services/ai-review.ts
@@ -1610,6 +1610,38 @@ const REVIEW_ATTEMPTS_PER_MODEL = 3;
 
 /** One reviewer opinion (whichever provider `env.AI` resolves to — self-host Codex/Claude Code/etc, or the
  *  legacy Workers-AI pair) with a per-slot reliable fallback and a 3× retry on the primary. */
+/**
+ * The reviewer inputs BOTH provider paths must agree on (#10253).
+ *
+ * `runWorkersOpinion` (Workers AI) and `runProviderReview` (BYOK) each ran the same demotion sequence off the
+ * same trailing arguments, kept in step by nothing but two comments reading "same contract as
+ * runWorkersOpinion". Two adjacent, same-typed, identically-defaulted booleans meant transposing them at any
+ * call site compiled cleanly, type-checked cleanly, and silently armed the wrong demotion — and doing it in
+ * only ONE of the two paths split Workers AI and BYOK behaviour apart with no signal at all.
+ *
+ * One shared type referenced by both signatures makes the compiler enforce what the comments only asserted, so
+ * the pair cannot drift and needs no entry in `NAMED_TWIN_PAIRS` (scripts/check-engine-parity.ts) to guard it.
+ */
+type ReviewerDemotionContext = {
+  /** Pixel-diff-confirmed screenshot(s) for a visual-vision pass (#4111). Absent for every existing caller —
+   *  wiring a real caller (source images, invoke with them) is a deliberately deferred follow-up; see
+   *  review/visual/visual-findings.ts. Kept rather than deleted: removing a deferred-but-designed parameter is
+   *  a separate call from de-positionalising this signature. */
+  images?: readonly AiContentBlock[] | undefined;
+  /** #8961: true when the PR description exceeded the prompt window — arms the evidence-absence demotion. */
+  bodyTruncated?: boolean | undefined;
+  /** #8833: true when the PR changes at least one test path — arms the test-absence demotion. */
+  prHasTestEvidence?: boolean | undefined;
+};
+
+/** {@link runWorkersOpinion}'s own accidental tail, on top of the shared context above. `env` through
+ *  `maxTokens` stay positional — those are the genuine arguments. */
+type WorkersOpinionOptions = ReviewerDemotionContext & {
+  diagnostics?: AiReviewDiagnostic[] | undefined;
+  systemAppend?: string | undefined;
+  correlation?: AiRunCorrelation | undefined;
+};
+
 async function runWorkersOpinion(
   env: Env,
   primary: string,
@@ -1617,18 +1649,11 @@ async function runWorkersOpinion(
   system: string,
   user: string,
   maxTokens: number,
-  diagnostics: AiReviewDiagnostic[] = [],
-  systemAppend = "",
-  correlation?: AiRunCorrelation,
-  // Pixel-diff-confirmed screenshot(s) for a visual-vision pass (#4111). Absent for every existing caller —
-  // wiring a real caller (source images, invoke with them) is a deliberately deferred follow-up; see
-  // review/visual/visual-findings.ts.
-  images?: readonly AiContentBlock[] | undefined,
-  // #8961: true when the PR description exceeded the prompt window — arms the evidence-absence demotion.
-  bodyTruncated = false,
-  // #8833: true when the PR changes at least one test path — arms the test-absence demotion.
-  prHasTestEvidence = false,
+  options: WorkersOpinionOptions = {},
 ): Promise<ReviewerOpinionOutcome> {
+  // Destructured with the identical defaults the positional signature carried, so every body reference below
+  // is unchanged and this stays a pure de-positionalisation.
+  const { diagnostics = [], systemAppend = "", correlation, images, bodyTruncated = false, prHasTestEvidence = false } = options;
   const ai = env.AI as unknown as AiRunner | undefined;
   if (!ai || typeof ai.run !== "function") return { review: null };
   // Route through Cloudflare AI Gateway when configured (caching, rate-limiting, logging, fallback). The
@@ -2174,15 +2199,16 @@ export async function regeneratePublicSafeSummary(
   return toPublicSafeBySentence(trimmed, options);
 }
 
+/** The BYOK half of the pair {@link ReviewerDemotionContext} documents. It now shares that type with
+ *  `runWorkersOpinion` rather than restating the same three parameters positionally, so the two cannot drift. */
 async function runProviderReview(
   providerKey: AiReviewProviderKey,
   system: string,
   user: string,
   maxTokens: number,
-  images?: readonly AiContentBlock[] | undefined,
-  bodyTruncated = false, // #8961: arms the evidence-absence demotion, same contract as runWorkersOpinion
-  prHasTestEvidence = false, // #8833: arms the test-absence demotion, same contract as runWorkersOpinion
+  options: ReviewerDemotionContext = {},
 ): Promise<ProviderReviewOutcome> {
+  const { images, bodyTruncated = false, prHasTestEvidence = false } = options;
   const { text, usage, failure } = await callAiProvider(
     providerKey,
     system,
@@ -3217,15 +3243,7 @@ export async function runLoopOverAiReview(
     anthropicModel: input.reviewKnobs?.model ?? input.anthropicModel ?? undefined,
   };
   if (input.providerKey) {
-    const outcome = await runProviderReview(
-      input.providerKey,
-      system,
-      user,
-      maxTokens,
-      undefined,
-      bodyTruncated,
-      prHasTestEvidence,
-    );
+    const outcome = await runProviderReview(input.providerKey, system, user, maxTokens, { bodyTruncated, prHasTestEvidence });
     advisoryReview = outcome.review;
     byokFailure = outcome.failure;
     if (outcome.fallbackNote) fallbackNotes.push(outcome.fallbackNote);
@@ -3238,12 +3256,7 @@ export async function runLoopOverAiReview(
       system,
       user,
       maxTokens,
-      reviewDiagnostics,
-      repoInstructionsSystemAppend,
-      aiRunCorrelation,
-      undefined,
-      bodyTruncated,
-      prHasTestEvidence,
+      { diagnostics: reviewDiagnostics, systemAppend: repoInstructionsSystemAppend, correlation: aiRunCorrelation, bodyTruncated, prHasTestEvidence },
     );
     advisoryReview = outcome.review;
     if (outcome.fallbackNote) fallbackNotes.push(outcome.fallbackNote);
@@ -3269,12 +3282,7 @@ export async function runLoopOverAiReview(
               system,
               user,
               maxTokens,
-              reviewDiagnostics,
-              repoInstructionsSystemAppend,
-              aiRunCorrelation,
-              undefined,
-              bodyTruncated,
-              prHasTestEvidence,
+              { diagnostics: reviewDiagnostics, systemAppend: repoInstructionsSystemAppend, correlation: aiRunCorrelation, bodyTruncated, prHasTestEvidence },
             )
           : Promise.resolve<ReviewerOpinionOutcome>({ review: advisoryReview }),
         runWorkersOpinion(
@@ -3284,12 +3292,7 @@ export async function runLoopOverAiReview(
           system,
           user,
           maxTokens,
-          reviewDiagnostics,
-          repoInstructionsSystemAppend,
-          aiRunCorrelation,
-          undefined,
-          bodyTruncated,
-          prHasTestEvidence,
+          { diagnostics: reviewDiagnostics, systemAppend: repoInstructionsSystemAppend, correlation: aiRunCorrelation, bodyTruncated, prHasTestEvidence },
         ),
       ]);
       if (a.fallbackNote) fallbackNotes.push(a.fallbackNote);
@@ -3353,12 +3356,7 @@ export async function runLoopOverAiReview(
             system,
             user,
             maxTokens,
-            reviewDiagnostics,
-            repoInstructionsSystemAppend,
-            aiRunCorrelation,
-            undefined,
-            bodyTruncated,
-            prHasTestEvidence,
+            { diagnostics: reviewDiagnostics, systemAppend: repoInstructionsSystemAppend, correlation: aiRunCorrelation, bodyTruncated, prHasTestEvidence },
           )
         : ({ review: advisoryReview } as ReviewerOpinionOutcome);
       if (a.fallbackNote) fallbackNotes.push(a.fallbackNote);
@@ -3406,12 +3404,7 @@ export async function runLoopOverAiReview(
         system + rotatedExemplarSuffix(rotationSeed, runIndex),
         user,
         maxTokens,
-        reviewDiagnostics,
-        repoInstructionsSystemAppend,
-        aiRunCorrelation,
-        undefined,
-        bodyTruncated,
-        prHasTestEvidence,
+        { diagnostics: reviewDiagnostics, systemAppend: repoInstructionsSystemAppend, correlation: aiRunCorrelation, bodyTruncated, prHasTestEvidence },
       );
       // No fallbackNote handling: runWorkersOpinion never produces one (that field is the BYOK provider
       // path's). A failed extra simply contributes no stance -- recorded below as spend, never fabricated.

--- a/test/unit/ai-review.test.ts
+++ b/test/unit/ai-review.test.ts
@@ -3571,7 +3571,7 @@ describe("pure helpers", () => {
       response: '{"assessment":"looks off","blockers":["No before/after screenshots provided for this visual change","Null deref in src/a.ts"],"nits":[],"suggestions":[]}',
     }));
     const env = createTestEnv({ AI: { run } as unknown as Ai });
-    const truncated = await runWorkersOpinion(env, "@cf/x/model", "@cf/x/model", "sys", "user", 256, [], "", undefined, undefined, true);
+    const truncated = await runWorkersOpinion(env, "@cf/x/model", "@cf/x/model", "sys", "user", 256, { bodyTruncated: true });
     expect(truncated.review?.blockers).toEqual(["Null deref in src/a.ts"]);
     expect(truncated.review?.nits.some((nit) => nit.includes("absence of evidence inside the truncated window"))).toBe(true);
     expect(warn.mock.calls.some(([line]) => String(line).includes("ai_review_evidence_absence_demoted"))).toBe(true);
@@ -3590,7 +3590,7 @@ describe("pure helpers", () => {
     });
     const env = createTestEnv({ AI: { run } as unknown as Ai });
     const images = [{ type: "image" as const, data: "QUJD", mimeType: "image/png" }];
-    await runWorkersOpinion(env, "m", "m", "sys", "user text", 256, [], "", undefined, images);
+    await runWorkersOpinion(env, "m", "m", "sys", "user text", 256, { images });
     expect(seenContents[0]).toEqual([
       { type: "text", text: "user text" },
       { type: "image", data: "QUJD", mimeType: "image/png" },
@@ -3608,7 +3608,7 @@ describe("pure helpers", () => {
     });
     const env = createTestEnv({ AI: { run } as unknown as Ai });
     const diagnostics: Array<{ status: string; model: string }> = [];
-    const parsed = await runWorkersOpinion(env, "primary", "fallback", "sys", "user", 256, diagnostics as never);
+    const parsed = await runWorkersOpinion(env, "primary", "fallback", "sys", "user", 256, { diagnostics: diagnostics as never });
     expect(parsed.review?.assessment).toContain("reasonable");
     expect(primaryAttempts).toBe(1); // NOT 3 -- the timeout short-circuits further retries of this model.
     expect(run).toHaveBeenCalledTimes(2); // 1 primary (timed out) + 1 fallback (succeeded on its first try).
@@ -3633,7 +3633,7 @@ describe("pure helpers", () => {
     });
     const env = createTestEnv({ AI: { run } as unknown as Ai });
     const diagnostics: Array<{ status: string; model: string }> = [];
-    const parsed = await runWorkersOpinion(env, "primary", "fallback", "sys", "user", 256, diagnostics as never);
+    const parsed = await runWorkersOpinion(env, "primary", "fallback", "sys", "user", 256, { diagnostics: diagnostics as never });
     expect(parsed.review?.assessment).toContain("reasonable");
     expect(primaryAttempts).toBe(1); // NOT 3 -- the stall short-circuits further retries of this model.
     expect(run).toHaveBeenCalledTimes(2); // 1 primary (stalled) + 1 fallback (succeeded on its first try).
@@ -3650,7 +3650,7 @@ describe("pure helpers", () => {
     });
     const env = createTestEnv({ AI: { run } as unknown as Ai });
     const diagnostics: Array<{ status: string; model: string }> = [];
-    await runWorkersOpinion(env, "primary", "fallback", "sys", "user", 256, diagnostics as never);
+    await runWorkersOpinion(env, "primary", "fallback", "sys", "user", 256, { diagnostics: diagnostics as never });
     expect(primaryAttempts).toBe(3);
   });
 
@@ -3665,7 +3665,7 @@ describe("pure helpers", () => {
     });
     const env = createTestEnv({ AI: { run } as unknown as Ai });
     const diagnostics: Array<{ status: string; model: string }> = [];
-    await runWorkersOpinion(env, "primary", "fallback", "sys", "user", 256, diagnostics as never);
+    await runWorkersOpinion(env, "primary", "fallback", "sys", "user", 256, { diagnostics: diagnostics as never });
     expect(primaryAttempts).toBe(3);
   });
 
@@ -3678,7 +3678,7 @@ describe("pure helpers", () => {
     });
     const env = createTestEnv({ AI: { run } as unknown as Ai });
     const diagnostics: Array<{ status: string; model: string }> = [];
-    const parsed = await runWorkersOpinion(env, "primary", "fallback", "sys", "user", 256, diagnostics as never);
+    const parsed = await runWorkersOpinion(env, "primary", "fallback", "sys", "user", 256, { diagnostics: diagnostics as never });
     expect(parsed.review?.assessment).toContain("reasonable");
     expect(primaryAttempts).toBe(1); // NOT 3 -- the 429 short-circuits further retries of this model.
     expect(run).toHaveBeenCalledTimes(2); // 1 primary (rate-limited) + 1 fallback (succeeded on its first try).
@@ -3693,7 +3693,7 @@ describe("pure helpers", () => {
     });
     const env = createTestEnv({ AI: { run } as unknown as Ai });
     const diagnostics: Array<{ status: string; model: string }> = [];
-    const parsed = await runWorkersOpinion(env, "primary", "fallback", "sys", "user", 256, diagnostics as never);
+    const parsed = await runWorkersOpinion(env, "primary", "fallback", "sys", "user", 256, { diagnostics: diagnostics as never });
     expect(parsed.review?.assessment).toContain("reasonable");
     expect(primaryAttempts).toBe(1); // NOT 3 -- a structural config error is deterministic, so retrying is pointless.
     expect(run).toHaveBeenCalledTimes(2); // 1 primary (structural failure) + 1 fallback (succeeded on its first try).
@@ -3708,7 +3708,7 @@ describe("pure helpers", () => {
     });
     const env = createTestEnv({ AI: { run } as unknown as Ai });
     const diagnostics: Array<{ status: string; model: string }> = [];
-    const parsed = await runWorkersOpinion(env, "primary", "fallback", "sys", "user", 256, diagnostics as never);
+    const parsed = await runWorkersOpinion(env, "primary", "fallback", "sys", "user", 256, { diagnostics: diagnostics as never });
     expect(parsed.review?.assessment).toContain("reasonable");
     expect(primaryAttempts).toBe(1); // NOT 3 -- the model's own deliberate bail will not change on a same-model retry.
     expect(run).toHaveBeenCalledTimes(2); // 1 primary (incoherent-diff bail) + 1 fallback (succeeded on its first try).
@@ -3736,7 +3736,7 @@ describe("pure helpers", () => {
     });
     const env = createTestEnv({ AI: { run } as unknown as Ai });
     const diagnostics: Array<{ status: string; model: string; attempt: number }> = [];
-    const parsed = await runWorkersOpinion(env, "primary", "fallback", "sys", "user", 256, diagnostics as never);
+    const parsed = await runWorkersOpinion(env, "primary", "fallback", "sys", "user", 256, { diagnostics: diagnostics as never });
     expect(parsed.review?.assessment).toBe("The change looks reasonable and focused.");
     expect(attempts).toBe(2); // 1 missing-assessment attempt, then a real one -- same model, no fallback needed.
     expect(diagnostics[0]).toMatchObject({ model: "primary", attempt: 0, status: "missing_assessment" });
@@ -3781,7 +3781,7 @@ describe("pure helpers", () => {
     }));
     const env = createTestEnv({ AI: { run } as unknown as Ai });
     const diagnostics: Array<{ status: string }> = [];
-    const parsed = await runWorkersOpinion(env, "m", "m", "sys", "user", 256, diagnostics as never);
+    const parsed = await runWorkersOpinion(env, "m", "m", "sys", "user", 256, { diagnostics: diagnostics as never });
     expect(parsed.review).toBeNull(); // INCOHERENT_DIFF_ASSESSMENT parses to null (see parseModelReview)
     expect(diagnostics.some((d) => d.status === "missing_assessment")).toBe(false);
   });
@@ -3855,7 +3855,7 @@ describe("pure helpers", () => {
       return { response: reviewJson() };
     });
     const env = createTestEnv({ AI: { run } as unknown as Ai });
-    await runWorkersOpinion(env, "@cf/x/model", "@cf/x/model", "sys", "user", 256, [], "", {
+    await runWorkersOpinion(env, "@cf/x/model", "@cf/x/model", "sys", "user", 256, { correlation: {
       jobId: "job-1",
       repoFullName: "acme/widgets",
       pullNumber: 7,
@@ -3863,7 +3863,7 @@ describe("pure helpers", () => {
       claudeEffort: "low",
       codexModel: "gpt-5.4-mini",
       codexEffort: "high",
-    });
+    } });
     expect(seenOptions).toMatchObject({
       jobId: "job-1",
       repoFullName: "acme/widgets",
@@ -3973,7 +3973,7 @@ describe("pure helpers", () => {
     const run = vi.fn(async () => ({ response: longResponse }));
     const env = createTestEnv({ AI: { run } as unknown as Ai });
     const diagnostics: AiReviewDiagnostic[] = [];
-    await runWorkersOpinion(env, "primary-model", "primary-model", "sys", "user", 256, diagnostics);
+    await runWorkersOpinion(env, "primary-model", "primary-model", "sys", "user", 256, { diagnostics });
     // reviewDiagnostics flows into result/Sentry context that must never carry raw provider text (see the
     // "withholds unsafe provider and reviewer fallback text" test) -- the snippet only ever reaches the log.
     expect(diagnostics[0]).not.toHaveProperty("responseSnippet");
@@ -5593,7 +5593,7 @@ describe("reviewer vote attribution (#9478)", () => {
     });
     const env = createTestEnv({ AI: { run } as unknown as Ai });
     const diagnostics: Array<{ status: string; model: string }> = [];
-    const parsed = await runWorkersOpinion(env, "primary", "fallback", "sys", "user", 256, diagnostics as never);
+    const parsed = await runWorkersOpinion(env, "primary", "fallback", "sys", "user", 256, { diagnostics: diagnostics as never });
 
     expect(parsed.review).not.toBeNull();
     expect(parsed.producedBy).toBe("fallback"); // NOT "primary"
@@ -5603,7 +5603,7 @@ describe("reviewer vote attribution (#9478)", () => {
     const run = vi.fn(async () => ({ response: reviewJson() }));
     const env = createTestEnv({ AI: { run } as unknown as Ai });
     const diagnostics: Array<{ status: string; model: string }> = [];
-    const parsed = await runWorkersOpinion(env, "primary", "fallback", "sys", "user", 256, diagnostics as never);
+    const parsed = await runWorkersOpinion(env, "primary", "fallback", "sys", "user", 256, { diagnostics: diagnostics as never });
 
     expect(parsed.producedBy).toBe("primary");
   });


### PR DESCRIPTION
## Summary

`runWorkersOpinion` took **12 positional parameters**, ending in two adjacent, same-typed, identically-defaulted booleans. `runProviderReview` carried the **identical** trailing sequence — its own comments said so:

```ts
  images?: readonly AiContentBlock[] | undefined,
  bodyTruncated = false,      // #8961: arms the evidence-absence demotion, same contract as runWorkersOpinion
  prHasTestEvidence = false,  // #8833: arms the test-absence demotion, same contract as runWorkersOpinion
```

Both then ran the same demotion pair in the same order — `demoteEvidenceAbsenceBlockers` then `demoteTestEvidenceAbsenceBlockers` (1739/1741 and 2204/2209).

**Two places that must agree, with nothing enforcing it.** Transposing the two booleans at any call site compiled cleanly, type-checked cleanly, and silently armed the wrong demotion. Doing it in only *one* of the two paths split Workers AI and BYOK behaviour apart with no signal at all — strictly worse than getting it wrong in both. Six call sites passed them positionally, each threading an `undefined` placeholder past `images?`, a parameter no caller has supplied since #4111:

```ts
const outcome = await runWorkersOpinion(
  env, primary.model, primaryFallback, system, user, maxTokens,
  reviewDiagnostics, repoInstructionsSystemAppend, aiRunCorrelation,
  undefined,        // images — never passed by anyone
  bodyTruncated,
  prHasTestEvidence,
);
```

## Approach

One shared `ReviewerDemotionContext`, referenced by **both** signatures, so the compiler enforces what the two comments only asserted.

That is deliberately chosen over registering the pair in `NAMED_TWIN_PAIRS` (`scripts/check-engine-parity.ts`), the other option raised on the issue. A drift check would be redundant against a type the compiler already checks, and a redundant guard is one more thing that has to stay true. If the two ever need to diverge, the type is the thing you have to edit — which is the conversation you want to be forced into.

`env` … `maxTokens` stay positional; those are the genuine arguments. Everything from `diagnostics` onward was the accidental part.

**Pure de-positionalisation.** Every default is preserved by destructuring at the top of each function, so no body reference changed and no behaviour moved. `images?` is **kept**, not deleted — removing a deferred-but-designed parameter is a separate call from this one, and the issue flagged it rather than deciding it.

## What the refactor exposed

Two test call sites used `diagnostics as never`. That cast let an **array** through where the options object now goes, so `options.diagnostics` was `undefined` and the caller's array silently stayed empty. Ten call sites carried that cast.

- **Two failed loudly** and are fixed.
- **A third (line 3784) did not fail, and that is the interesting one.** It asserted `expect(diagnostics.some((d) => d.status === "missing_assessment")).toBe(false)` against an array that could never be populated — vacuously true, and passing for the wrong reason. It now receives a real array. I verified the assertion is genuine rather than still-vacuous by temporarily asserting `diagnostics.length > 0` alongside it (passes), then restoring.

No assertion was weakened or edited to make this pass; the call sites were fixed to match the new signature, which is the mechanical consequence of the refactor.

Closes #10253

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed**
- [ ] `npm run actionlint`
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

Detail:

- Full suite: **26,623 passed, 0 failed**. `test/unit/ai-review.test.ts` is **293 passed** with no assertion edited.
- Patch coverage verified **line-by-line against lcov** across every changed hunk: **all changed lines and branches covered**.
- `npm run typecheck` green across root, packages and both UI workspaces — the refactor is enforced by the compiler at every call site, which is the point.
- Unchecked boxes cover surfaces this diff does not touch (no workflow, MCP, UI, binding or schema change). `npm audit` reports only pre-existing advisories transitive under `release-please`; this PR changes no dependencies.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

No behaviour change: no signal added or removed, no prompt, demotion rule or verdict path touched. The demotion arming that these parameters control is bit-for-bit what it was — the only difference is that the two paths can no longer be armed inconsistently by a transposition.

## UI Evidence

Not applicable — no visible UI, frontend, docs, or extension change.

## Notes

Successor to #10210, and the same shape of fix. Found via an AST re-measurement of #10170's parameter-count figures, which were inflated by JSDoc commas: the real count is **177** functions at ≥6 params, not 267, and `persistDecisionRecord` — the offender that issue named — has **6**, not 13. `runWorkersOpinion` at 12 was the genuine worst. Details on [#10170](https://github.com/JSONbored/loopover/issues/10170#issuecomment-5143952296).
