### PR TITLE
chore(ui): sync MCP_PACKAGE_KNOWN_LATEST_VERSION with npm dist-tags.latest

### DIFF
--- a/apps/loopover-ui/src/lib/mcp-package.ts
+++ b/apps/loopover-ui/src/lib/mcp-package.ts
@@ -8,7 +8,7 @@ export const MCP_PACKAGE_REGISTRY_URL = `https://registry.npmjs.org/${MCP_PACKAG
 export const MCP_PACKAGE_NPM_URL = `https://www.npmjs.com/package/${MCP_PACKAGE_NAME}`;
 // Tracks the latest PUBLISHED release: ui:version-audit requires this to equal npm dist-tags.latest, so it is
 // bumped to a new version only AFTER that version publishes (never ahead of npm).
-export const MCP_PACKAGE_KNOWN_LATEST_VERSION = "3.21.1";
+export const MCP_PACKAGE_KNOWN_LATEST_VERSION = "3.21.2";
 export const MCP_MINIMUM_SUPPORTED_VERSION = "0.5.0";
 
 export type NpmPackageMetadata = {


### PR DESCRIPTION
Automated: @loopover/mcp v3.21.2 just published to npm; keeps apps/loopover-ui/src/lib/mcp-package.ts's known-latest-version copy in sync (ui:version-audit).