### PR TITLE
queue: dedupe backfill mapWithConcurrency helper

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -86,6 +86,7 @@ import {
 import { fetchCachedGitHubGraphQl } from "./graphql-cache";
 import { incr } from "../selfhost/metrics";
 import { fetchBrokeredInstallationToken, isOrbBrokerMode } from "../orb/broker-client";
+import { mapWithConcurrency } from "../queue/map-with-concurrency";
 type GitHubLabelPayload = {
   name: string;
   color?: string;
@@ -5194,22 +5195,6 @@ function parseNullableInt(value: string | null): number | undefined {
   if (!value) return undefined;
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : undefined;
-}
-
-async function mapWithConcurrency<T, R>(items: T[], concurrency: number, mapper: (item: T, index: number) => Promise<R>): Promise<R[]> {
-  const results: R[] = new Array(items.length);
-  let nextIndex = 0;
-  const workerCount = Math.max(1, Math.min(concurrency, items.length || 1));
-  await Promise.all(
-    Array.from({ length: workerCount }, async () => {
-      while (nextIndex < items.length) {
-        const index = nextIndex;
-        nextIndex += 1;
-        results[index] = await mapper(items[index] as T, index);
-      }
-    }),
-  );
-  return results;
 }
 
 // Mirror of app.ts's isRateLimitedResponse, reconstructed from the status, rate-limit headers, and body that

--- a/src/queue/map-with-concurrency.ts
+++ b/src/queue/map-with-concurrency.ts
@@ -1,7 +1,7 @@
 export async function mapWithConcurrency<T, R>(
   items: T[],
   concurrency: number,
-  mapper: (item: T) => Promise<R>,
+  mapper: (item: T, index: number) => Promise<R>,
 ): Promise<R[]> {
   const results: R[] = new Array(items.length);
   let nextIndex = 0;
@@ -11,7 +11,7 @@ export async function mapWithConcurrency<T, R>(
       while (nextIndex < items.length) {
         const index = nextIndex;
         nextIndex += 1;
-        results[index] = await mapper(items[index] as T);
+        results[index] = await mapper(items[index] as T, index);
       }
     }),
   );

--- a/test/unit/map-with-concurrency.test.ts
+++ b/test/unit/map-with-concurrency.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { mapWithConcurrency } from "../../src/queue/map-with-concurrency";
+
+describe("mapWithConcurrency", () => {
+  it("passes each mapper the stable item index with concurrent workers", async () => {
+    const seenByItem: number[] = [];
+
+    const result = await mapWithConcurrency(["a", "b", "c", "d"], 3, async (item, index) => {
+      seenByItem[index] = index;
+      await Promise.resolve();
+      return `${index}:${item}`;
+    });
+
+    expect(seenByItem).toEqual([0, 1, 2, 3]);
+    expect(result).toEqual(["0:a", "1:b", "2:c", "3:d"]);
+  });
+
+  it("keeps one-argument mappers source-compatible", async () => {
+    const result = await mapWithConcurrency([1, 2, 3], 2, async (item) => item * 2);
+
+    expect(result).toEqual([2, 4, 6]);
+  });
+});


### PR DESCRIPTION
## Summary

- reuse the canonical queue `mapWithConcurrency` helper from backfill
- pass stable item indexes through the shared helper
- add focused concurrency/index regression coverage

Fixes #10289

## Verification

- focused prequeue concurrency/index regression harness: passed
- TypeScript compile of the changed canonical helper: passed
- relay-compatible unified patch apply/whitespace check: passed
- full LoopOver Vitest suite could not be run in the execution container because the repository dependency toolchain is unavailable here; draft CI should confirm it

<!-- pr-relay-job relay-111-55a863e1f329cf9bf611 -->