### PR TITLE
fix(review): reserve header length in buildUnifiedReviewDiff's no-patch branch

### DIFF
--- a/src/review/review-diff.ts
+++ b/src/review/review-diff.ts
@@ -185,7 +185,15 @@ export function buildUnifiedReviewDiff(files: ReviewDiffFile[], budget: number =
       break;
     }
     if (!file.patch) {
-      diff += `${header}(no inline patch — binary or too large)\n\n`;
+      const suffix = `(no inline patch — binary or too large)\n\n`;
+      // Mirror the patched branch's `header.length + body.length + 2 > remaining` reservation: a long
+      // enough `file.path` can make the header+suffix overflow `budget`, so fall through to the same
+      // truncation-notice-and-break path the `remaining < 240` case uses rather than silently overflowing (#10327).
+      if (header.length + suffix.length > remaining) {
+        diff += truncationNotice;
+        break;
+      }
+      diff += `${header}${suffix}`;
       continue;
     }
     let body = file.patch;

--- a/test/unit/review-diff.test.ts
+++ b/test/unit/review-diff.test.ts
@@ -168,6 +168,26 @@ describe("buildUnifiedReviewDiff — the #1528 fix: never silently drop the file
   });
 });
 
+describe("buildUnifiedReviewDiff — the #10327 fix: a patch-less file's header+suffix respects the remaining budget", () => {
+  it("falls through to the truncation-notice-and-break path when a long path makes header+suffix overflow, staying within budget", () => {
+    // remaining >= 240 (past the `remaining < 240` break), but a ~250-char path makes header+suffix (~310) exceed it,
+    // so the patch-less branch must break with the truncation notice rather than silently overflow `budget` (#10327).
+    const longPath = "a".repeat(250);
+    const budget = 250;
+    const diff = buildUnifiedReviewDiff([{ path: longPath, patch: undefined, status: "added", additions: 0, deletions: 0 }], budget);
+    expect(diff.length).toBeLessThanOrEqual(budget); // the invariant the patched branch already holds
+    expect(diff).toContain("…diff truncated"); // the drop is announced, not silent
+    expect(diff).not.toContain("no inline patch"); // the overflowing file was not appended
+  });
+
+  it("renders a short-path patch-less file unchanged when it comfortably fits (the header+suffix fits, so no break)", () => {
+    const diff = buildUnifiedReviewDiff([{ path: "logo.png", patch: undefined, status: "added", additions: 0, deletions: 0 }]);
+    expect(diff).toContain("### logo.png (added) +0/-0");
+    expect(diff).toContain("(no inline patch — binary or too large)");
+    expect(diff).not.toContain("…diff truncated"); // it fit, so no truncation
+  });
+});
+
 describe("keepHighSignalHunks — non-positive budget guard (#5849)", () => {
   it("returns only the truncation marker when the budget is zero", () => {
     expect(keepHighSignalHunks("@@ a\n+x\n+y", 0)).toBe("… (this file's diff truncated)");


### PR DESCRIPTION
## What & why

`buildUnifiedReviewDiff` builds a size-bounded unified diff for review. The **patched-file** branch already reserves the header's length against the `remaining` budget before appending:

```ts
if (header.length + body.length + 2 > remaining) {
  body = keepHighSignalHunks(file.patch, remaining - header.length - 4 - truncationNotice.length);
}
```

The **no-patch** branch (binary or too-large files) did not — it appended `header + suffix` unconditionally:

```ts
if (!file.patch) {
  diff += `${header}(no inline patch — binary or too large)\n\n`;
  continue;
}
```

Because the header interpolates `file.path`, a long enough path makes `header.length + suffix.length` exceed the file's `remaining` budget, and the returned diff overflows `budget`. That breaks the same bounded-output invariant the patched branch upholds — the one asymmetry between the two branches' budget handling.

## The fix

Mirror the patched branch's reservation in the no-patch branch: check `header.length + suffix.length` against `remaining` before appending, and when it doesn't fit, fall through to the **same** truncation-notice-and-break path the loop already uses for the `remaining < 240` case — rather than silently overflowing `budget` or silently dropping the file with no visible signal.

```ts
if (!file.patch) {
  const suffix = `(no inline patch — binary or too large)\n\n`;
  if (header.length + suffix.length > remaining) {
    diff += truncationNotice;
    break;
  }
  diff += `${header}${suffix}`;
  continue;
}
```

**Unchanged:** the patched-file branch's existing logic, and the common case — a patch-less file whose header+suffix fits comfortably renders byte-for-byte as before (`"${header}(no inline patch — binary or too large)\n\n"`). This is an edge-case fix for a long `file.path` only.

## Tests (`test/unit/review-diff.test.ts`)

Extends the existing `#10017` budget-invariant suite:

- **True branch (the fix):** a patch-less file with a ~250-char path and `budget: 250` — `remaining` clears the `< 240` floor but `header + suffix` (~310) overflows it. Asserts the returned diff's `.length <= budget`, the truncation notice is present, and the overflowing file was not appended. **Fails on `main`** (returns 308 > 250).
- **False branch (regression):** a short-path patch-less file with a comfortable budget still renders exactly `"### logo.png (added) +0/-0\n(no inline patch — binary or too large)\n\n"` with no truncation notice.

## Validation

- Diff line + **branch** coverage on `src/review/review-diff.ts` is **100%** — both arms of the new `header.length + suffix.length > remaining` check are exercised (lcov `BRDA` confirms taken=true and taken=false).
- `npm run typecheck` clean; `npm run engine-parity:drift-check` passes (the `DIFF_FILE_PRIORITY` twin markers are untouched — 7 pairs agree); `npm run dead-exports:check`, `manifest:drift-check`, `docs:drift-check` clean.
- `git diff --check` clean; no schema / migration / generated-artifact change.

Closes #10327
