### PR TITLE
signals: ignore empty normalized titles in duplicate detection

### DIFF
--- a/src/signals/contributor-open-pr-monitor.ts
+++ b/src/signals/contributor-open-pr-monitor.ts
@@ -239,6 +239,7 @@ function duplicatePronePullNumbers(openPullRequests: PullRequestRecord[]): Set<n
   const byNormalizedTitle = new Map<string, PullRequestRecord[]>();
   for (const pr of openPullRequests) {
     const key = normalizeTitle(pr.title);
+    if (!key) continue;
     const bucket = byNormalizedTitle.get(key) ?? [];
     bucket.push(pr);
     byNormalizedTitle.set(key, bucket);

--- a/test/unit/contributor-open-pr-monitor-empty-title.test.ts
+++ b/test/unit/contributor-open-pr-monitor-empty-title.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { __contributorOpenPrMonitorInternals } from "../../src/signals/contributor-open-pr-monitor";
+import type { PullRequestRecord } from "../../src/types";
+
+function pr(number: number, title: string, labels: string[] = []): PullRequestRecord {
+  return {
+    repoFullName: "acme/widgets",
+    number,
+    title,
+    state: "open",
+    authorLogin: "contributor",
+    labels,
+    linkedIssues: [],
+  } as PullRequestRecord;
+}
+
+describe("duplicate-prone title grouping", () => {
+  it("does not group unrelated titles whose normalized form is empty", () => {
+    const flagged = __contributorOpenPrMonitorInternals.duplicatePronePullNumbers([pr(1, "..."), pr(2, "🎉🎉🎉")]);
+    expect([...flagged]).toEqual([]);
+  });
+
+  it("still groups matching non-empty normalized titles", () => {
+    const flagged = __contributorOpenPrMonitorInternals.duplicatePronePullNumbers([pr(3, "Fix bug"), pr(4, "fix   bug!!")]);
+    expect([...flagged].sort((a, b) => a - b)).toEqual([3, 4]);
+  });
+
+  it("still flags explicit wip and duplicate labels", () => {
+    const flagged = __contributorOpenPrMonitorInternals.duplicatePronePullNumbers([pr(5, "...", ["wip"]), pr(6, "🎉", ["duplicate"])]);
+    expect([...flagged].sort((a, b) => a - b)).toEqual([5, 6]);
+  });
+});


### PR DESCRIPTION
## Summary

- skip the empty normalized-title bucket in duplicate-pr detection
- preserve real non-empty duplicate-title grouping
- preserve WIP and duplicate-label based flags with focused regression coverage

Fixes #10292

## Verification

- focused prequeue duplicate-title regression harness: passed
- relay-compatible unified patch apply/whitespace check: passed
- full LoopOver Vitest suite could not be run in the execution container because the repository dependency toolchain is unavailable here; draft CI should confirm it

<!-- pr-relay-job relay-113-b43c6616fec10a0274d7 -->