### PR TITLE
signals: use safety-filtered preferred labels in guidance

### DIFF
--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -816,7 +816,7 @@ export function buildFocusManifestGuidance(args: {
       detail: preferredLabelsDetail,
       action: "Consider applying a maintainer-preferred label so triage stays aligned.",
     });
-    publicNextSteps.push(`Consider a maintainer-preferred label (${manifest.preferredLabels.slice(0, 3).join(", ")}).`);
+    publicNextSteps.push(`Consider a maintainer-preferred label (${safePreferredLabels.slice(0, 3).join(", ")}).`);
   }
 
   if (manifest.linkedIssuePolicy === "required" && linkedIssueCount === 0 && bodyObserved && !hasNoIssueRationale) {

--- a/test/unit/focus-manifest-preferred-label-next-step.test.ts
+++ b/test/unit/focus-manifest-preferred-label-next-step.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { buildFocusManifestGuidance, parseFocusManifest } from "../../src/signals/focus-manifest";
+
+function guidance(preferredLabels: string[]) {
+  return buildFocusManifestGuidance({
+    manifest: parseFocusManifest({ preferredLabels }),
+    changedPaths: ["src/example.ts"],
+    labels: [],
+  });
+}
+
+describe("preferred-label public next steps", () => {
+  it("keeps the safe preferred labels when the configured list also contains an unsafe label", () => {
+    const result = guidance(["bug", "reward payout", "good first issue"]);
+    const finding = result.findings.find((entry) => entry.code === "manifest_missing_preferred_label");
+    const nextStep = result.publicNextSteps.find((entry) => entry.startsWith("Consider a maintainer-preferred label"));
+
+    expect(finding?.detail).toBe("Maintainer prefers labels: bug, good first issue.");
+    expect(nextStep).toBe("Consider a maintainer-preferred label (bug, good first issue).");
+    expect(nextStep).not.toMatch(/reward payout/i);
+  });
+
+  it("keeps all-safe preferred-label output unchanged", () => {
+    const result = guidance(["bug", "enhancement", "good first issue"]);
+    const finding = result.findings.find((entry) => entry.code === "manifest_missing_preferred_label");
+    const nextStep = result.publicNextSteps.find((entry) => entry.startsWith("Consider a maintainer-preferred label"));
+
+    expect(finding?.detail).toBe("Maintainer prefers labels: bug, enhancement, good first issue.");
+    expect(nextStep).toBe("Consider a maintainer-preferred label (bug, enhancement, good first issue).");
+  });
+});


### PR DESCRIPTION
## Summary

- build preferred-label next-step text from the already safety-filtered label list
- prevent an unsafe preferred label from leaking into contributor-facing guidance
- cover mixed safe/unsafe and all-safe label lists

Fixes #10293

## Verification

- focused prequeue preferred-label safety regression harness: passed
- relay-compatible unified patch apply/whitespace check: passed
- full LoopOver Vitest suite could not be run in the execution container because the repository dependency toolchain is unavailable here; draft CI should confirm it

<!-- pr-relay-job relay-116-3ab7892502f4a512a6f2 -->