### PR TITLE
signals: unify score-preview blocker and severity matching

### DIFF
--- a/src/signals/local-branch.ts
+++ b/src/signals/local-branch.ts
@@ -32,6 +32,8 @@ import { simulateOpenPrPressure } from "../services/open-pr-pressure-scenarios";
 import { isCodeFile, isTestFile } from "./path-matchers";
 import { isMaintainerAuthorAssociation } from "../github/author-association";
 
+const SCORE_PREVIEW_BLOCKING_WARNING_PATTERN = /not registered|no active|exceeds|credibility|token gate|confirmed ineligible/i;
+
 export type LocalBranchChangedFile = {
   path: string;
   previousPath?: string | undefined;
@@ -356,7 +358,7 @@ export function buildLocalBranchAnalysis(args: {
   });
   const scoreBlockers = [
     ...rewardRisk.scoreBlockers,
-    ...scorePreview.warnings.filter((warning) => /not registered|no active|exceeds|credibility|token gate|confirmed ineligible/i.test(warning)),
+    ...scorePreview.warnings.filter((warning) => SCORE_PREVIEW_BLOCKING_WARNING_PATTERN.test(warning)),
     ...preflight.findings.filter((finding) => finding.severity !== "info").map((finding) => finding.title),
   ];
   const eligibilityPlan = deriveEligibilityPlan(scorePreview);
@@ -789,6 +791,15 @@ function isApprovedOrMergeableOpenPr(pr: PullRequestRecord): boolean {
   return reviewDecision === "approved" || ["clean", "has_hooks", "mergeable", "mergeable_state_clean"].includes(mergeableState);
 }
 
+function scorePreviewWarningFinding(warning: string): LocalBranchAnalysis["localFindings"][number] {
+  return {
+    code: "score_preview_warning",
+    severity: SCORE_PREVIEW_BLOCKING_WARNING_PATTERN.test(warning) ? "warning" : "info",
+    title: "Private preview warning",
+    detail: warning,
+  };
+}
+
 function buildLocalFindings(
   input: LocalBranchAnalysisInput,
   changedFiles: LocalBranchChangedFile[],
@@ -894,12 +905,7 @@ function buildLocalFindings(
     ...branchEligibilityFindings(branchEligibility),
     ...scorePreview.warnings
       .filter((warning) => !/branch eligibility/i.test(warning))
-      .map((warning) => ({
-        code: "score_preview_warning",
-        severity: /not registered|no active|exceeds|credibility/i.test(warning) ? ("warning" as const) : ("info" as const),
-        title: "Private preview warning",
-        detail: warning,
-      })),
+      .map(scorePreviewWarningFinding),
     ...preflight.findings.map((finding) => ({
       code: `preflight_${finding.code}`,
       severity: finding.severity,
@@ -1284,3 +1290,7 @@ function nonNegative(value: number | undefined): number {
 function unique<T>(value: T, index: number, values: T[]): boolean {
   return values.indexOf(value) === index;
 }
+
+export const __localBranchInternals = {
+  scorePreviewWarningFinding,
+};

--- a/test/unit/local-branch-score-preview-warning.test.ts
+++ b/test/unit/local-branch-score-preview-warning.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { __localBranchInternals } from "../../src/signals/local-branch";
+
+describe("score preview warning severity", () => {
+  it.each([
+    "token gate is not satisfied",
+    "confirmed ineligible for this branch",
+    "contributor is not registered",
+    "no active registration",
+    "open PR count exceeds the threshold",
+    "credibility is below the required floor",
+  ])("classifies blocking warning text as warning: %s", (warning) => {
+    expect(__localBranchInternals.scorePreviewWarningFinding(warning)).toMatchObject({
+      code: "score_preview_warning",
+      severity: "warning",
+      detail: warning,
+    });
+  });
+
+  it("keeps unrelated preview warnings informational", () => {
+    expect(__localBranchInternals.scorePreviewWarningFinding("Mirror data is still warming up")).toMatchObject({
+      code: "score_preview_warning",
+      severity: "info",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- centralize score-preview blocker/severity matching in one shared warning pattern
- classify `token gate` and `confirmed ineligible` warnings consistently as warnings
- cover the existing blocker phrases plus an unrelated informational warning

Fixes #10294

## Verification

- focused prequeue warning-severity regression harness: passed
- relay-compatible unified patch apply/whitespace check: passed
- full LoopOver Vitest suite could not be run in the execution container because the repository dependency toolchain is unavailable here; draft CI should confirm it

<!-- pr-relay-job relay-114-f80f96899b14f34ddcd5 -->