### PR TITLE
fix(review): trim LOOPOVER_PUBLIC_STATS before the truthy-flag regex test

### DIFF
--- a/src/review/public-stats.ts
+++ b/src/review/public-stats.ts
@@ -79,7 +79,10 @@ export function isPublicStatsEnabled(
   manifestOverride?: PublicStatsManifestOverride | undefined,
 ): boolean {
   if (manifestOverride?.present) return manifestOverride.enabled;
-  return /^(1|true|yes|on)$/i.test(env.LOOPOVER_PUBLIC_STATS ?? "");
+  // #10329: trim before the anchored regex, matching every sibling flag-checker (e.g. pr-reconciliation.ts).
+  // A trailing newline/space (plausible from `wrangler secret put` reading a file, or a CI-injected var) makes
+  // `/^(1|true|yes|on)$/i.test("true\n")` false even though the operator clearly meant to enable the flag.
+  return /^(1|true|yes|on)$/i.test((env.LOOPOVER_PUBLIC_STATS ?? "").trim());
 }
 
 // Short in-isolate TTL cache for resolvePublicStatsManifestOverride, mirroring review-memory-wire.ts's

--- a/test/unit/public-stats.test.ts
+++ b/test/unit/public-stats.test.ts
@@ -76,6 +76,15 @@ describe("isPublicStatsEnabled", () => {
       expect(isPublicStatsEnabled({ LOOPOVER_PUBLIC_STATS: v })).toBe(false);
   });
 
+  it("#10329: trims the flag before the anchored regex, matching pr-reconciliation.ts", () => {
+    // A trailing newline / surrounding whitespace (wrangler secret from a file, a CI-injected var) must not
+    // defeat the operator's clear intent to enable it. Also confirms a genuinely unrecognised value stays off.
+    for (const on of ["true\n", " 1 ", "\ton\t", "  yes"])
+      expect(isPublicStatsEnabled({ LOOPOVER_PUBLIC_STATS: on }), on).toBe(true);
+    for (const off of ["  false  ", "\n0\n", "  maybe  "])
+      expect(isPublicStatsEnabled({ LOOPOVER_PUBLIC_STATS: off }), off).toBe(false);
+  });
+
   it("a present manifest override wins outright over the env flag, in both directions (#6275)", () => {
     expect(isPublicStatsEnabled({ LOOPOVER_PUBLIC_STATS: "false" }, { present: true, enabled: true })).toBe(true);
     expect(isPublicStatsEnabled({ LOOPOVER_PUBLIC_STATS: "true" }, { present: true, enabled: false })).toBe(false);


### PR DESCRIPTION
## What & why

`isPublicStatsEnabled` checked the `LOOPOVER_PUBLIC_STATS` env flag against an anchored truthy regex on the **raw, untrimmed** value:

```ts
return /^(1|true|yes|on)$/i.test(env.LOOPOVER_PUBLIC_STATS ?? "");
```

Every sibling boolean-env-flag checker in the codebase trims first — e.g. `pr-reconciliation.ts`'s `isPrReconciliationEnabled`:

```ts
return /^(1|true|yes|on)$/i.test((env.LOOPOVER_PR_RECONCILIATION ?? "").trim());
```

`isPublicStatsEnabled` was the odd one out. A trailing newline or surrounding whitespace — plausible via `wrangler secret put` reading from a file, or CI/CD injecting an env var with a trailing newline — makes the anchored regex fail to match even though the operator clearly meant to enable the flag: `/^(1|true|yes|on)$/i.test("true\n")` is `false`. The sibling's trimmed behaviour is deliberately regression-tested; `isPublicStatsEnabled` had no `.trim()` and no equivalent test.

## The fix

Trim `env.LOOPOVER_PUBLIC_STATS` before the regex test, matching the established convention:

```ts
return /^(1|true|yes|on)$/i.test((env.LOOPOVER_PUBLIC_STATS ?? "").trim());
```

**Unchanged:** the `manifestOverride?.present` early-return, and every already-clean value (no leading/trailing whitespace) evaluates exactly as before — this is a whitespace-robustness fix only.

## Tests (`test/unit/public-stats.test.ts`)

- `isPublicStatsEnabled({ LOOPOVER_PUBLIC_STATS: "true\n" })` (and `" 1 "`, `"\ton\t"`, `"  yes"`) now returns `true`; a whitespace-padded unrecognised value (`"  maybe  "`, `"  false  "`, `"\n0\n"`) stays `false` — **fails on `main`**.
- The existing "is truthy only for 1/true/yes/on" test already pins the already-clean regression (`"true"`, `"0"`, `""`, `undefined`) and still passes unchanged.

## Validation

- Diff coverage on `src/review/public-stats.ts` is **100%** (the `.trim()` line; no new branch).
- `npm run typecheck` clean; `npm run engine-parity:drift-check` passes (not a twin); `npm run dead-exports:check` clean; the public-stats suite and its parity-invariant test green.
- `git diff --check` clean; no schema/migration/generated-artifact change.

Closes #10329
