### PR TITLE
fix(review): give shadow overrides the same expired-clear_at handling as live overrides

### DIFF
--- a/src/review/auto-apply.ts
+++ b/src/review/auto-apply.ts
@@ -276,10 +276,14 @@ async function loadShadowOverrideRow(env: StorageEnv, project: string): Promise<
 /** Write a recommended override to the SHADOW queue with a future validated_until (the soak deadline). MERGED
  *  over any existing shadow row so a partial write never erases a prior queued tunable. (#partial-overwrite-fix)
  *  Preserves any existing clear_at rather than silently nulling it via INSERT OR REPLACE (#stale-clear-at-fix). */
-export async function writeShadowOverride(env: StorageEnv, project: string, o: TunableOverride, validatedUntilIso: string): Promise<void> {
+export async function writeShadowOverride(env: StorageEnv, project: string, o: TunableOverride, validatedUntilIso: string, nowIso?: string): Promise<void> {
   const existingRow = await loadShadowOverrideRow(env, project);
-  const merged = mergeOverride(existingRow ? rowToOverride(existingRow) : null, o);
-  const clearAt = existingRow?.clear_at ?? null;
+  // #10291: mirror writeLiveOverride exactly. Thread nowIso through the merge read AND the clear_at
+  // preservation so an already-lapsed clear_at is DROPPED rather than resurrected — the shadow side only
+  // ported the "preserve the column" half of the #stale-clear-at-fix, not the "drop it once expired" half,
+  // so a stale shadow tightening could be promoted to live after its own operator-set expiry had passed.
+  const merged = mergeOverride(existingRow ? rowToOverride(existingRow, nowIso) : null, o);
+  const clearAt = existingRow && !clearAtIsExpired(existingRow.clear_at, nowIso) ? existingRow.clear_at : null;
   await storage(env)
     .prepare(
       "INSERT OR REPLACE INTO tunables_overrides_shadow (project, confidence_floor, scope_cap_files, scope_cap_lines, applied_at, validated_until, clear_at) VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP, ?, ?)",
@@ -289,10 +293,12 @@ export async function writeShadowOverride(env: StorageEnv, project: string, o: T
 }
 
 /** Load the pending shadow override for a project (null if none / DB error). */
-export async function loadShadowOverride(env: StorageEnv, project: string): Promise<ShadowOverride | null> {
+export async function loadShadowOverride(env: StorageEnv, project: string, nowIso?: string): Promise<ShadowOverride | null> {
   const row = await loadShadowOverrideRow(env, project);
   if (!row) return null;
-  const override = rowToOverride(row);
+  // #10291: thread nowIso (mirroring loadOverride) so a shadow row whose clear_at has already lapsed is read
+  // back as cleared, not still-active — rowToOverride applies the same clearAtIsExpired rule the live read uses.
+  const override = rowToOverride(row, nowIso);
   return override ? { override, validatedUntil: row.validated_until } : null;
 }
 

--- a/test/unit/auto-apply.test.ts
+++ b/test/unit/auto-apply.test.ts
@@ -612,6 +612,25 @@ describe("writeShadowOverride / loadShadowOverride / deleteShadowOverride", () =
     await writeShadowOverride(env, "g", { confidenceFloor: 0.95 }, "2026-06-25T00:00:00Z");
     expect(tables.shadow.get("g")?.clear_at).toBe("2099-01-01T00:00:00Z");
   });
+  // #10291: the shadow pair only ported the "preserve the column" half of #stale-clear-at-fix, not the
+  // "drop it once expired" half — mirror the live-side "does NOT resurrect an ALREADY-EXPIRED override" test.
+  it("#10291: writeShadowOverride DROPS an already-expired clear_at (and does not resurrect the expired floor) when nowIso is passed", async () => {
+    const { env, tables } = fakeEnv();
+    tables.shadow.set("g", { confidence_floor: 0.8, scope_cap_files: null, scope_cap_lines: null, validated_until: "2026-06-19T00:00:00Z", clear_at: "2020-01-01T00:00:00Z" });
+    await writeShadowOverride(env, "g", { scopeCap: { files: 3, lines: 100 } }, "2026-06-25T00:00:00Z", "2026-06-20T00:00:00Z");
+    const row = tables.shadow.get("g");
+    expect(row?.clear_at).toBeNull(); // the lapsed clear_at is dropped, not carried forward
+    expect(row?.confidence_floor).toBeNull(); // the expired floor is not resurrected into the merge
+    expect(row?.scope_cap_files).toBe(3); // the new write still applies normally
+  });
+  it("#10291: loadShadowOverride reads an already-expired clear_at row as cleared when nowIso is after it", async () => {
+    const { env, tables } = fakeEnv();
+    // Only a confidence_floor gated by an expired clear_at: rowToOverride drops it → the override is empty → null.
+    tables.shadow.set("g", { confidence_floor: 0.8, scope_cap_files: null, scope_cap_lines: null, validated_until: "2026-06-19T00:00:00Z", clear_at: "2020-01-01T00:00:00Z" });
+    expect(await loadShadowOverride(env, "g", "2026-06-20T00:00:00Z")).toBeNull();
+    // Without nowIso (the pre-#10291 caller convention) the row is still read active — additive, non-breaking.
+    expect(await loadShadowOverride(env, "g")).not.toBeNull();
+  });
   it("loadShadowOverride returns null when the row maps to an EMPTY override (rowToOverride → null arm)", async () => {
     const { env, tables } = fakeEnv();
     tables.shadow.set("g", { confidence_floor: null, scope_cap_files: null, scope_cap_lines: null, validated_until: "2026-06-25T00:00:00Z" });


### PR DESCRIPTION
## What & why

`src/review/auto-apply.ts` keeps two parallel tunable-override tables — LIVE (`tunables_overrides`) and SHADOW (`tunables_overrides_shadow`, a soak-gated staging area promoted to live once validated). Both carry an operator-settable `clear_at` (a temporary override's own expiration).

The **LIVE** pair correctly treats an already-lapsed `clear_at` as cleared:

```ts
export async function loadOverride(env, project, nowIso?) { return rowToOverride(await loadOverrideRow(env, project), nowIso); }
export async function writeLiveOverride(env, project, o, nowIso?) {
  const clearAt = existingRow && !clearAtIsExpired(existingRow.clear_at, nowIso) ? existingRow.clear_at : null; // dropped when expired
}
```

The **SHADOW** pair only ported the "preserve the column" half of the `#stale-clear-at-fix`, not the "drop it once expired" half:

- `writeShadowOverride` had **no `nowIso` parameter** and computed `clearAt` as `existingRow?.clear_at ?? null` — re-persisting a lapsed `clear_at` unconditionally, and calling `rowToOverride(existingRow)` with no `nowIso` so `clearAtIsExpired` always short-circuited to false during the merge.
- `loadShadowOverride` had no `nowIso` parameter and called `rowToOverride(row)` with no second argument, so a shadow row with a lapsed `clear_at` was read back as still active.

**Impact:** `loadShadowOverride` feeds `runAutoApplyRecommendations`'s promotion step and the `gate-config/effective` / `live-gate-thresholds` API + MCP routes. A shadow override whose `clear_at` has already lapsed was treated as active indefinitely, and a stale shadow tightening could be promoted to LIVE after its own operator-set expiration had passed — silently defeating the temporary-override-expiration semantics the live side already honours.

## The fix

Thread an optional `nowIso` through both, mirroring the live pair **exactly**:

- `loadShadowOverride(env, project, nowIso?)` passes `nowIso` into `rowToOverride`, so a lapsed `clear_at` reads as cleared.
- `writeShadowOverride(env, project, o, validatedUntilIso, nowIso?)` computes `clearAt` via `existingRow && !clearAtIsExpired(existingRow.clear_at, nowIso) ? existingRow.clear_at : null` and passes `nowIso` into its own `rowToOverride(existingRow, nowIso)` merge read.

Both parameters are **optional and additive**, so every existing caller compiles and behaves exactly as before when `nowIso` is omitted (matching the live side's convention).

**Unchanged:** the live `loadOverride`/`writeLiveOverride` pair, the promotion/soak-gate decision logic, and every other behaviour. No migration (additive optional params only).

## Tests (`test/unit/auto-apply.test.ts`)

- `writeShadowOverride` **drops** an already-expired `clear_at` (and does not resurrect the expired floor) when `nowIso` is after it — mirroring the existing live-side "does NOT resurrect an ALREADY-EXPIRED override" test.
- `loadShadowOverride` reads an expired-`clear_at` row as cleared (`null`) when `nowIso` is after it, and still reads it active when `nowIso` is omitted (the non-breaking, additive contract).
- The existing "PRESERVES an existing clear_at across a shadow write" test (a FUTURE `clear_at`) still passes unchanged.
- Both new assertions **fail on `main`**.

## Validation

- Diff coverage on `src/review/auto-apply.ts` is **100%** line and branch (all three arms of the new `existingRow && !clearAtIsExpired(...)` guard).
- `npm run typecheck` clean for these files; `npm run engine-parity:drift-check` passes (not a twin); `npm run dead-exports:check` clean; the suite (100 tests) green.
- `git diff --check` clean; no schema/migration/generated-artifact change.

Closes #10291
