### PR TITLE
fix(mcp): document review-pr label and issue flags

### DIFF
--- a/packages/loopover-mcp/README.md
+++ b/packages/loopover-mcp/README.md
@@ -52,7 +52,7 @@ loopover-mcp notifications-read --login <github-login> [--id <delivery-id>]... [
 loopover-mcp watch <list|add|remove> [owner/repo] [--labels a,b] [--login <github-login>] [--json]
 loopover-mcp analyze-branch --login <github-login> [--repo owner/repo] [--base origin/main] [--branch-eligibility eligible|ineligible|unknown] [--pending-merged-prs 3] [--expected-open-prs 0] [--projected-credibility 0.8] [--scenario-note "..."] [--validation "passed|npm test|summary"] [--format table] [--json]
 loopover-mcp preflight --login <github-login> [--repo owner/repo] [--base origin/main] [--branch-eligibility eligible|ineligible|unknown] [--pending-merged-prs 3] [--expected-open-prs 0] [--projected-credibility 0.8] [--validation "passed|npm test|summary"] [--format table] [--json]
-loopover-mcp review-pr --login <github-login> [--repo owner/repo] [--base origin/main] [--commit <message>]... [--body <text>] [--body-file <path>] [--linked-issue <number>] [--json]
+loopover-mcp review-pr --login <github-login> [--repo owner/repo] [--base origin/main] [--commit <message>]... [--body <text>] [--body-file <path>] [--label <name>]... [--linked-issue <number>] [--issue <number>]... [--json]
 loopover-mcp lint-pr-text [--commit <message>]... [--body <text>] [--body-file <path>] [--linked-issue <number>] [--json]
 loopover-mcp validate-config --file <path> [--source repo_file|api_record|none] [--json]
 loopover-mcp slop-risk [--description <text>] [--description-file <path>] [--changed-file <path[:additions:deletions]>]... [--test <command>]... [--test-file <path>]... [--json]

--- a/packages/loopover-mcp/bin/loopover-mcp.ts
+++ b/packages/loopover-mcp/bin/loopover-mcp.ts
@@ -302,7 +302,7 @@ const CLI_COMMAND_SPEC = {
   },
   "review-pr": {
     subcommands: [],
-    usage: ["review-pr --login <github-login> [--repo owner/repo] [--base origin/main] [--commit <message>]... [--body <text>] [--body-file <path>] [--linked-issue <number>] [--json]"],
+    usage: ["review-pr --login <github-login> [--repo owner/repo] [--base origin/main] [--commit <message>]... [--body <text>] [--body-file <path>] [--label <name>]... [--linked-issue <number>] [--issue <number>]... [--json]"],
   },
   "lint-pr-text": { subcommands: [], usage: ["lint-pr-text [--commit <message>]... [--body <text>] [--body-file <path>] [--linked-issue <number>] [--json]"] },
   "validate-config": { subcommands: [], usage: ["validate-config --file <path> [--source repo_file|api_record|none] [--json]"] },
@@ -3194,11 +3194,15 @@ function writeBranchAnalysisTable(result: any, command: string) {
 function printReviewPrHelp() {
   process.stdout.write(
     [
-      "Usage: loopover-mcp review-pr --login <github-login> [--repo owner/repo] [--base origin/main] [--commit <message>]... [--body <text>] [--body-file <path>] [--linked-issue <number>] [--json]",
+      "Usage: loopover-mcp review-pr --login <github-login> [--repo owner/repo] [--base origin/main] [--commit <message>]... [--body <text>] [--body-file <path>] [--label <name>]... [--linked-issue <number>] [--issue <number>]... [--json]",
       "",
       "Compose the existing preflight + slop-risk + PR-text-lint checks into ONE pre-PR review report,",
       "so a contributor's own local agent can see everything the loopover gate would flag before ever opening a PR.",
       "Mirrors the loopover_review_pr_before_push MCP tool. Thin composition only — does not reimplement any check. No source upload.",
+      "",
+      "Repeat --label <name> to pass labels to the review request.",
+      "Repeat --issue <number> as an alternate way to provide linked issue numbers.",
+      "When both --linked-issue and --issue are provided, --linked-issue takes precedence and --issue is ignored.",
       "",
       "Pass --json for machine-readable output.",
     ].join("\n") + "\n",

--- a/packages/loopover-mcp/test/review-pr-help.test.ts
+++ b/packages/loopover-mcp/test/review-pr-help.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest";
+
+const BIN_MODULE = "../bin/loopover-mcp.ts";
+type BinModule = { runCli: (args: readonly string[]) => Promise<number | void> };
+
+describe("loopover-mcp review-pr help", () => {
+  it("documents the repeatable labels and issue flags and their precedence", async () => {
+    const { runCli } = (await import(BIN_MODULE)) as BinModule;
+    const chunks: string[] = [];
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation((chunk: string | Uint8Array): boolean => {
+      chunks.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+      return true;
+    });
+
+    try {
+      await runCli(["review-pr", "--help"]);
+    } finally {
+      stdout.mockRestore();
+    }
+
+    const help = chunks.join("");
+    expect(help).toContain("[--label <name>]...");
+    expect(help).toContain("[--issue <number>]...");
+    expect(help).toContain("--linked-issue takes precedence and --issue is ignored");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -68,7 +68,7 @@ export default defineConfig({
     // Codecov, or that PR's own Codecov bot comment). No dashboard is wired up to surface it proactively,
     // so check it deliberately if a retry shows up in CI output rather than assuming it's pure infra noise.
     retry: 1,
-    include: ["test/**/*.test.ts"],
+    include: ["test/**/*.test.ts", "packages/loopover-mcp/test/**/*.test.ts"],
     exclude: ["test/workers/**/*.test.ts"],
     reporters: junitPath ? ["default", "junit"] : ["default"],
     ...(junitPath ? { outputFile: { junit: junitPath } } : {}),


### PR DESCRIPTION
## Summary

- Document the repeatable `--label` and `--issue` flags accepted by `review-pr`.
- Explain that `--linked-issue` takes precedence when both issue flag forms are supplied.
- Add a package-local regression test for the rendered help output.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves: `Closes #10306`.

## Validation

- [x] `git diff --check`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npx vitest run test/unit/mcp-cli-review-pr.test.ts packages/loopover-mcp/test/review-pr-help.test.ts`
- [x] `npx prettier --check packages/loopover-mcp/bin/loopover-mcp.ts packages/loopover-mcp/test/review-pr-help.test.ts packages/loopover-mcp/README.md vitest.config.ts`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage`
- [ ] `npm run test:workers`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New behavior has a regression test for the help-text branches exercised here.

If any required check was skipped, explain why:

- The change is limited to MCP help text, README usage text, the root Vitest include wiring needed to run the package-local test, and that regression test. The full `npm run test:ci` chain and unrelated UI/worker checks were not run locally.
- The audit was run with `npm audit --audit-level=moderate --omit=dev`; it reports six existing transitive advisories in dependencies outside this docs-only change. No dependency files were modified.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized and does not imply compensation guarantees or optimization tactics.
- [x] No auth, cookie, CORS, GitHub App, Cloudflare, or session changes were made.
- [x] No API/OpenAPI/MCP behavior was changed; the existing help output was documented and tested.
- [x] No frontend UI changes were made.
- [x] Public docs were updated where needed; no changelog was edited.

## UI Evidence

Not applicable: this PR changes command-line help and Markdown usage text, not a rendered frontend or extension UI.

## Notes

- The handler behavior is intentionally unchanged: `--linked-issue` still takes precedence over `--issue`.
