### PR TITLE
miner: use canonical acceptance criteria filename in cross-repo eval

### DIFF
--- a/packages/loopover-miner/lib/cross-repo-evaluation.ts
+++ b/packages/loopover-miner/lib/cross-repo-evaluation.ts
@@ -724,7 +724,7 @@ async function runExecutionPhases(
   const task = {
     attemptId: `cross-repo-eval-${repoFullName.replace("/", "-")}`,
     workingDirectory: workspace.path,
-    acceptanceCriteriaPath: specResult.acceptanceCriteriaPath ?? join(workspace.path, "ACCEPTANCE_CRITERIA.md"),
+    acceptanceCriteriaPath: specResult.acceptanceCriteriaPath ?? join(workspace.path, ACCEPTANCE_CRITERIA_FILENAME),
     instructions: specResult.instructions ?? "",
     maxTurns: options.maxTurns ?? DEFAULT_CROSS_REPO_EXECUTION_MAX_TURNS,
   };

--- a/test/unit/miner-cross-repo-evaluation.test.ts
+++ b/test/unit/miner-cross-repo-evaluation.test.ts
@@ -890,7 +890,7 @@ describe("cross-repo evaluation harness (#4788)", () => {
       });
       expect(result.passed).toBe(true);
       expect(tasks[0]?.instructions).toBe("");
-      expect(String(tasks[0]?.acceptanceCriteriaPath).endsWith("ACCEPTANCE_CRITERIA.md")).toBe(true);
+      expect(String(tasks[0]?.acceptanceCriteriaPath).endsWith("acceptance-criteria.json")).toBe(true);
     });
 
     it("runCrossRepoFullExecution mirrors the readiness runner's manifest and filter handling", async () => {


### PR DESCRIPTION
Fixes #10331

Use the existing acceptance-criteria filename constant for the fallback path and update the exact-filename regression assertion so automatic cross-repo evaluation points at the artifact the spec builder actually writes.

<!-- pr-relay-job relay-148-e18edd594122951e4614 -->